### PR TITLE
Fix dynamic row height offset bug

### DIFF
--- a/examples/CollapseExample.js
+++ b/examples/CollapseExample.js
@@ -57,7 +57,6 @@ class CollapseExample extends React.Component {
           rowHeight={50}
           rowsCount={dataList.getSize()}
           rowHeightGetter={this._rowHeightGetter}
-          rowClass
           headerHeight={50}
           width={1000}
           height={500}

--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -117,12 +117,22 @@ var FixedDataTableBufferedRows = React.createClass({
     var rowPositionGetter = props.rowPositionGetter;
 
     var rowsToRender = this.state.rowsToRender;
+
+    //Sort the rows, we slice first to avoid changing original
+    var sortedRowsToRender = rowsToRender.slice().sort((a, b) => a - b);
+    var rowPositions = {};
+
+    //Row position calculation requires that rows are calculated in order
+    sortedRowsToRender.forEach((rowIndex) => {
+      rowPositions[rowIndex] = rowPositionGetter(rowIndex);
+    });
+
     this._staticRowArray.length = rowsToRender.length;
 
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
-      var rowOffsetTop = rowPositionGetter(rowIndex);
+      var rowOffsetTop = rowPositions[rowIndex];
 
       var hasBottomBorder =
         rowIndex === props.rowsCount - 1 && props.showLastRowBorder;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Row offset calculation is dependent on a subset of previous row offsets. ScrollHelper's scrollTo or scrollBy functions calculate them correct. But you may update scrollPosition without triggering a scrollTo/scrollBy. 

A simple way to test this is to scroll down a bunch, then scroll up to the first row and collapse it. [See attached video](https://github.com/schrodinger/fixed-data-table-2/files/298481/scroll.bug.mp4.zip).

This fix forces the sorts the rows before calculating their offsets.

This shouldn't hamper performance because visible rows should be small. It may be possible to speed this up using something like radix sort.

## Motivation and Context
https://github.com/facebook/fixed-data-table/issues/405

## How Has This Been Tested?
Tested locally but running dev site.
See [video](https://github.com/schrodinger/fixed-data-table-2/files/298481/scroll.bug.mp4.zip)
 for original repo steps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.