### PR TITLE
Publish the reorder handle file

### DIFF
--- a/src/FixedDataTableColumnReorderHandle.react.js
+++ b/src/FixedDataTableColumnReorderHandle.react.js
@@ -6,11 +6,10 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * This is to be used with the FixedDataTable. It is a read line
- * that when you click on a column that is resizable appears and allows
- * you to resize the corresponding column.
+ * This is to be used with the FixedDataTable. It is a header icon
+ * that allows you to reorder the corresponding column.
  *
- * @providesModule FixedDataTableColumnResizeHandle.react
+ * @providesModule FixedDataTableColumnReorderHandle.react
  * @typechecks
  */
 
@@ -35,7 +34,7 @@ var FixedDataTableColumnReorderHandle = React.createClass({
     onColumnReorderEnd: PropTypes.func,
 
     /**
-     * Column key for the column being resized.
+     * Column key for the column being reordered.
      */
     columnKey: PropTypes.oneOfType([
       PropTypes.string,
@@ -118,7 +117,7 @@ var FixedDataTableColumnReorderHandle = React.createClass({
   _updateState() {
     if (this._animating) {
       requestAnimationFrame(this._updateState)
-    } 
+    }
     this.setState({
       dragDistance: this._distance
     });


### PR DESCRIPTION
Fix annotation on FixedDataTableColumnReorderHandle.react.js so it gets published to npm as expected.

## Description
Update providesModule annotation and some documentation

## Motivation and Context
Publishing scripts rely on providesModule annotation for creating file to publish

Documentation on reorder column options doesn't seem to exist yet and should be added down the line 

## How Has This Been Tested?
Ran npm run build-npm and verified files created as expected 
Installed new internal directory in a sandbox and verified project could be loaded as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

