### PR TITLE
Stop velocity tracking on touch cancel

### DIFF
--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -637,6 +637,7 @@ var FixedDataTable = React.createClass({
         onTouchStart={this._touchHandler.onTouchStart}
         onTouchEnd={this._touchHandler.onTouchEnd}
         onTouchMove={this._touchHandler.onTouchMove}
+        onTouchCancel={this._touchHandler.onTouchCancel}
         style={{height: state.height, width: state.width}}>
         <div
           className={cx('fixedDataTableLayout/rowsContainer')}

--- a/src/vendor_upstream/dom/ReactTouchHandler.js
+++ b/src/vendor_upstream/dom/ReactTouchHandler.js
@@ -97,6 +97,7 @@ class ReactTouchHandler {
     this.onTouchStart = this.onTouchStart.bind(this);
     this.onTouchEnd = this.onTouchEnd.bind(this);
     this.onTouchMove = this.onTouchMove.bind(this);
+    this.onTouchCancel = this.onTouchCancel.bind(this);
   }
 
   onTouchStart(/*object*/ event) {
@@ -129,6 +130,18 @@ class ReactTouchHandler {
 
     // Initialize decelerating autoscroll on drag stop
     requestAnimationFrame(this._startAutoScroll);
+
+    event.preventDefault();
+    if (this._stopPropagation()) {
+      event.stopPropagation();
+    }
+  }
+
+  onTouchCancel(/*object*/ event) {
+
+    // Stop tracking velocity
+    clearInterval(this._trackerId);
+    this._trackerId = null;
 
     event.preventDefault();
     if (this._stopPropagation()) {

--- a/src/vendor_upstream/dom/ReactTouchHandler.js
+++ b/src/vendor_upstream/dom/ReactTouchHandler.js
@@ -116,7 +116,6 @@ class ReactTouchHandler {
     clearInterval(this._trackerId);
     this._trackerId = setInterval(this._track, TRACKER_TIMEOUT);
 
-    event.preventDefault();
     if (this._stopPropagation()) {
       event.stopPropagation();
     }
@@ -131,7 +130,6 @@ class ReactTouchHandler {
     // Initialize decelerating autoscroll on drag stop
     requestAnimationFrame(this._startAutoScroll);
 
-    event.preventDefault();
     if (this._stopPropagation()) {
       event.stopPropagation();
     }
@@ -143,7 +141,6 @@ class ReactTouchHandler {
     clearInterval(this._trackerId);
     this._trackerId = null;
 
-    event.preventDefault();
     if (this._stopPropagation()) {
       event.stopPropagation();
     }


### PR DESCRIPTION
Stop velocity tracking on touch cancel

## Description
Add a handler so onTouchCancel we clear the interval used for tracking velocity.

## Motivation and Context
Prevents wasted CPU cycles when a drag is cancelled

## How Has This Been Tested?
Tested in sandbox in chrome on Galaxy S5

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

