### PR TITLE
SS-16128: Column reorder dragging

### DIFF
--- a/examples/ReorderExample.js
+++ b/examples/ReorderExample.js
@@ -29,7 +29,10 @@ var columnTitles = {
   'firstName': 'First Name',
   'lastName': 'Last Name',
   'sentence': 'Sentence',
-  'companyName': 'Company'
+  'companyName': 'Company',
+  'city': 'City',
+  'street': 'Street',
+  'zipCode': 'Zip Code'
 };
 
 var columnWidths = {
@@ -37,6 +40,9 @@ var columnWidths = {
   lastName: 150,
   sentence: 240,
   companyName: 100,
+  city: 240,
+  street: 260,
+  zipCode: 240
 };
 
 class ReorderExample extends React.Component {
@@ -48,6 +54,9 @@ class ReorderExample extends React.Component {
       columnOrder: [
         'firstName',
         'lastName',
+        'city',
+        'street',
+        'zipCode',
         'sentence',
         'companyName'
       ],

--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -40,6 +40,8 @@ var BORDER_HEIGHT = 1;
 var HEADER = 'header';
 var FOOTER = 'footer';
 var CELL = 'cell';
+var DRAG_SCROLL_SPEED = 15;
+var DRAG_SCROLL_BUFFER = 100;
 
 /**
  * Data grid component with fixed or scrollable header and columns.
@@ -727,6 +729,7 @@ var FixedDataTable = React.createClass({
       isColumnReordering: true,
       columnReorderingData: {
         dragDistance: 0,
+        scrollStart: this.state.scrollX,
         columnKey: columnKey,
         columnWidth: width,
         originalLeft: left,
@@ -744,7 +747,24 @@ var FixedDataTable = React.createClass({
     reorderingData.columnBefore = undefined;
     reorderingData.columnAfter = undefined;
 
+    var scrollX = this.state.scrollX;
+    //Relative dragX position on scroll
+    var dragX = reorderingData.originalLeft - reorderingData.scrollStart + reorderingData.dragDistance;
+
+    var fixedColumnsWidth = this.state.bodyFixedColumns.reduce((sum, column) => sum + column.props.width, 0);
+    var relativeWidth = this.props.width - fixedColumnsWidth;
+
+    //Scroll the table left or right if we drag near the edges of the table
+    if (dragX > relativeWidth - DRAG_SCROLL_BUFFER) {
+      scrollX = Math.min(scrollX + DRAG_SCROLL_SPEED, this.state.maxScrollX);
+    } else if (dragX <= DRAG_SCROLL_BUFFER) {
+      scrollX = Math.max(scrollX - DRAG_SCROLL_SPEED, 0);
+    }
+
+    reorderingData.dragDistance += this.state.scrollX - reorderingData.scrollStart;
+
     this.setState({
+      scrollX: scrollX,
       columnReorderingData: reorderingData
     });
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While dragging to reorder columns, we now scroll to left or right when user drags to to appropriate edge. Example [screencast](https://s3.amazonaws.com/uploads.hipchat.com/21252/1928569/dE1HhEu8e1DlHAo/reorder%20drag%20scroll.mp4)

## Motivation and Context
https://github.com/schrodinger/fixed-data-table-2/issues/13

## How Has This Been Tested?
Tested locally [see video](https://s3.amazonaws.com/uploads.hipchat.com/21252/1928569/dE1HhEu8e1DlHAo/reorder%20drag%20scroll.mp4)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

