### PR TITLE
Fixing column drag scroll with cell recycling

### DIFF
--- a/examples/ReorderExample.js
+++ b/examples/ReorderExample.js
@@ -96,6 +96,7 @@ class ReorderExample extends React.Component {
         {...this.props}>
         {this.state.columnOrder.map(function (columnKey, i) {
           return <Column
+            allowCellsRecycling={true}
             columnKey={columnKey}
             key={i}
             isReorderable={true}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -785,6 +785,11 @@ var FixedDataTable = React.createClass({
     this.props.onColumnReorderEndCallback({
       columnBefore, columnAfter, reorderColumn
     });
+
+    var onHorizontalScroll = this.props.onHorizontalScroll;
+    if (this.state.columnReorderingData.scrollStart !== this.state.scrollX && onHorizontalScroll) {
+      onHorizontalScroll(this.state.scrollX)
+    };
   },
 
   _areColumnSettingsIdentical(

--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -64,7 +64,7 @@ var FixedDataTableCellDefault = React.createClass({
   },
 
   render() {
-    var {height, width, style, className, children, columnKey, ...props} = this.props;
+    var {height, width, style, className, children, columnKey, rowIndex, ...props} = this.props;
 
     var innerStyle = {
       height,

--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -64,6 +64,7 @@ var FixedDataTableCellDefault = React.createClass({
   },
 
   render() {
+    //Remove some props like columnKey and rowIndex so we don't pass it into the div
     var {height, width, style, className, children, columnKey, rowIndex, ...props} = this.props;
 
     var innerStyle = {

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -78,7 +78,8 @@ var FixedDataTableCellGroupImpl = React.createClass({
     var currentPosition = 0;
     for (var i = 0, j = columns.length; i < j; i++) {
       var columnProps = columns[i].props;
-      if (!columnProps.allowCellsRecycling || (
+      var recycable = columnProps.allowCellsRecycling && !isColumnReordering;
+      if (!recycable || (
             currentPosition - props.left <= props.width &&
             currentPosition - props.left + columnProps.width >= 0)) {
         var key = 'cell_' + i;

--- a/src/FixedDataTableColumnReorderHandle.js
+++ b/src/FixedDataTableColumnReorderHandle.js
@@ -54,6 +54,8 @@ var FixedDataTableColumnReorderHandle = React.createClass({
 
   componentWillUnmount() {
     if (this._mouseMoveTracker) {
+      cancelAnimationFrame(this.frameId);
+      this.frameId = null;
       this._mouseMoveTracker.releaseMouseMoves();
       this._mouseMoveTracker = null;
     }
@@ -101,7 +103,7 @@ var FixedDataTableColumnReorderHandle = React.createClass({
 
     this._distance = 0;
     this._animating = true;
-    requestAnimationFrame(this._updateState);
+    this.frameId = requestAnimationFrame(this._updateState);
   },
 
   _onMove(/*number*/ deltaX) {
@@ -110,13 +112,15 @@ var FixedDataTableColumnReorderHandle = React.createClass({
 
   _onColumnReorderEnd() {
     this._animating = false;
+    cancelAnimationFrame(this.frameId);
+    this.frameId = null;
     this._mouseMoveTracker.releaseMouseMoves();
     this.props.onColumnReorderEnd();
   },
 
   _updateState() {
     if (this._animating) {
-      requestAnimationFrame(this._updateState)
+      this.frameId = requestAnimationFrame(this._updateState)
     }
     this.setState({
       dragDistance: this._distance


### PR DESCRIPTION
## Description
Fix column drag and reorder when allowCellRecycling is enabled. This was causing issues because the original cell that the event started on was being destroyed.

## Motivation and Context
https://github.com/schrodinger/fixed-data-table-2/issues/39
SS-16510

## How Has This Been Tested?
Tested locally with reorder example

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

