### PR TITLE
Combine componentWillMount and getInitialState

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -312,8 +312,18 @@ var FixedDataTable = React.createClass({
     };
   },
 
-  getInitialState() /*object*/ {
+  componentWillMount() {
     var props = this.props;
+
+    var scrollToRow = props.scrollToRow;
+    if (scrollToRow !== undefined && scrollToRow !== null) {
+      this._rowToScrollTo = scrollToRow;
+    }
+    var scrollToColumn = props.scrollToColumn;
+    if (scrollToColumn !== undefined && scrollToColumn !== null) {
+      this._columnToScrollTo = scrollToColumn;
+    }
+
     var viewportHeight =
       (props.height === undefined ? props.maxHeight : props.height) -
       (props.headerHeight || 0) -
@@ -325,25 +335,13 @@ var FixedDataTable = React.createClass({
       viewportHeight,
       props.rowHeightGetter
     );
+
     if (props.scrollTop) {
       this._scrollHelper.scrollTo(props.scrollTop);
     }
     this._didScrollStop = debounceCore(this._didScrollStop, 200, this);
 
-    return this._calculateState(this.props);
-  },
-
-  componentWillMount() {
-    var scrollToRow = this.props.scrollToRow;
-    if (scrollToRow !== undefined && scrollToRow !== null) {
-      this._rowToScrollTo = scrollToRow;
-    }
-    var scrollToColumn = this.props.scrollToColumn;
-    if (scrollToColumn !== undefined && scrollToColumn !== null) {
-      this._columnToScrollTo = scrollToColumn;
-    }
-
-    var touchEnabled = this.state.touchScrollEnabled === true;
+    var touchEnabled = props.touchScrollEnabled === true;
 
     this._wheelHandler = new ReactWheelHandler(
       this._onScroll,
@@ -355,6 +353,8 @@ var FixedDataTable = React.createClass({
       touchEnabled && this._shouldHandleWheelX,
       touchEnabled && this._shouldHandleWheelY
     );
+
+    this.setState(this._calculateState(props));
   },
 
   _shouldHandleWheelX(/*number*/ delta) /*boolean*/ {


### PR DESCRIPTION
## Description

There is a bug when setting scrollToRow/scrollToColumn before the initial render of a FixedDataTable: because we compute the state before setting this._rowToScrollTo, we don't scroll appropriately. To fix this bug, and avoid others like it, we combine getInitialState with componentWillMount (which run one after another anyway) into one function and sequence its operation appropriately.

## Motivation and Context

Fixes facebook/fixed-data-table/#458

## How Has This Been Tested?

Ran 'npm run test'; also tested that this fixed scrollToRow within an internal project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

