### PR TITLE
Fixing setting scrollLeft not firing callback

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -443,7 +443,8 @@ var FixedDataTable = React.createClass({
 
     // In the case of controlled scrolling, notify.
     if (this.props.ownerHeight !== nextProps.ownerHeight ||
-      this.props.scrollTop !== nextProps.scrollTop) {
+        this.props.scrollTop !== nextProps.scrollTop ||
+        this.props.scrollLeft !== nextProps.scrollLeft) {
       this._didScrollStart();
     }
     this._didScrollStop();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
onScrollEnd/onScrollStart callbacks weren't firing when scrollLeft is set manually by the user.
_didScrollStop was being called, but _.isScrolling flag wasn't set. This is because _didScrollStart wasn't fired on initial call.

## Motivation and Context
https://github.com/schrodinger/fixed-data-table-2/issues/53

## How Has This Been Tested?
https://jsfiddle.net/nprp19me/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

