### PR TITLE
Set scrollTop on initial render

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -323,6 +323,10 @@ var FixedDataTable = React.createClass({
     if (scrollToColumn !== undefined && scrollToColumn !== null) {
       this._columnToScrollTo = scrollToColumn;
     }
+    var scrollTop = props.scrollTop;
+    if (typeof scrollTop !== 'undefined' && scrollTop !== null) {
+      this._scrollTop = scrollTop;
+    }
 
     var viewportHeight =
       (props.height === undefined ? props.maxHeight : props.height) -
@@ -336,9 +340,6 @@ var FixedDataTable = React.createClass({
       props.rowHeightGetter
     );
 
-    if (props.scrollTop) {
-      this._scrollHelper.scrollTo(props.scrollTop);
-    }
     this._didScrollStop = debounceCore(this._didScrollStop, 200, this);
 
     var touchEnabled = props.touchScrollEnabled === true;
@@ -945,6 +946,15 @@ var FixedDataTable = React.createClass({
       firstRowOffset = scrollState.offset;
       scrollY = scrollState.position;
       delete this._rowToScrollTo;
+    }
+
+    // Check if scrollTop was provided as a prop on initial mount
+    if (typeof this._scrollTop !== 'undefined') {
+      scrollState = this._scrollHelper.scrollTo(this._scrollTop);
+      firstRowIndex = scrollState.index;
+      firstRowOffset = scrollState.offset;
+      scrollY = scrollState.position;
+      delete this._scrollTop;
     }
 
     var columnResizingData;


### PR DESCRIPTION
## Description
This moves the handling of the `scrollTop` prop from `componentWillMount` into `_calculateState`.

## Motivation and Context
Using the latest version, I found that setting a `scrollTop` did not have any effect on the initial render.  This seemed to be a similar problem to that which was solved by https://github.com/schrodinger/fixed-data-table-2/pull/52, so this PR mirrors those changes.

## How Has This Been Tested?
I tested this in an internal project, and my app now behaves as it used to before my upgrade to React15 and the move from `fixed-data-table` to `fixed-data-table-2`.  Providing a `scrollTop` correctly scrolls the table to the correct position on the first render.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.

