### PR TITLE
Initial scrollTo* props fail to render

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "less-loader": "^2.0.0",
     "marked": "^0.3.2",
     "mocha": "^2.5.3",
+    "mocha-loader": "^1.0.0",
     "mocha-webpack": "^0.4.0",
     "null-loader": "^0.1.0",
     "postcss": "^4.0.2",

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -323,6 +323,10 @@ var FixedDataTable = React.createClass({
     if (scrollToColumn !== undefined && scrollToColumn !== null) {
       this._columnToScrollTo = scrollToColumn;
     }
+    var scrollTop = props.scrollTop;
+    if (typeof scrollTop !== 'undefined' && scrollTop !== null) {
+      this._scrollTop = scrollTop;
+    }
 
     var viewportHeight =
       (props.height === undefined ? props.maxHeight : props.height) -
@@ -336,9 +340,6 @@ var FixedDataTable = React.createClass({
       props.rowHeightGetter
     );
 
-    if (props.scrollTop) {
-      this._scrollHelper.scrollTo(props.scrollTop);
-    }
     this._didScrollStop = debounceCore(this._didScrollStop, 200, this);
 
     var touchEnabled = props.touchScrollEnabled === true;
@@ -945,6 +946,15 @@ var FixedDataTable = React.createClass({
       firstRowOffset = scrollState.offset;
       scrollY = scrollState.position;
       delete this._rowToScrollTo;
+    }
+
+    // Check if scrollTop was provided as a prop on initial mount
+    if (typeof this._scrollTop !== 'undefined') {
+      scrollState = this._scrollHelper.scrollTo(this._scrollTop);
+      firstRowIndex = scrollState.index;
+      firstRowOffset = scrollState.offset;
+      scrollY = scrollState.position;
+      delete this._scrollTop;
     }
 
     var columnResizingData;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -882,8 +882,8 @@ var FixedDataTable = React.createClass({
     var scrollY = oldState ? oldState.scrollY : 0;
     var scrollX = oldState ? oldState.scrollX : 0;
 
-    var lastScrollLeft = oldState ? oldState.scrollLeft : undefined;
-    if (props.scrollLeft !== lastScrollLeft) {
+    var lastScrollLeft = oldState ? oldState.scrollLeft : 0;
+    if (props.scrollLeft !== undefined && props.scrollLeft !== lastScrollLeft) {
       scrollX = props.scrollLeft;
     }
 
@@ -921,7 +921,7 @@ var FixedDataTable = React.createClass({
 
     var lastScrollTop = oldState ? oldState.scrollTop : undefined;
     if (props.scrollTop !== lastScrollTop) {
-      scrollState = this._scrollHelper.scrollRowIntoView(props.scrollTop);
+      scrollState = this._scrollHelper.scrollTo(props.scrollTop);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;
       scrollY = scrollState.position;
@@ -959,7 +959,7 @@ var FixedDataTable = React.createClass({
     );
 
     var lastScrollToColumn = oldState ? oldState.scrollToColumn : undefined;
-    if (props.scrollToColumn !== lastScrollToColumn) {
+    if (props.scrollToColumn !== null && props.scrollToColumn !== lastScrollToColumn) {
       // If selected column is a fixed column, don't scroll
       var fixedColumnsCount = columnInfo.bodyFixedColumns.length;
       if (props.scrollToColumn >= fixedColumnsCount) {

--- a/src/FixedDataTableRoot-test.js
+++ b/src/FixedDataTableRoot-test.js
@@ -26,7 +26,7 @@ describe('FixedDataTableRoot', function() {
         </Table>
       );
       let renderer = createRenderer();
-      return renderer.render(table);
+      renderer.render(table);
       let tableRender = renderer.getRenderOutput();
 
       assert.isTrue(isElement(tableRender));

--- a/src/FixedDataTableRoot-test.js
+++ b/src/FixedDataTableRoot-test.js
@@ -12,7 +12,7 @@ const { Table, Column } = FixedDataTable;
 describe('FixedDataTableRoot', function() {
   describe('render ', function() {
     it('should not crash and burn', function() {
-      var table = (
+      let table = (
         <Table
           width={600}
           height={400}
@@ -25,12 +25,59 @@ describe('FixedDataTableRoot', function() {
           />
         </Table>
       );
-      var renderer = createRenderer();
-      renderer.render(table);
-      var tableRender = renderer.getRenderOutput();
+      let renderer = createRenderer();
+      return renderer.render(table);
+      let tableRender = renderer.getRenderOutput();
 
       assert.isTrue(isElement(tableRender));
     });
+  });
+
+  describe('initial render', function() {
+    const renderTable = (optionalProps = {}) => {
+      let table = (
+        <Table
+          width={600}
+          height={400}
+          rowsCount={50}
+          rowHeight={100}
+          headerHeight={50}
+          {...optionalProps}
+        >
+          <Column width={300} />
+          <Column width={300} />
+          <Column width={300} />
+          <Column width={300} />
+          <Column width={300} />
+        </Table>
+      );
+      let renderer = createRenderer();
+      renderer.render(table);
+      return renderer.getMountedInstance();
+    };
+
+    it('should set scrollLeft correctly', function() {
+      let table = renderTable({scrollLeft: 300});
+      assert.equal(table.state.scrollX, 300, 'should set scrollX to 300');
+    });
+
+    it('should set scrollTop correctly', function() {
+      let table = renderTable({scrollTop: 600});
+      assert.equal(table.state.scrollY, 600, 'should set scrollY to 600');
+    });
+
+    it('should set scrollToColumn correctly', function() {
+      let table = renderTable({scrollToColumn: 3});
+      assert.equal(table.state.scrollX, 300 * 2, 'should be third visible column');
+    });
+
+    it('should set scrollToRow correctly', function() {
+      let table = renderTable({scrollToRow: 30, height: 300});
+      //scrollToRow is considered valid if row is visible. Test to make sure that row is somewhere in between
+      assert.isBelow(table.state.scrollY, 30 * 100, 'should be below first row');
+      assert.isAbove(table.state.scrollY, 30 * 100 - 300, 'should be above last row');
+    });
+
   });
 });
 


### PR DESCRIPTION
## Description
scrollToRow, scrollToColumn, scrollLeft and scrollTop were not correctly being used to calculate initial state. https://github.com/schrodinger/fixed-data-table-2/pull/52 attempted to fix this by storing as a temporary variable; but we can use the state object to determine if the props have changed.

## Motivation and Context
https://github.com/schrodinger/fixed-data-table-2/pull/55
https://github.com/schrodinger/fixed-data-table-2/pull/52

## How Has This Been Tested?
Added new unit tests and tested with dev server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
