### PR TITLE
Add left and right shadows to indicate that the table is horizontally scrollable

### DIFF
--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -195,9 +195,9 @@ var FixedDataTableRowImpl = React.createClass({
   _renderColumnsLeftShadow(/*number*/ left) /*?object*/ {
     var className = cx({
       'fixedDataTableRowLayout/fixedColumnsDivider': left > 0,
-       'fixedDataTableRowLayout/columnsShadow': this.props.scrollLeft > 0,
-       'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
-       'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
+      'fixedDataTableRowLayout/columnsShadow': this.props.scrollLeft > 0,
+      'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
+      'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
      });
      var style = {
        left: left,
@@ -207,13 +207,13 @@ var FixedDataTableRowImpl = React.createClass({
    },
 
   _renderColumnsRightShadow(/*number*/ totalWidth) /*?object*/ {
-    if (this.props.scrollLeft + this.props.width + 0.5 < totalWidth) {
-      var className = cx({
-        'fixedDataTableRowLayout/columnsShadow': true,
-        'fixedDataTableRowLayout/columnsRightShadow': true,
-        'public/fixedDataTableRow/columnsShadow': true,
-        'public/fixedDataTableRow/columnsRightShadow': true,
-      });
+    if (Math.ceil(this.props.scrollLeft + this.props.width) < totalWidth) {
+      var className = cx(
+        'fixedDataTableRowLayout/columnsShadow',
+        'fixedDataTableRowLayout/columnsRightShadow',
+        'public/fixedDataTableRow/columnsShadow',
+        'public/fixedDataTableRow/columnsRightShadow'
+      );
       var style = {
         height: this.props.height
       };

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -142,7 +142,7 @@ var FixedDataTableRowImpl = React.createClass({
         rowHeight={this.props.height}
         rowIndex={this.props.index}
       />;
-    var columnsShadow = this._renderColumnsShadow(fixedColumnsWidth);
+    var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
     var scrollableColumns =
       <FixedDataTableCellGroup
         key="scrollable_cells"
@@ -162,6 +162,8 @@ var FixedDataTableRowImpl = React.createClass({
         rowHeight={this.props.height}
         rowIndex={this.props.index}
       />;
+    var scrollableColumnsWidth = this._getColumnsWidth(this.props.scrollableColumns);
+    var columnsRightShadow = this._renderColumnsRightShadow(fixedColumnsWidth + scrollableColumnsWidth);
 
     return (
       <div
@@ -175,8 +177,9 @@ var FixedDataTableRowImpl = React.createClass({
         <div className={cx('fixedDataTableRowLayout/body')}>
           {fixedColumns}
           {scrollableColumns}
-          {columnsShadow}
+          {columnsLeftShadow}
         </div>
+        {columnsRightShadow}
       </div>
     );
   },
@@ -189,16 +192,29 @@ var FixedDataTableRowImpl = React.createClass({
     return width;
   },
 
-  _renderColumnsShadow(/*number*/ left) /*?object*/ {
-    if (left > 0) {
+  _renderColumnsLeftShadow(/*number*/ left) /*?object*/ {
+    var className = cx({
+      'fixedDataTableRowLayout/fixedColumnsDivider': left > 0,
+       'fixedDataTableRowLayout/columnsShadow': this.props.scrollLeft > 0,
+       'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
+       'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
+     });
+     var style = {
+       left: left,
+       height: this.props.height
+     };
+     return <div className={className} style={style} />;
+   },
+
+  _renderColumnsRightShadow(/*number*/ totalWidth) /*?object*/ {
+    if (this.props.scrollLeft + this.props.width + 0.5 < totalWidth) {
       var className = cx({
-        'fixedDataTableRowLayout/fixedColumnsDivider': true,
-        'fixedDataTableRowLayout/columnsShadow': this.props.scrollLeft > 0,
-        'public/fixedDataTableRow/fixedColumnsDivider': true,
-        'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
+        'fixedDataTableRowLayout/columnsShadow': true,
+        'fixedDataTableRowLayout/columnsRightShadow': true,
+        'public/fixedDataTableRow/columnsShadow': true,
+        'public/fixedDataTableRow/columnsRightShadow': true,
       });
       var style = {
-        left: left,
         height: this.props.height
       };
       return <div className={className} style={style} />;

--- a/src/css/layout/fixedDataTableRowLayout.css
+++ b/src/css/layout/fixedDataTableRowLayout.css
@@ -33,7 +33,12 @@
 }
 
 .fixedDataTableRowLayout/columnsShadow {
+  position: absolute;
   width: 4px;
+}
+
+.fixedDataTableRowLayout/columnsRightShadow {
+  right: 1px;
 }
 
 .fixedDataTableRowLayout/rowWrapper {

--- a/src/css/style/fixedDataTableRow.css
+++ b/src/css/style/fixedDataTableRow.css
@@ -28,3 +28,10 @@
 .public/fixedDataTableRow/columnsShadow {
   background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAABCAYAAAD5PA/NAAAAFklEQVQIHWPSkNeSBmJhTQVtbiDNCgASagIIuJX8OgAAAABJRU5ErkJggg==) repeat-y;
 }
+
+.public/fixedDataTableRow/columnsRightShadow {
+  -webkit-transform: rotate(180deg);
+     -moz-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg);
+}

--- a/src/css/style/fixedDataTableRow.css
+++ b/src/css/style/fixedDataTableRow.css
@@ -30,8 +30,5 @@
 }
 
 .public/fixedDataTableRow/columnsRightShadow {
-  -webkit-transform: rotate(180deg);
-     -moz-transform: rotate(180deg);
-      -ms-transform: rotate(180deg);
-          transform: rotate(180deg);
+  transform: rotate(180deg);
 }


### PR DESCRIPTION
Added shadows to the table on both left and right sides to indicate the table is horizontally scrollable.

## Description
When a table has many columns, horizontal scrollbar shows up to allow users to scroll horizontally to the right or the left to view columns on the two ends. The change adds shadows to one or both sides to indicate if there are columns not being exposed thus the table can be scrolled to view them.

## Motivation and Context
Due to user experience tests, horizontal scrollbars are not clear enough to users that the they can scroll horizontally to view columns on the sides that are currently hidden. Having shadows makes it more clear and users can easily understand if they have hidden columns that they need to scroll to view.

## How Has This Been Tested?
Very minor JavaScript code change and some simply CSS style change. 

Manual testing only. No automated test. It has been tested in IE11+ (Win10), Edge(Win10), Chrome (MacOS), Safari(MacOS), Firefox(MacOS).

No impact on other area of the code is expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.