### PR TITLE
Do not crash when unsetting scrollToRow

### DIFF
--- a/build_helpers/test-globals.js
+++ b/build_helpers/test-globals.js
@@ -1,0 +1,28 @@
+'use strict'
+
+var jsdom = require('jsdom')
+
+// setup the simplest document possible
+var doc = jsdom.jsdom('<!doctype html><html><body></body></html>')
+
+// get the window object out of the document
+var win = doc.defaultView
+
+// set globals for mocha that make access to document and window feel
+// natural in the test environment
+global.document = doc
+global.window = win
+
+// take all properties of the window object and also attach it to the
+// mocha global object
+propagateToGlobal(win)
+
+// from mocha-jsdom https://github.com/rstacruz/mocha-jsdom/blob/master/index.js#L80
+function propagateToGlobal (window) {
+  for (let key in window) {
+    if (!window.hasOwnProperty(key)) continue
+    if (key in global) continue
+
+    global[key] = window[key]
+  }
+}

--- a/build_helpers/test-globals.js
+++ b/build_helpers/test-globals.js
@@ -1,28 +1,29 @@
 'use strict'
 
-var jsdom = require('jsdom')
+var jsdom = require('jsdom');
 
 // setup the simplest document possible
-var doc = jsdom.jsdom('<!doctype html><html><body></body></html>')
+var doc = jsdom.jsdom('<!doctype html><html><body></body></html>');
 
 // get the window object out of the document
-var win = doc.defaultView
+var win = doc.defaultView;
 
 // set globals for mocha that make access to document and window feel
 // natural in the test environment
-global.document = doc
-global.window = win
+global.document = doc;
+global.window = win;
 
 // take all properties of the window object and also attach it to the
 // mocha global object
-propagateToGlobal(win)
+propagateToGlobal(win);
 
 // from mocha-jsdom https://github.com/rstacruz/mocha-jsdom/blob/master/index.js#L80
 function propagateToGlobal (window) {
   for (let key in window) {
-    if (!window.hasOwnProperty(key)) continue
-    if (key in global) continue
+    if (!window.hasOwnProperty(key) || key in global) {
+      continue;
+    }
 
-    global[key] = window[key]
+    global[key] = window[key];
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "file-loader": "^0.8.1",
     "glob": "^4.3.5",
     "html-loader": "^0.2.3",
+    "jsdom": "^9.6.0",
     "less": "^2.2.0",
     "less-loader": "^2.0.0",
     "marked": "^0.3.2",
@@ -37,6 +38,7 @@
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.2.1",
     "react-docgen": "^1.2.0",
+    "react-dom": "^15.3.2",
     "react-tools": "^0.12.2",
     "sinon": "^2.0.0-pre.2",
     "style-loader": "^0.8.3",
@@ -52,8 +54,8 @@
     "build-docs": "./build_helpers/buildAPIDocs.sh",
     "publish-site": "./build_helpers/publishStaticSite.sh",
     "publish-package": "./build_helpers/publishPackage.sh",
-    "test": "mocha-webpack --webpack-config webpack.config-test.js \"src/**/*-test.js\"",
-    "test:watch": "mocha-webpack --webpack-config webpack.config-test.js --watch \"src/**/*-test.js\"",
+    "test": "mocha-webpack --webpack-config webpack.config-test.js \"src/**/*-test.js\" --require build_helpers/test-globals.js",
+    "test:watch": "mocha-webpack --webpack-config webpack.config-test.js --watch \"src/**/*-test.js\" --require build_helpers/test-globals.js",
     "test:server": "webpack-dev-server --config webpack.config-test.js --hot --inline"
   },
   "repository": {

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -912,7 +912,7 @@ var FixedDataTable = React.createClass({
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;
-    if (props.scrollToRow !== lastScrollToRow) {
+    if (typeof props.scrollToRow !== 'undefined' && props.scrollToRow !== null && props.scrollToRow !== lastScrollToRow) {
       scrollState = this._scrollHelper.scrollRowIntoView(props.scrollToRow);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -912,7 +912,7 @@ var FixedDataTable = React.createClass({
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;
-    if (typeof props.scrollToRow !== 'undefined' && props.scrollToRow !== null && props.scrollToRow !== lastScrollToRow) {
+    if (props.scrollToRow != null && props.scrollToRow !== lastScrollToRow) {
       scrollState = this._scrollHelper.scrollRowIntoView(props.scrollToRow);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;
@@ -920,7 +920,7 @@ var FixedDataTable = React.createClass({
     }
 
     var lastScrollTop = oldState ? oldState.scrollTop : undefined;
-    if (typeof props.scrollTop !== 'undefined' && props.scrollTop !== null && props.scrollTop !== lastScrollTop) {
+    if (props.scrollTop != null && props.scrollTop !== lastScrollTop) {
       scrollState = this._scrollHelper.scrollTo(props.scrollTop);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -920,7 +920,7 @@ var FixedDataTable = React.createClass({
     }
 
     var lastScrollTop = oldState ? oldState.scrollTop : undefined;
-    if (props.scrollTop !== lastScrollTop) {
+    if (typeof props.scrollTop !== 'undefined' && props.scrollTop !== null && props.scrollTop !== lastScrollTop) {
       scrollState = this._scrollHelper.scrollTo(props.scrollTop);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTableRoot-test.js
+++ b/src/FixedDataTableRoot-test.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import React from 'react';
 import FixedDataTable from './FixedDataTableRoot';
-import { createRenderer, isElement } from 'react-addons-test-utils';
+import { createRenderer, isElement, renderIntoDocument, findRenderedComponentWithType } from 'react-addons-test-utils';
 
 const { Table, Column } = FixedDataTable;
 
@@ -77,7 +77,54 @@ describe('FixedDataTableRoot', function() {
       assert.isBelow(table.state.scrollY, 30 * 100, 'should be below first row');
       assert.isAbove(table.state.scrollY, 30 * 100 - 300, 'should be above last row');
     });
-
   });
-});
 
+  describe('update render', function() {
+    let renderedTable;
+    beforeEach(function() {
+      class TableHOC extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            scrollToRow: 0,
+          };
+        }
+
+        render() {
+          return (
+            <Table
+              scrollToRow={this.state.scrollToRow}
+              {...this.props}
+            >
+              {this.props.children}
+            </Table>
+          );
+        }
+      }
+
+      const table = (
+        <TableHOC
+          width={600}
+          height={400}
+          rowsCount={50}
+          rowHeight={100}
+          headerHeight={50}
+          >
+          <Column width={300} />
+          <Column width={300} />
+          <Column width={300} />
+          <Column width={300} />
+          <Column width={300} />
+        </TableHOC>
+      );
+      const renderedTree = renderIntoDocument(table);
+      renderedTable = findRenderedComponentWithType(renderedTree, TableHOC)
+    })
+
+    it('should not blow up when unsetting the scrollToRow property', function() {
+      assert.doesNotThrow(function() {
+        renderedTable.setState({scrollToRow: undefined});
+      })
+    });
+  })
+});

--- a/src/FixedDataTableRoot-test.js
+++ b/src/FixedDataTableRoot-test.js
@@ -41,7 +41,7 @@ describe('FixedDataTableRoot', function() {
     }
 
     /**
-     * Returns state from FDT.Table object
+     * Returns state from FDT.Table object for unit testing
      *
      * @return {!Object}
      */
@@ -108,14 +108,12 @@ describe('FixedDataTableRoot', function() {
       });
     });
 
-
     it('should not blow up when unsetting the scrollTop property', function() {
       let table = renderTable({scrollTop: 600});
       //assert.doesNotThrow(function() {
         table.setState({scrollTop: undefined});
       //});
     });
-
 
     it('should not blow up when unsetting the scrollToColumn property', function() {
       let table = renderTable({scrollToColumn: 3});
@@ -130,6 +128,5 @@ describe('FixedDataTableRoot', function() {
         table.setState({scrollToRow: undefined});
       });
     });
-
   });
 });

--- a/src/vendor_upstream/core/shallowEqual.js
+++ b/src/vendor_upstream/core/shallowEqual.js
@@ -13,8 +13,6 @@
 
 'use strict';
 
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-
 /**
  * Performs equality by iterating through keys on an object and returning false
  * when any key has values which are not strictly equal between the arguments.
@@ -38,7 +36,7 @@ function shallowEqual(objA: mixed, objB: mixed): boolean {
   }
 
   // Test for A's keys different from B.
-  var bHasOwnProperty = hasOwnProperty.bind(objB);
+  var bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
   for (var i = 0; i < keysA.length; i++) {
     if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
       return false;


### PR DESCRIPTION
## Description
This avoids trying to scroll to an `undefined` row.

## Motivation and Context
Since the latest release (0.7.5), I began to see the following error:

```
Uncaught Error: Invariant Violation: Index out of range undefined
```

I found that this happened after setting a `scrollToRow` prop and then returning it to `undefined`.

## How Has This Been Tested?
I tested this in my app, as well as added a test for it.  Note: I needed to be able to `setState`, which required full rendering, so I add jsdom and react-dom to the dev dependencies.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.

