### PR TITLE
Fix ExamplesPage

### DIFF
--- a/examples/ResponsiveExample.js
+++ b/examples/ResponsiveExample.js
@@ -60,6 +60,10 @@ class ResponsiveExample extends React.Component {
 // https://github.com/digidem/react-dimensions
 module.exports = Dimensions({
   getHeight: function(element) {
-    return element.clientHeight - 200;
+    return window.innerHeight - 200;
+  },
+  getWidth: function(element) {
+    var widthOffset = window.innerWidth < 680 ? 0 : 240;
+    return window.innerWidth - widthOffset;
   }
 })(ResponsiveExample);

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -62,27 +62,43 @@ var ExamplesPage = React.createClass({
 
   _renderPage() {
     var Example = EXAMPLE_COMPONENTS[this.props.page.location];
+
     return (
       <Example
-        height={this.props.containerHeight}
-        width={this.props.containerWidth}
+        height={this.state.tableHeight}
+        width={this.state.tableWidth}
       />
     );
   },
 
   componentDidMount() {
+    this._update();
+    var win = window;
+    if (win.addEventListener) {
+      win.addEventListener('resize', this._onResize, false);
+    } else if (win.attachEvent) {
+      win.attachEvent('onresize', this._onResize);
+    } else {
+      win.onresize = this._onResize;
+    }
+  },
+
+  _onResize() {
+    clearTimeout(this._updateTimer);
+    this._updateTimer = setTimeout(this._update, 16);
+  },
+
+  _update() {
+    var win = window;
+
+    var widthOffset = win.innerWidth < 680 ? 0 : 240;
+
     this.setState({
-      renderPage: true
+      renderPage: true,
+      tableWidth: win.innerWidth - widthOffset,
+      tableHeight: win.innerHeight - 200,
     });
   }
 });
 
-module.exports = Dimensions({
-  getHeight: function(element) {
-    return window.innerHeight - 200;
-  },
-  getWidth: function(element) {
-    var widthOffset = window.innerWidth < 680 ? 0 : 240;
-    return window.innerWidth - widthOffset;
-  }
-})(ExamplesPage);
+module.exports = ExamplesPage;

--- a/site/examples/examplesPageStyle.less
+++ b/site/examples/examplesPageStyle.less
@@ -6,7 +6,6 @@
 
 .examplesPage {
   @import (less) '../base.less';
-  height: 100%;
 
   input {
     padding: 10px 8px;
@@ -16,14 +15,12 @@
   .pageBody {
     padding: 0 36px;
     position: relative;
-    height: 100%;
   }
 
 
   .contents {
     margin: 0 auto;
     padding: 50px 0 0;
-    height: 100%;
   }
 
   .sidebarItemText,
@@ -202,7 +199,6 @@
     font-family: Helvetica, Arial, 'lucida grande', tahoma, verdana, arial, sans-serif;
     font-size: 12px;
     margin-left: @sidebar-width;
-    height: 100%;
   }
 
   @media only screen and (max-width: 680px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
My recent changes broke the layout so you could scroll the grid up to overlap the header.  Switching back to the old ExamplesPage resizing code to resolve things.

I've already pushed these changes to the github pages so public examples are bug free.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

