### PR TITLE
Fixed issue #67: Limitation of row count due to the max height of any HTML Dom element

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -131,10 +131,12 @@ var FixedDataTableBufferedRows = React.createClass({
 
     this._staticRowArray.length = rowsToRender.length;
 
+    var baseOffsetTop = props.firstRowOffset - props.rowPositionGetter(props.firstRowIndex) + props.offsetTop;
+
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
-      var rowOffsetTop = rowPositions[rowIndex];
+      var rowOffsetTop = baseOffsetTop + rowPositions[rowIndex];
 
       var hasBottomBorder =
         rowIndex === props.rowsCount - 1 && props.showLastRowBorder;
@@ -176,7 +178,7 @@ var FixedDataTableBufferedRows = React.createClass({
     FixedDataTableTranslateDOMPosition(
       style,
       0,
-      props.firstRowOffset - firstRowPosition + props.offsetTop,
+      0,
       this._initialRender,
     );
 

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -17,7 +17,6 @@ import FixedDataTableRow from 'FixedDataTableRow';
 import cx from 'cx';
 import emptyFunction from 'emptyFunction';
 import joinClasses from 'joinClasses';
-import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
 
 var {PropTypes} = React;
 
@@ -168,21 +167,7 @@ var FixedDataTableBufferedRows = React.createClass({
         />;
     }
 
-    var firstRowPosition = props.rowPositionGetter(props.firstRowIndex);
-
-    var style = {
-      position: 'absolute',
-      pointerEvents: props.isScrolling ? 'none' : 'auto',
-    };
-
-    FixedDataTableTranslateDOMPosition(
-      style,
-      0,
-      0,
-      this._initialRender,
-    );
-
-    return <div style={style}>{this._staticRowArray}</div>;
+    return <div>{this._staticRowArray}</div>;
   },
 
   _getRowHeight(/*number*/ index) /*number*/ {


### PR DESCRIPTION
Modified the way of visible rows are rendered to avoid issues caused by the the combined height of all rows exceeding the limit in browsers.

## Description
When loading a large number of rows to the fixed-data-table-2 component, rows at the bottom of the table may not be rendered currently. Sometimes it can even crash the browser. This is caused by the height limit of a HTML Dom element in the browser. Different browsers may have different limit. In the implementation of the fixed-data-table-2, it uses a sliding canvas container to expose rows that are visible depending on the window size and the scrolling position. The height of the canvas is the combined height of all rows, visible and hidden. If the combined height exceeds the allowed height of any element in the Dom structure, rows at the bottom with a top offset larger than the limited value, won't be displayed correctly.

Instead of using a sliding canvas and setting the height of the canvas to be literally the combined height of all rows, we can simply slide the visible rows up or down to by a calculated offset to bring them to the right position that they can be seen. The offset will always be less than combined the height of visible rows, which will never exceed the limit of any browsers.

## Motivation and Context
It prevents loading a large number of data to the fixed-data-table-2 component. Please see issue #67.

## How Has This Been Tested?
Manually tested in the following browsers:
- Chrome in Windows 10 and Mac 10.12
- Firefox in Windows 10 and Mac 10.12
- Safari in Mac 10.12
- IE11 and Edge in Windows 10

## Screenshots (if appropriate):
Rendering 10 million rows with no issues.
![loading 10,000,000 rows with now issue](https://cloud.githubusercontent.com/assets/15616770/19500823/91ed94fa-9555-11e6-9f6a-32f2b9a465e9.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
