### PR TITLE
Add cursor move to column reorder container header

### DIFF
--- a/src/css/style/fixedDataTableColumnReorder.css
+++ b/src/css/style/fixedDataTableColumnReorder.css
@@ -7,6 +7,7 @@
   width: 12px;
   margin-right: -12px;
   float: left;
+  cursor: move;
 }
 .fixedDataTableCellLayout/columnReorderContainer:after {
 	content: '::';


### PR DESCRIPTION
## Description
Add cursor move style to the re-orderable column handle.

## Motivation and Context
This provides the user with visual feedback as to which part of the header is the interactive control handle

## How Has This Been Tested?
* Ran locally and and on hover the move cursor hover is shown

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/2892213/19719534/ef99b5a0-9b9c-11e6-8064-dc48e0217e49.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

