### PR TITLE
Adding collapsible dropdown to rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/api
 dist
 .tmp
 *.swp
+.idea/
+yarn.lock

--- a/examples/CollapseExample.js
+++ b/examples/CollapseExample.js
@@ -5,8 +5,8 @@
 "use strict";
 
 const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
-const { CollapseCell, TextCell } = require('./helpers/cells');
-const { Table, Column, Cell } = require('fixed-data-table-2');
+const {CollapseCell, TextCell} = require('./helpers/cells');
+const {Table, Column, Cell} = require('fixed-data-table-2');
 const React = require('react');
 
 class CollapseExample extends React.Component {
@@ -19,6 +19,8 @@ class CollapseExample extends React.Component {
 
     this._handleCollapseClick = this._handleCollapseClick.bind(this);
     this._rowHeightGetter = this._rowHeightGetter.bind(this);
+    this._rowDropdownGetter = this._rowDropdownGetter.bind(this);
+    this._rowDropdownHeightGetter = this._rowDropdownHeightGetter.bind(this);
   }
 
   _handleCollapseClick(rowIndex) {
@@ -30,7 +32,31 @@ class CollapseExample extends React.Component {
   }
 
   _rowHeightGetter(index) {
-    return this.state.collapsedRows.has(index) ? 100 : 50;
+    return this.state.collapsedRows.has(index) ? 50.1 : 50;
+  }
+
+  _rowDropdownHeightGetter(index) {
+    return this.state.collapsedRows.has(index) ? 50 : 0;
+  }
+
+  _rowDropdownGetter(index) {
+    var style = {
+      height: '100%',
+      width: '100%',
+      textAlign: 'center',
+      lineHeight: '50px',
+      fontSize: 30,
+      fontWeight: 'bold',
+      color: '#777',
+      background: '#CCC',
+      letterSpacing: '1px'
+    };
+
+    return (
+      <div style={style}>
+        {index}
+      </div>
+    )
   }
 
   render() {
@@ -42,45 +68,47 @@ class CollapseExample extends React.Component {
           rowHeight={50}
           rowsCount={dataList.getSize()}
           rowHeightGetter={this._rowHeightGetter}
+          rowDropdownHeightGetter={this._rowDropdownHeightGetter}
+          rowDropdownGetter={this._rowDropdownGetter}
           headerHeight={50}
           width={1000}
           height={500}
           {...this.props}>
           <Column
-            cell={<CollapseCell callback={this._handleCollapseClick} collapsedRows={collapsedRows} />}
+            cell={<CollapseCell callback={this._handleCollapseClick} collapsedRows={collapsedRows}/>}
             fixed={true}
             width={30}
           />
           <Column
             columnKey="firstName"
             header={<Cell>First Name</Cell>}
-            cell={<TextCell data={dataList} />}
+            cell={<TextCell data={dataList}/>}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
             header={<Cell>Last Name</Cell>}
-            cell={<TextCell data={dataList} />}
+            cell={<TextCell data={dataList}/>}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
             header={<Cell>City</Cell>}
-            cell={<TextCell data={dataList} />}
+            cell={<TextCell data={dataList}/>}
             width={100}
           />
           <Column
             columnKey="street"
             header={<Cell>Street</Cell>}
-            cell={<TextCell data={dataList} />}
+            cell={<TextCell data={dataList}/>}
             width={200}
           />
           <Column
             columnKey="zipCode"
             header={<Cell>Zip Code</Cell>}
-            cell={<TextCell data={dataList} />}
+            cell={<TextCell data={dataList}/>}
             width={200}
           />
         </Table>

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -175,6 +175,18 @@ var FixedDataTable = React.createClass({
     rowHeightGetter: PropTypes.func,
 
     /**
+     * If specified, `rowDropdownGetter(index)` is called for each row and the
+     * returned data is shown as a dropdown.
+     */
+    rowDropdownGetter: PropTypes.func,
+
+    /**
+     * If specified, `rowExpansionHeightGetter(index)` is called for each row and the
+     * returned value adds to `rowHeight` for particular row.
+     */
+    rowDropdownHeightGetter: PropTypes.func,
+
+    /**
      * To get any additional CSS classes that should be added to a row,
      * `rowClassNameGetter(index)` is called.
      */
@@ -306,6 +318,7 @@ var FixedDataTable = React.createClass({
       footerHeight: 0,
       groupHeaderHeight: 0,
       headerHeight: 0,
+
       showScrollbarX: true,
       showScrollbarY: true,
       touchScrollEnabled: false
@@ -324,7 +337,8 @@ var FixedDataTable = React.createClass({
       props.rowsCount,
       props.rowHeight,
       viewportHeight,
-      props.rowHeightGetter
+      props.rowHeightGetter,
+      props.rowDropdownHeightGetter
     );
 
     this._didScrollStop = debounceCore(this._didScrollStop, 200, this);
@@ -659,6 +673,8 @@ var FixedDataTable = React.createClass({
         rowsCount={state.rowsCount}
         rowGetter={state.rowGetter}
         rowHeightGetter={state.rowHeightGetter}
+        rowDropdownGetter={state.rowDropdownGetter}
+        rowDropdownHeightGetter={state.rowDropdownHeightGetter}
         scrollLeft={state.scrollX}
         scrollableColumns={state.bodyScrollableColumns}
         showLastRowBorder={true}
@@ -901,7 +917,8 @@ var FixedDataTable = React.createClass({
         props.rowsCount,
         props.rowHeight,
         viewportHeight,
-        props.rowHeightGetter
+        props.rowHeightGetter,
+        props.rowDropdownHeightGetter
       );
       scrollState = this._scrollHelper.scrollToRow(firstRowIndex, firstRowOffset);
       firstRowIndex = scrollState.index;
@@ -909,6 +926,8 @@ var FixedDataTable = React.createClass({
       scrollY = scrollState.position;
     } else if (oldState && props.rowHeightGetter !== oldState.rowHeightGetter) {
       this._scrollHelper.setRowHeightGetter(props.rowHeightGetter);
+    } else if (oldState && props.rowDropdownHeightGetter !== oldState.rowDropdownHeightGetter) {
+      this._scrollHelper.setRowDropdownHeightGetter(props.rowDropdownHeightGetter);
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -10,13 +10,12 @@
  * @typechecks
  */
 
-import React from 'React';
-import FixedDataTableRowBuffer from 'FixedDataTableRowBuffer';
-import FixedDataTableRow from 'FixedDataTableRow';
-
-import cx from 'cx';
-import emptyFunction from 'emptyFunction';
-import joinClasses from 'joinClasses';
+import React from "React";
+import FixedDataTableRowBuffer from "FixedDataTableRowBuffer";
+import FixedDataTableRow from "FixedDataTableRow";
+import cx from "cx";
+import emptyFunction from "emptyFunction";
+import joinClasses from "joinClasses";
 
 var {PropTypes} = React;
 
@@ -38,6 +37,8 @@ var FixedDataTableBufferedRows = React.createClass({
     rowClassNameGetter: PropTypes.func,
     rowsCount: PropTypes.number.isRequired,
     rowHeightGetter: PropTypes.func,
+    rowDropdownGetter: PropTypes.func,
+    rowDropdownHeightGetter: PropTypes.func,
     rowPositionGetter: PropTypes.func.isRequired,
     scrollLeft: PropTypes.number.isRequired,
     scrollableColumns: PropTypes.array.isRequired,
@@ -73,8 +74,8 @@ var FixedDataTableBufferedRows = React.createClass({
 
   componentWillReceiveProps(/*object*/ nextProps) {
     if (nextProps.rowsCount !== this.props.rowsCount ||
-        nextProps.defaultRowHeight !== this.props.defaultRowHeight ||
-        nextProps.height !== this.props.height) {
+      nextProps.defaultRowHeight !== this.props.defaultRowHeight ||
+      nextProps.height !== this.props.height) {
       this._rowBuffer =
         new FixedDataTableRowBuffer(
           nextProps.rowsCount,
@@ -135,6 +136,8 @@ var FixedDataTableBufferedRows = React.createClass({
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
+      var currentRowDropdownHeight = this._getRowDropdownHeight(rowIndex);
+      var currentRowDropdown = this._getRowDropdown(rowIndex);
       var rowOffsetTop = baseOffsetTop + rowPositions[rowIndex];
 
       var hasBottomBorder =
@@ -147,6 +150,8 @@ var FixedDataTableBufferedRows = React.createClass({
           index={rowIndex}
           width={props.width}
           height={currentRowHeight}
+          dropdown={currentRowDropdown}
+          dropdownHeight={currentRowDropdownHeight}
           scrollLeft={Math.round(props.scrollLeft)}
           offsetTop={Math.round(rowOffsetTop)}
           fixedColumns={props.fixedColumns}
@@ -175,6 +180,18 @@ var FixedDataTableBufferedRows = React.createClass({
       this.props.rowHeightGetter(index) :
       this.props.defaultRowHeight;
   },
+
+  _getRowDropdown(index) {
+    return this.props.rowDropdownGetter ?
+      this.props.rowDropdownGetter(index) :
+      null;
+  },
+
+  _getRowDropdownHeight(/*number*/ index) /*number*/ {
+    return this.props.rowDropdownHeightGetter ?
+      this.props.rowDropdownHeightGetter(index) :
+      0;
+  }
 });
 
 module.exports = FixedDataTableBufferedRows;

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -12,12 +12,11 @@
 
 'use strict';
 
-import React from 'React';
-import FixedDataTableCellGroup from 'FixedDataTableCellGroup';
-
-import cx from 'cx';
-import joinClasses from 'joinClasses';
-import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
+import React from "React";
+import FixedDataTableCellGroup from "FixedDataTableCellGroup";
+import cx from "cx";
+import joinClasses from "joinClasses";
+import FixedDataTableTranslateDOMPosition from "FixedDataTableTranslateDOMPosition";
 
 var {PropTypes} = React;
 
@@ -41,6 +40,16 @@ var FixedDataTableRowImpl = React.createClass({
      * Height of the row.
      */
     height: PropTypes.number.isRequired,
+
+    /**
+     * dropdown content of each row
+     */
+    dropdown: PropTypes.any,
+
+    /**
+     * Height of the dropdown.
+     */
+    dropdownHeight: PropTypes.number,
 
     /**
      * The row index.
@@ -113,7 +122,7 @@ var FixedDataTableRowImpl = React.createClass({
   render() /*object*/ {
     var style = {
       width: this.props.width,
-      height: this.props.height,
+      height: this.props.height + this.props.dropdownHeight,
     };
 
     var className = cx({
@@ -165,6 +174,22 @@ var FixedDataTableRowImpl = React.createClass({
     var scrollableColumnsWidth = this._getColumnsWidth(this.props.scrollableColumns);
     var columnsRightShadow = this._renderColumnsRightShadow(fixedColumnsWidth + scrollableColumnsWidth);
 
+    var dropdownWrapper;
+    if (this.props.dropdownHeight) {
+      var dropdownStyle = {
+        position: 'relative',
+        top: this.props.height,
+        width: this.props.width,
+        height: this.props.dropdownHeight
+      };
+
+      dropdownWrapper = (
+        <div className={cx('fixedDataTableRowLayout/dropdown')} style={dropdownStyle}>
+          {this.props.dropdown}
+        </div>
+      );
+    }
+
     return (
       <div
         className={joinClasses(className, this.props.className)}
@@ -180,6 +205,7 @@ var FixedDataTableRowImpl = React.createClass({
           {columnsLeftShadow}
         </div>
         {columnsRightShadow}
+        {dropdownWrapper}
       </div>
     );
   },
@@ -198,13 +224,13 @@ var FixedDataTableRowImpl = React.createClass({
       'fixedDataTableRowLayout/columnsShadow': this.props.scrollLeft > 0,
       'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
       'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
-     });
-     var style = {
-       left: left,
-       height: this.props.height
-     };
-     return <div className={className} style={style} />;
-   },
+    });
+    var style = {
+      left: left,
+      height: this.props.height
+    };
+    return <div className={className} style={style}/>;
+  },
 
   _renderColumnsRightShadow(/*number*/ totalWidth) /*?object*/ {
     if (Math.ceil(this.props.scrollLeft + this.props.width) < totalWidth) {
@@ -217,7 +243,7 @@ var FixedDataTableRowImpl = React.createClass({
       var style = {
         height: this.props.height
       };
-      return <div className={className} style={style} />;
+      return <div className={className} style={style}/>;
     }
   },
 
@@ -254,6 +280,16 @@ var FixedDataTableRow = React.createClass({
     height: PropTypes.number.isRequired,
 
     /**
+     * Dropdown content
+     */
+    dropdown: PropTypes.any,
+
+    /**
+     * Height of the dropdown.
+     */
+    dropdownHeight: PropTypes.number,
+
+    /**
      * Z-index on which the row will be displayed. Used e.g. for keeping
      * header and footer in front of other rows.
      */
@@ -279,11 +315,14 @@ var FixedDataTableRow = React.createClass({
   },
 
   render() /*object*/ {
+    var dropdownHeight = this.props.dropdownHeight || 0;
+
     var style = {
       width: this.props.width,
-      height: this.props.height,
+      height: this.props.height + dropdownHeight,
       zIndex: (this.props.zIndex ? this.props.zIndex : 0),
     };
+
     FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
 
     return (
@@ -292,6 +331,7 @@ var FixedDataTableRow = React.createClass({
         className={cx('fixedDataTableRowLayout/rowWrapper')}>
         <FixedDataTableRowImpl
           {...this.props}
+          dropdownHeight={dropdownHeight}
           offsetTop={undefined}
           zIndex={undefined}
         />

--- a/src/FixedDataTableScrollHelper.js
+++ b/src/FixedDataTableScrollHelper.js
@@ -28,7 +28,8 @@ class FixedDataTableScrollHelper {
     /*number*/ rowCount,
     /*number*/ defaultRowHeight,
     /*number*/ viewportHeight,
-    /*?function*/ rowHeightGetter
+    /*?function*/ rowHeightGetter,
+    /*?function*/ rowDropdownHeightGetter
   ) {
     this._rowOffsets = PrefixIntervalTree.uniform(rowCount, defaultRowHeight);
     this._storedHeights = new Array(rowCount);
@@ -42,6 +43,9 @@ class FixedDataTableScrollHelper {
     this._rowHeightGetter = rowHeightGetter ?
       rowHeightGetter :
       () => defaultRowHeight;
+    this._rowDropdownHeightGetter = rowDropdownHeightGetter ?
+      rowDropdownHeightGetter :
+      () => 0;
     this._viewportHeight = viewportHeight;
     this.scrollRowIntoView = this.scrollRowIntoView.bind(this);
     this.setViewportHeight = this.setViewportHeight.bind(this);
@@ -49,6 +53,7 @@ class FixedDataTableScrollHelper {
     this.scrollTo = this.scrollTo.bind(this);
     this.scrollToRow = this.scrollToRow.bind(this);
     this.setRowHeightGetter = this.setRowHeightGetter.bind(this);
+    this.setRowDropdownHeightGetter = this.setRowDropdownHeightGetter.bind(this);
     this.getContentHeight = this.getContentHeight.bind(this);
     this.getRowPosition = this.getRowPosition.bind(this);
 
@@ -58,6 +63,11 @@ class FixedDataTableScrollHelper {
   setRowHeightGetter(/*function*/ rowHeightGetter) {
     this._rowHeightGetter = rowHeightGetter;
   }
+
+  setRowDropdownHeightGetter(/*function*/ rowDropdownHeightGetter) {
+    this._rowDropdownHeightGetter = rowDropdownHeightGetter;
+  }
+
 
   setViewportHeight(/*number*/ viewportHeight) {
     this._viewportHeight = viewportHeight;
@@ -93,7 +103,7 @@ class FixedDataTableScrollHelper {
     if (rowIndex < 0 || rowIndex >= this._rowCount) {
       return 0;
     }
-    var newHeight = this._rowHeightGetter(rowIndex);
+    var newHeight = this._rowHeightGetter(rowIndex) + this._rowDropdownHeightGetter(rowIndex);
     if (newHeight !== this._storedHeights[rowIndex]) {
       var change = newHeight - this._storedHeights[rowIndex];
       this._rowOffsets.set(rowIndex, newHeight);


### PR DESCRIPTION
Enables rows to have dropdown which can be used to display additional information about the row if needed.
## Description

Added a dropdownGetter and dropdownHeightGetter to the FixedDataTable class. Changed a couple additional classes as necessary.
## Motivation and Context

The table will be used to render results from a testing suite. Data about the tests will be displayed under each row in the dropdown.
## How Has This Been Tested?

No heavy testing at the moment. Will be performed if pull request is considered.
## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/376453/19833129/532e3554-9dec-11e6-96a0-1e351053dc56.png)

![image](https://cloud.githubusercontent.com/assets/376453/19987028/4b80ba96-a1d6-11e6-9654-86a08683f4bd.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.

Let me know if this pull request is worth pursuing. If so, I can meet the requirements.
