### PR TITLE
Class for adding Column Group border

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -443,6 +443,12 @@ var FixedDataTable = React.createClass({
 
     var groupHeader;
     if (state.useGroupHeader) {
+      var allGroupsIndexes = [];
+      var columnGroupCount = state.groupHeaderFixedColumns.length + state.groupHeaderScrollableColumns.length;
+      for (var i = 0; i < columnGroupCount; i++) {
+        allGroupsIndexes.push(i);
+      }
+
       groupHeader = (
         <FixedDataTableRow
           key="group_header"
@@ -459,6 +465,7 @@ var FixedDataTable = React.createClass({
           scrollLeft={state.scrollX}
           fixedColumns={state.groupHeaderFixedColumns}
           scrollableColumns={state.groupHeaderScrollableColumns}
+          positionOfLastColumnInGroups={allGroupsIndexes}
           onColumnResize={this._onColumnResize}
           onColumnReorder={onColumnReorder}
           onColumnReorderMove={this._onColumnReorderMove}
@@ -549,6 +556,7 @@ var FixedDataTable = React.createClass({
           offsetTop={footOffsetTop}
           fixedColumns={state.footFixedColumns}
           scrollableColumns={state.footScrollableColumns}
+          positionOfLastColumnInGroups={state.positionOfLastColumnInGroups}
           scrollLeft={state.scrollX}
         />;
     }
@@ -571,6 +579,7 @@ var FixedDataTable = React.createClass({
         scrollLeft={state.scrollX}
         fixedColumns={state.headFixedColumns}
         scrollableColumns={state.headScrollableColumns}
+        positionOfLastColumnInGroups={state.positionOfLastColumnInGroups}
         onColumnResize={this._onColumnResize}
         onColumnReorder={onColumnReorder}
         onColumnReorderMove={this._onColumnReorderMove}
@@ -655,6 +664,7 @@ var FixedDataTable = React.createClass({
         onRowMouseDown={state.onRowMouseDown}
         onRowMouseEnter={state.onRowMouseEnter}
         onRowMouseLeave={state.onRowMouseLeave}
+        positionOfLastColumnInGroups={state.positionOfLastColumnInGroups}
         rowClassNameGetter={state.rowClassNameGetter}
         rowsCount={state.rowsCount}
         rowGetter={state.rowGetter}
@@ -705,7 +715,7 @@ var FixedDataTable = React.createClass({
     /*number*/ left,
     /*object*/ event
   ) {
-    var isFixed = !!this.state.headFixedColumns.find(function(column) { 
+    var isFixed = !!this.state.headFixedColumns.find(function(column) {
       return column.props.columnKey === columnKey;
     });
 
@@ -854,6 +864,21 @@ var FixedDataTable = React.createClass({
         columnInfo.groupHeaderFixedColumns = groupHeaderColumnTypes.fixed;
         columnInfo.groupHeaderScrollableColumns =
           groupHeaderColumnTypes.scrollable;
+      }
+    }
+
+    // NOTE (jordan) This is a hacky fix for styling column group borders.  Cleanup with move to Redux
+    if (canReuseColumnGroupSettings && canReuseColumnSettings) {
+      columnInfo.positionOfLastColumnInGroups = oldState.positionOfLastColumnInGroups;
+    } else {
+      columnInfo.positionOfLastColumnInGroups = [];
+      if (columnGroups) {
+        var count = 0;
+        for (var i = 0; i < columnGroups.length; ++i) {
+          var columns = columnGroups[i].props.children;
+          count += columns.length;
+          columnInfo.positionOfLastColumnInGroups.push(count-1);
+        }
       }
     }
 

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -35,6 +35,7 @@ var FixedDataTableBufferedRows = React.createClass({
     onRowMouseDown: PropTypes.func,
     onRowMouseEnter: PropTypes.func,
     onRowMouseLeave: PropTypes.func,
+    positionOfLastColumnInGroups: PropTypes.array.isRequired,
     rowClassNameGetter: PropTypes.func,
     rowsCount: PropTypes.number.isRequired,
     rowHeightGetter: PropTypes.func,
@@ -151,6 +152,7 @@ var FixedDataTableBufferedRows = React.createClass({
           offsetTop={Math.round(rowOffsetTop)}
           fixedColumns={props.fixedColumns}
           scrollableColumns={props.scrollableColumns}
+          positionOfLastColumnInGroups={props.positionOfLastColumnInGroups}
           onClick={props.onRowClick}
           onDoubleClick={props.onRowDoubleClick}
           onMouseDown={props.onRowMouseDown}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -78,6 +78,8 @@ var FixedDataTableCell = React.createClass({
      * The left offset in pixels of the cell.
      */
     left: PropTypes.number,
+
+    lastInGroup: PropTypes.bool.isRequired,
   },
 
   getInitialState() {
@@ -201,6 +203,7 @@ var FixedDataTableCell = React.createClass({
         'public/fixedDataTableCell/alignRight': props.align === 'right',
         'public/fixedDataTableCell/highlighted': props.highlighted,
         'public/fixedDataTableCell/main': true,
+        'public/fixedDataTableCell/lastInGroup': props.lastInGroup,
         'public/fixedDataTableCell/hasReorderHandle': !!props.onColumnReorder,
         'public/fixedDataTableCell/reordering': this.state.isReorderingThisColumn,
       }),

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -46,6 +46,7 @@ var FixedDataTableCellGroupImpl = React.createClass({
     onColumnReorder: PropTypes.func,
     onColumnReorderMove: PropTypes.func,
     onColumnReorderEnd: PropTypes.func,
+    positionOfLastColumnInGroups: PropTypes.array.isRequired,
 
     rowHeight: PropTypes.number.isRequired,
 
@@ -54,6 +55,7 @@ var FixedDataTableCellGroupImpl = React.createClass({
     width: PropTypes.number.isRequired,
 
     zIndex: PropTypes.number.isRequired,
+
   },
 
   componentWillMount() {
@@ -77,6 +79,7 @@ var FixedDataTableCellGroupImpl = React.createClass({
 
     var currentPosition = 0;
     for (var i = 0, j = columns.length; i < j; i++) {
+      var lastInGroup = props.positionOfLastColumnInGroups.indexOf(i) > -1;
       var columnProps = columns[i].props;
       var recycable = columnProps.allowCellsRecycling && !isColumnReordering;
       if (!recycable || (
@@ -90,7 +93,8 @@ var FixedDataTableCellGroupImpl = React.createClass({
           currentPosition,
           key,
           contentWidth,
-          isColumnReordering
+          isColumnReordering,
+          lastInGroup
         );
       }
       currentPosition += columnProps.width;
@@ -120,6 +124,7 @@ var FixedDataTableCellGroupImpl = React.createClass({
     /*string*/ key,
     /*number*/ columnGroupWidth,
     /*boolean*/ isColumnReordering,
+    /*boolean*/ lastInGroup,
   ) /*object*/ {
 
     var cellIsResizable = columnProps.isResizable &&
@@ -151,6 +156,7 @@ var FixedDataTableCellGroupImpl = React.createClass({
         left={left}
         cell={columnProps.cell}
         columnGroupWidth={columnGroupWidth}
+        lastInGroup={lastInGroup}
       />
     );
   },

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -108,6 +108,11 @@ var FixedDataTableRowImpl = React.createClass({
      * @param number distance
      */
     onColumnReorderEnd: PropTypes.func,
+
+    /**
+     * Used for adding a class to the first column in a column group
+     */
+    positionOfLastColumnInGroups: PropTypes.array.isRequired,
   },
 
   render() /*object*/ {
@@ -137,12 +142,26 @@ var FixedDataTableRowImpl = React.createClass({
         onColumnReorder={this.props.onColumnReorder}
         onColumnReorderMove={this.props.onColumnReorderMove}
         onColumnReorderEnd={this.props.onColumnReorderEnd}
+        positionOfLastColumnInGroups={this.props.positionOfLastColumnInGroups}
         isColumnReordering={this.props.isColumnReordering}
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}
         rowIndex={this.props.index}
       />;
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
+
+    var scrollablepositionOfLastColumnInGroups = []
+    if (this.props.fixedColumns.length > 0) {
+      for (var idx = 0; idx < this.props.positionOfLastColumnInGroups.length; ++idx) {
+        var newPosition = this.props.positionOfLastColumnInGroups[idx] - this.props.fixedColumns.length;
+        if (newPosition >= 0) {
+          scrollablepositionOfLastColumnInGroups.push(newPosition);
+        }
+      }
+    } else {
+      scrollablepositionOfLastColumnInGroups = this.props.positionOfLastColumnInGroups;
+    }
+
     var scrollableColumns =
       <FixedDataTableCellGroup
         key="scrollable_cells"
@@ -157,6 +176,7 @@ var FixedDataTableRowImpl = React.createClass({
         onColumnReorder={this.props.onColumnReorder}
         onColumnReorderMove={this.props.onColumnReorderMove}
         onColumnReorderEnd={this.props.onColumnReorderEnd}
+        positionOfLastColumnInGroups={scrollablepositionOfLastColumnInGroups}
         isColumnReordering={this.props.isColumnReordering}
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a class to the last cells in a column group so you can style a column group border

## Description
<!--- Describe your changes in detail -->
Added a public_fixedDataTableCell_lastInGroup css class to the cells which are in the last column of a column group.  This enables styling the border between column groups.

This is a really hacky approach to this.  I'm going to prioritize doing it correctly on the 0.8 branch with Redux.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#70

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried this out in our examples.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/1034455/20501082/4841139c-b006-11e6-9afc-bcd804e4a5b7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

