### PR TITLE
Column key is regenerated automatically even if key is already defined 

### DIFF
--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -82,7 +82,7 @@ var FixedDataTableCellGroupImpl = React.createClass({
       if (!recycable || (
             currentPosition - props.left <= props.width &&
             currentPosition - props.left + columnProps.width >= 0)) {
-        var key = 'cell_' + i;
+        var key = columnProps.columnKey || 'cell_' + i;
         cells[i] = this._renderCell(
           props.rowIndex,
           props.rowHeight,


### PR DESCRIPTION
See issue [#84](https://github.com/schrodinger/fixed-data-table-2/issues/84)

## Description
Changed generation key for Cell. For now we using columnKey as key when columnKey provided in props

## Motivation and Context
Cell was recreated each time after changing key(after hiding). Now it is only update

## How Has This Been Tested?
It is tested on example in Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [- ] My change requires a change to the documentation.
- [ -] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

