### PR TITLE
add prop for disabling the wheel handler

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -151,6 +151,11 @@ var FixedDataTable = React.createClass({
     showScrollbarY: PropTypes.bool,
 
     /**
+     * Disables the handling of wheel events.
+     */
+    disableWheelHandler: PropTypes.bool
+
+    /**
      * Callback when horizontally scrolling the grid
      *
      * Return false to stop propagation
@@ -346,7 +351,7 @@ var FixedDataTable = React.createClass({
   },
 
   _shouldHandleWheelX(/*number*/ delta) /*boolean*/ {
-    if (this.props.overflowX === 'hidden') {
+    if (this.props.overflowX === 'hidden' || this.props.disableWheelHandler) {
       return false;
     }
 
@@ -362,7 +367,7 @@ var FixedDataTable = React.createClass({
   },
 
   _shouldHandleWheelY(/*number*/ delta) /*boolean*/ {
-    if (this.props.overflowY === 'hidden'|| delta === 0) {
+    if (this.props.overflowY === 'hidden' || delta === 0 || this.props.disableWheelHandler) {
       return false;
     }
 
@@ -705,7 +710,7 @@ var FixedDataTable = React.createClass({
     /*number*/ left,
     /*object*/ event
   ) {
-    var isFixed = !!this.state.headFixedColumns.find(function(column) { 
+    var isFixed = !!this.state.headFixedColumns.find(function(column) {
       return column.props.columnKey === columnKey;
     });
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -153,7 +153,7 @@ var FixedDataTable = React.createClass({
     /**
      * Disables the handling of wheel events.
      */
-    disableWheelHandler: PropTypes.bool
+    disableWheelHandler: PropTypes.bool,
 
     /**
      * Callback when horizontally scrolling the grid

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -151,16 +151,18 @@ var FixedDataTable = React.createClass({
     showScrollbarY: PropTypes.bool,
 
     /**
-     * Disables the handling of wheel events.
-     */
-    disableWheelHandler: PropTypes.bool,
-
-    /**
-     * Callback when horizontally scrolling the grid
+     * Callback when horizontally scrolling the grid.
      *
-     * Return false to stop propagation
+     * Return false to stop propagation.
      */
     onHorizontalScroll: PropTypes.func,
+
+    /**
+     * Callback when vertically scrolling the grid.
+     *
+     * Return false to stop propagation.
+     */
+    onVerticalScroll: PropTypes.func,
 
     /**
      * Number of rows in the table.
@@ -351,7 +353,7 @@ var FixedDataTable = React.createClass({
   },
 
   _shouldHandleWheelX(/*number*/ delta) /*boolean*/ {
-    if (this.props.overflowX === 'hidden' || this.props.disableWheelHandler) {
+    if (this.props.overflowX === 'hidden') {
       return false;
     }
 
@@ -367,7 +369,7 @@ var FixedDataTable = React.createClass({
   },
 
   _shouldHandleWheelY(/*number*/ delta) /*boolean*/ {
-    if (this.props.overflowY === 'hidden' || delta === 0 || this.props.disableWheelHandler) {
+    if (this.props.overflowY === 'hidden' || delta === 0) {
       return false;
     }
 
@@ -1120,17 +1122,20 @@ var FixedDataTable = React.createClass({
       if (Math.abs(deltaY) > Math.abs(deltaX) &&
           this.props.overflowY !== 'hidden') {
         var scrollState = this._scrollHelper.scrollBy(Math.round(deltaY));
-        var maxScrollY = Math.max(
-          0,
-          scrollState.contentHeight - this.state.bodyHeight
-        );
-        this.setState({
-          firstRowIndex: scrollState.index,
-          firstRowOffset: scrollState.offset,
-          scrollY: scrollState.position,
-          scrollContentHeight: scrollState.contentHeight,
-          maxScrollY: maxScrollY,
-        });
+        var onVerticalScroll = this.props.onVerticalScroll;
+        if (onVerticalScroll ? onVerticalScroll(scrollState.position) : true) {
+          var maxScrollY = Math.max(
+            0,
+            scrollState.contentHeight - this.state.bodyHeight
+          );
+          this.setState({
+            firstRowIndex: scrollState.index,
+            firstRowOffset: scrollState.offset,
+            scrollY: scrollState.position,
+            scrollContentHeight: scrollState.contentHeight,
+            maxScrollY: maxScrollY,
+          });
+        }
       } else if (deltaX && this.props.overflowX !== 'hidden') {
         x += deltaX;
         x = x < 0 ? 0 : x;
@@ -1171,13 +1176,17 @@ var FixedDataTable = React.createClass({
         this._didScrollStart();
       }
       var scrollState = this._scrollHelper.scrollTo(Math.round(scrollPos));
-      this.setState({
-        firstRowIndex: scrollState.index,
-        firstRowOffset: scrollState.offset,
-        scrollY: scrollState.position,
-        scrollContentHeight: scrollState.contentHeight,
-      });
-      this._didScrollStop();
+
+      var onVerticalScroll = this.props.onVerticalScroll;
+      if (onVerticalScroll ? onVerticalScroll(scrollState.position) : true) {
+        this.setState({
+          firstRowIndex: scrollState.index,
+          firstRowOffset: scrollState.offset,
+          scrollY: scrollState.position,
+          scrollContentHeight: scrollState.contentHeight,
+        });
+        this._didScrollStop();
+      }
     }
   },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
~~adds a new boolean prop `disableWheelHandler`, that, when enabled, will disable handling wheel events.~~
adds a new boolean prop `onVerticalScroll`, that works like `onHorizontalScroll`.

## Motivation and Context
we have a use-case in which we need to handle the wheel by ourselves since we are using window scrolling with the table. now we need to resort to a hack like this:
```js
<Table
  ref={e => e && (e._wheelHandler = () => {})}
...
```
which is very ugly, so would be nice to be able to do this "officially" via a property!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
