### PR TITLE
xw - fix the bug that the right shadow sometimes displays when it shouldn't have

### DIFF
--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -207,7 +207,7 @@ var FixedDataTableRowImpl = React.createClass({
    },
 
   _renderColumnsRightShadow(/*number*/ totalWidth) /*?object*/ {
-    if (Math.ceil(this.props.scrollLeft + this.props.width) < totalWidth) {
+    if (Math.ceil(this.props.scrollLeft + this.props.width) < Math.floor(totalWidth)) {
       var className = cx(
         'fixedDataTableRowLayout/columnsShadow',
         'fixedDataTableRowLayout/columnsRightShadow',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In some cases, the right shadow of the report displays even if no more content to the right of the last column on the screen.

Turns out the bug is due to the way we treated `totalWidth` in this [line](https://github.com/schrodinger/fixed-data-table-2/pull/58/files#diff-fde5b1303832bdaa63c6b50e39d07352R210) of the PR #58 

Under some certain circumstances, re-assigning column widths based on current window width for example, the `totalWidth` could be a decimal like `180.001`, and it will lead the component `FixedDataTableRow` rendering the right shadow all the time.

To take care of such cases, we need to convert `totalWidth` to an Integer by `Math.floor(totalWidth)` in order to make sure the right column shadow won't display when it shouldn't. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To show a column shadow when it shouldn't have could be misleading. It makes people think there are more data to the right of the last column on the screen, even though that's not true at all.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's a very minor changes and I tested it manually on a number of browsers. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
