### PR TITLE
Fix column dragging in IE11

### DIFF
--- a/site/webpack-client.config.js
+++ b/site/webpack-client.config.js
@@ -65,6 +65,10 @@ module.exports = {
     }
   },
 
+  devServer: {
+    host: '0.0.0.0'
+  },
+
   plugins: [
     new ExtractTextPlugin(
       isDev ? '[name].css' : '[name]-[hash].css'

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -712,9 +712,8 @@ var FixedDataTable = React.createClass({
     /*number*/ left,
     /*object*/ event
   ) {
-    // No native support in IE11 for find, findIndex, or includes, so using every.
-    var isFixed = !this.state.headFixedColumns.every(function(column) {
-      return column.props.columnKey !== columnKey;
+    var isFixed = this.state.headFixedColumns.some(function(column) {
+      return column.props.columnKey === columnKey;
     });
 
     this.setState({

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -712,6 +712,7 @@ var FixedDataTable = React.createClass({
     /*number*/ left,
     /*object*/ event
   ) {
+    // No native support in IE11 for find, findIndex, or includes, so using some.
     var isFixed = this.state.headFixedColumns.some(function(column) {
       return column.props.columnKey === columnKey;
     });

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -712,8 +712,9 @@ var FixedDataTable = React.createClass({
     /*number*/ left,
     /*object*/ event
   ) {
-    var isFixed = !!this.state.headFixedColumns.find(function(column) {
-      return column.props.columnKey === columnKey;
+    // No native support in IE11 for find, findIndex, or includes, so using every.
+    var isFixed = !this.state.headFixedColumns.every(function(column) {
+      return column.props.columnKey !== columnKey;
     });
 
     this.setState({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Drag reordering did not work at all in IE11 because Array.prototype.find is not supported in it
Also, add host: 0.0.0.0 to the webpack-client.config.js so that developers can use VMs (such as when testing in IE11)

## Motivation and Context
SS-18621

## How Has This Been Tested?
Tested in column draggable example

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
