### PR TITLE
Fix scroll doesn't reset to top

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1057,11 +1057,10 @@ var FixedDataTable = React.createClass({
     this._scrollHelper.setViewportHeight(bodyHeight);
 
     // This calculation is synonymous to Element.scrollTop
-    var scrollTop = firstRowIndex != null ? Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex)) : 0;
-    // Handle the case where the scrollTop is beyond the maxScrollY, such as when the user is completely scrolled
-    // down and resizes the viewport to be smaller vertically. The other case is when resizing the viewport large enough
-    // so that a scrollbar is not necessary anymore, to make sure we set the scrollTop back to 0.
-    if (scrollTop > maxScrollY || (oldState && oldState.scrollY !== 0 && maxScrollY === 0)) {
+    var scrollTop = Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex));
+    // This case can happen when the user is completely scrolled down and resizes the viewport to be taller vertically.
+    // This is because we set the viewport height after having calculated the rows
+    if (scrollTop !== scrollY) {
       scrollTop = maxScrollY;
       scrollState = this._scrollHelper.scrollTo(scrollTop);
       firstRowIndex = scrollState.index;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1056,6 +1056,21 @@ var FixedDataTable = React.createClass({
 
     this._scrollHelper.setViewportHeight(bodyHeight);
 
+    // This calculation is synonymous to Element.scrollTop
+    var scrollTop = firstRowIndex && Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex));
+    if (scrollTop >= 0) {
+      var maxScrollTop = scrollContentHeight - bodyHeight;
+      // Handle the case where the scrollTop is beyond the maxScrollTop, such as when the user is completely scrolled
+      // down and resizes the viewport to be smaller vertically
+      if (scrollTop > maxScrollTop || scrollTop === 0) {
+        scrollTop = maxScrollTop;
+        scrollState = this._scrollHelper.scrollTo(scrollTop);
+        firstRowIndex = scrollState.index;
+        firstRowOffset = scrollState.offset;
+        scrollY = scrollState.position;
+      }
+    }
+
     // The order of elements in this object metters and bringing bodyHeight,
     // height or useGroupHeader to the top can break various features
     var newState = {
@@ -1078,7 +1093,6 @@ var FixedDataTable = React.createClass({
       scrollContentHeight,
       scrollX,
       scrollY,
-
       // These properties may overwrite properties defined in
       // columnInfo and props
       bodyHeight,
@@ -1160,7 +1174,6 @@ var FixedDataTable = React.createClass({
       this._didScrollStop();
     }
   },
-
 
   _onHorizontalScroll(/*number*/ scrollPos) {
     if (this.isMounted() && scrollPos !== this.state.scrollX) {

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1057,18 +1057,16 @@ var FixedDataTable = React.createClass({
     this._scrollHelper.setViewportHeight(bodyHeight);
 
     // This calculation is synonymous to Element.scrollTop
-    var scrollTop = firstRowIndex && Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex));
-    if (scrollTop >= 0) {
-      var maxScrollTop = maxScrollY ? scrollContentHeight - bodyHeight : 0;
-      // Handle the case where the scrollTop is beyond the maxScrollTop, such as when the user is completely scrolled
-      // down and resizes the viewport to be smaller vertically
-      if (scrollTop > maxScrollTop || maxScrollTop === 0) {
-        scrollTop = maxScrollTop;
-        scrollState = this._scrollHelper.scrollTo(scrollTop);
-        firstRowIndex = scrollState.index;
-        firstRowOffset = scrollState.offset;
-        scrollY = scrollState.position;
-      }
+    var scrollTop = firstRowIndex ? Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex)) : 0;
+    // Handle the case where the scrollTop is beyond the maxScrollY, such as when the user is completely scrolled
+    // down and resizes the viewport to be smaller vertically. The other case is when resizing the viewport large enough
+    // so that a scrollbar is not necessary anymore, to make sure we set the scrollTop back to 0.
+    if (scrollTop > maxScrollY || (oldState && oldState.scrollY !== 0 && maxScrollY === 0)) {
+      scrollTop = maxScrollY;
+      scrollState = this._scrollHelper.scrollTo(scrollTop);
+      firstRowIndex = scrollState.index;
+      firstRowOffset = scrollState.offset;
+      scrollY = scrollState.position;
     }
 
     // The order of elements in this object metters and bringing bodyHeight,

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1059,10 +1059,10 @@ var FixedDataTable = React.createClass({
     // This calculation is synonymous to Element.scrollTop
     var scrollTop = firstRowIndex && Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex));
     if (scrollTop >= 0) {
-      var maxScrollTop = scrollContentHeight - bodyHeight;
+      var maxScrollTop = maxScrollY ? scrollContentHeight - bodyHeight : 0;
       // Handle the case where the scrollTop is beyond the maxScrollTop, such as when the user is completely scrolled
       // down and resizes the viewport to be smaller vertically
-      if (scrollTop > maxScrollTop || scrollTop === 0) {
+      if (scrollTop > maxScrollTop || maxScrollTop === 0) {
         scrollTop = maxScrollTop;
         scrollState = this._scrollHelper.scrollTo(scrollTop);
         firstRowIndex = scrollState.index;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1057,7 +1057,7 @@ var FixedDataTable = React.createClass({
     this._scrollHelper.setViewportHeight(bodyHeight);
 
     // This calculation is synonymous to Element.scrollTop
-    var scrollTop = firstRowIndex ? Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex)) : 0;
+    var scrollTop = firstRowIndex != null ? Math.abs(firstRowOffset - this._scrollHelper.getRowPosition(firstRowIndex)) : 0;
     // Handle the case where the scrollTop is beyond the maxScrollY, such as when the user is completely scrolled
     // down and resizes the viewport to be smaller vertically. The other case is when resizing the viewport large enough
     // so that a scrollbar is not necessary anymore, to make sure we set the scrollTop back to 0.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the bug where if you were to scroll to the bottom (or anywhere below the top), then resize the screen bigger until there is no scrollbar, the content used to not scroll up as the 'clientHeight' was increasing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/schrodinger/fixed-data-table-2/issues/87

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by sizing the screen smaller to create a scrollbar, scrolling to bottom, then increasing the size until there is no scrollbar. Did this several times and used logging to ensure that bad state was not happening.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
