### PR TITLE
update viewportHeight when height changes (closes #120)

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -919,7 +919,7 @@ var FixedDataTable = React.createClass({
 
     var groupHeaderHeight = useGroupHeader ? props.groupHeaderHeight : 0;
 
-    if (oldState && (props.rowsCount !== oldState.rowsCount || props.rowHeight !== oldState.rowHeight)) {
+    if (oldState && (props.rowsCount !== oldState.rowsCount || props.rowHeight !== oldState.rowHeight || props.height !== oldState.height)) {
       // Number of rows changed, try to scroll to the row from before the
       // change
       var viewportHeight =
@@ -927,6 +927,9 @@ var FixedDataTable = React.createClass({
         (props.headerHeight || 0) -
         (props.footerHeight || 0) -
         (props.groupHeaderHeight || 0);
+
+    var oldViewportHeight = this._scrollHelper._viewportHeight;
+
       this._scrollHelper = new FixedDataTableScrollHelper(
         props.rowsCount,
         props.rowHeight,
@@ -942,7 +945,7 @@ var FixedDataTable = React.createClass({
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;
-    if (props.scrollToRow != null && props.scrollToRow !== lastScrollToRow) {
+    if (props.scrollToRow != null && (props.scrollToRow !== lastScrollToRow || viewportHeight !== oldViewportHeight)) {
       scrollState = this._scrollHelper.scrollRowIntoView(props.scrollToRow);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -928,7 +928,7 @@ var FixedDataTable = React.createClass({
         (props.footerHeight || 0) -
         (props.groupHeaderHeight || 0);
 
-    var oldViewportHeight = this._scrollHelper._viewportHeight;
+      var oldViewportHeight = this._scrollHelper._viewportHeight;
 
       this._scrollHelper = new FixedDataTableScrollHelper(
         props.rowsCount,

--- a/src/FixedDataTableRoot-test.js
+++ b/src/FixedDataTableRoot-test.js
@@ -128,5 +128,13 @@ describe('FixedDataTableRoot', function() {
         table.setState({scrollToRow: undefined});
       });
     });
+
+    it('should set scrollToRow correctly when height changes', function() {
+      let table = renderTable({ height: 0, scrollToRow: 30});
+      table.setState({height: 200});
+      //scrollToRow is considered valid if row is visible. Test to make sure that row is somewhere in between
+      assert.isBelow(table.getTableState().scrollY, 30 * 100, 'should be below first row');
+      assert.isAbove(table.getTableState().scrollY, 30 * 100 - 300, 'should be above last row');
+    });
   });
 });


### PR DESCRIPTION
as per issue #120, viewportHeight should be updated when height changes.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Issue #120

## How Has This Been Tested?
Modify ScrollToExample to receive width, height from local state. Initialize them to zero and update the size in `componentDidMount`.
Pass `scrollToRow={0}` when no row is found (like at first render).

Previous to this commit, fdt will start with scroll position > 0.
After this commit, fdt will start at the right scroll position.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
