### PR TITLE
Add width to FDTCellGroupWrapper

### DIFF
--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -207,6 +207,7 @@ var FixedDataTableCellGroup = React.createClass({
 
     var style = {
       height: props.height,
+      width: props.width
     };
 
     if (DIR_SIGN === 1) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add width to FDTCellGroupWrapper in order to enable overflow styling on it.

## Motivation and Context
CellGroupWrappers can now be styled to prevent overflow into other cell groups.

## How Has This Been Tested?
Manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
