### PR TITLE
Add prop to disable scroll event propagation.

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -241,6 +241,11 @@ var FixedDataTable = React.createClass({
     onScrollEnd: PropTypes.func,
 
     /**
+     * If enabled scroll events will not be propagated outside of the table.
+     */
+    stopScrollPropagation: PropTypes.bool,
+
+    /**
      * Callback that is called when `rowHeightGetter` returns a different height
      * for a row than the `rowHeight` prop. This is necessary because initially
      * table estimates heights of some parts of the content.
@@ -327,7 +332,8 @@ var FixedDataTable = React.createClass({
       headerHeight: 0,
       showScrollbarX: true,
       showScrollbarY: true,
-      touchScrollEnabled: false
+      touchScrollEnabled: false,
+      stopScrollPropagation: false
     };
   },
 
@@ -353,12 +359,14 @@ var FixedDataTable = React.createClass({
     this._wheelHandler = new ReactWheelHandler(
       this._onScroll,
       this._shouldHandleWheelX,
-      this._shouldHandleWheelY
+      this._shouldHandleWheelY,
+      props.stopScrollPropagation
     );
     this._touchHandler = new ReactTouchHandler(
       this._onScroll,
       touchEnabled && this._shouldHandleWheelX,
-      touchEnabled && this._shouldHandleWheelY
+      touchEnabled && this._shouldHandleWheelY,
+      props.stopScrollPropagation
     );
 
     this.setState(this._calculateState(props));


### PR DESCRIPTION
## Description

Exposes the ReactTouch/ReactWheelHandler `stopScrollPropagation` to the high-level props. The default behavior remains the same (false).

## Motivation and Context

We have some tables inside of other tables and the scroll event is captured by both and makes for a poor experience.

## How Has This Been Tested?

Tested visually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
