### PR TITLE
Support for multiple FDTs + scroll fix prep

### DIFF
--- a/build_helpers/buildNPMInternals.sh
+++ b/build_helpers/buildNPMInternals.sh
@@ -14,7 +14,7 @@ if (!fs.existsSync(internalPath)) {
 
 var providesModuleRegex = /@providesModule ([^\s*]+)/;
 var moduleRequireRegex = /=\s+require\((?:'|")([\w\.\/]+)(?:'|")\);/gm;
-var excludePathRegex = /^react($|\/)/;
+var excludePathRegex = /^(react|lodash|redux)($|\/)/;
 var findDEVRegex = /__DEV__/g;
 
 function replaceRequirePath(match, modulePath) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "react": ">=0.13.0 || ^0.14.0-beta3",
     "react-dom": ">=0.14.0 || ^0.14.0-beta3"
   },
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "redux": "^3.5.2"
+  },
   "devDependencies": {
     "aphrodite": "^0.5.0",
     "autoprefixer": "^5.0.0",
@@ -30,7 +34,6 @@
     "jsdom": "^9.6.0",
     "less": "^2.2.0",
     "less-loader": "^2.0.0",
-    "lodash": "^4.17.4",
     "marked": "^0.3.2",
     "mocha": "^2.5.3",
     "mocha-loader": "^1.0.0",
@@ -45,7 +48,6 @@
     "react-dom": "^15.3.2",
     "react-tools": "^0.12.2",
     "react-tooltip": "^3.2.1",
-    "redux": "^3.5.2",
     "sinon": "^2.0.0-pre.2",
     "style-loader": "^0.8.3",
     "url-loader": "^0.5.5",

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -318,12 +318,6 @@ var FixedDataTable = React.createClass({
   componentWillMount() {
     const props = this.props;
 
-    const viewportHeight =
-      (props.height === undefined ? props.maxHeight : props.height) -
-      (props.headerHeight || 0) -
-      (props.footerHeight || 0) -
-      (props.groupHeaderHeight || 0);
-
     this._didScrollStop = debounceCore(this._didScrollStop, 200, this);
 
     const touchEnabled = props.touchScrollEnabled === true;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -759,7 +759,6 @@ var FixedDataTable = React.createClass({
       elementTemplates,
       firstRowIndex,
       firstRowOffset,
-      groupHeaderHeight,
       horizontalScrollbarVisible,
       isColumnReordering,
       isColumnResizing,
@@ -782,7 +781,7 @@ var FixedDataTable = React.createClass({
     var useMaxHeight = props.height === undefined;
     var height = Math.round(useMaxHeight ? props.maxHeight : props.height);
     var totalHeightReserved = props.footerHeight + props.headerHeight +
-      groupHeaderHeight + 2 * BORDER_HEIGHT;
+      props.groupHeaderHeight + 2 * BORDER_HEIGHT;
     var bodyHeight = height - totalHeightReserved;
     var totalHeightNeeded = scrollContentHeight + totalHeightReserved;
 
@@ -898,7 +897,6 @@ var FixedDataTable = React.createClass({
       // These properties may overwrite properties defined in props
       bodyHeight,
       height,
-      groupHeaderHeight,
       useGroupHeader,
     };
   },

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -25,6 +25,8 @@ export default class FixedDataTableContainer extends React.Component {
     super(props);
 
     this.update = this.update.bind(this);
+
+    // TODO (jordan) destroy on unmount
     this.reduxStore = FixedDataTableStore.get();
     this.reduxStore.subscribe(this.update);
 

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -23,18 +23,19 @@ import * as columnActions from 'columnActions';
 export default class FixedDataTableContainer extends React.Component {
   constructor(props) {
     super(props);
-    
-    this.update = this.update.bind(this);
-    FixedDataTableStore.subscribe(this.update);
 
-    this.scrollActions = bindActionCreators(scrollActions, FixedDataTableStore.dispatch);
-    this.columnActions = bindActionCreators(columnActions, FixedDataTableStore.dispatch);
+    this.update = this.update.bind(this);
+    this.reduxStore = FixedDataTableStore.get();
+    this.reduxStore.subscribe(this.update);
+
+    this.scrollActions = bindActionCreators(scrollActions, this.reduxStore.dispatch);
+    this.columnActions = bindActionCreators(columnActions, this.reduxStore.dispatch);
   }
 
   componentWillMount() {
     const props = this.props;
 
-    FixedDataTableStore.dispatch({
+    this.reduxStore.dispatch({
       type: ActionTypes.INITIALIZE,
       props: props
     });
@@ -43,7 +44,7 @@ export default class FixedDataTableContainer extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    FixedDataTableStore.dispatch({
+    this.reduxStore.dispatch({
       type: ActionTypes.PROP_CHANGE,
       newProps: nextProps,
       oldProps: this.props,
@@ -52,9 +53,9 @@ export default class FixedDataTableContainer extends React.Component {
 
   render() {
     return (
-      <FixedDataTable 
-        {...this.props} 
-        {...this.state} 
+      <FixedDataTable
+        {...this.props}
+        {...this.state}
         scrollActions={this.scrollActions}
         columnActions={this.columnActions}
       />
@@ -62,7 +63,7 @@ export default class FixedDataTableContainer extends React.Component {
   }
 
   update() {
-    const state = FixedDataTableStore.getState();
+    const state = this.reduxStore.getState();
     const {
       firstRowIndex,
       firstRowOffset,
@@ -72,6 +73,7 @@ export default class FixedDataTableContainer extends React.Component {
       scrollY,
     } = state.scrollState;
 
+    // TODO REDUX_MIGRATION
     //const maxScrollY = Math.max(0, scrollContentHeight - this.state.bodyHeight);
 
     this.setState({

--- a/src/FixedDataTableStore.js
+++ b/src/FixedDataTableStore.js
@@ -15,5 +15,7 @@ import reducers from 'reducers'
 import { createStore } from 'redux'
 
 module.exports = {
-  get: () => createStore(reducers),
+  get: () => {
+    return createStore(reducers)
+  },
 };

--- a/src/FixedDataTableStore.js
+++ b/src/FixedDataTableStore.js
@@ -14,8 +14,6 @@
 import reducers from 'reducers'
 import { createStore } from 'redux'
 
-const store = createStore(
-  reducers
-);
-
-module.exports = store;
+module.exports = {
+  get: () => createStore(reducers),
+};

--- a/src/reducers/scrollState.js
+++ b/src/reducers/scrollState.js
@@ -62,21 +62,31 @@ function scrollState(state = DEFAULT_STATE, action) {
         state = scrollToRow(state, props.scrollToRow);
       }
 
-
       state = updateVisibleRows(state);
 
       return state;
 
     case ActionTypes.PROP_CHANGE:
       let { newProps, oldProps } = action;
+      let needsVisibleRowsUpdate = false;
+
+      // TODO (jordan) Handle changes to default row height & viewport height
+      if (newProps.rowsCount !== oldProps.rowsCount) {
+        state = updateRowCount(state, newProps);
+        needsVisibleRowsUpdate = true;
+      }
 
       if (newProps.scrollTop && newProps.scrollTop !== oldProps.scrollTop) {
         state = scrollTo(state, newProps.scrollTop);
-        state = updateVisibleRows(state);
+        needsVisibleRowsUpdate = true;
       }
 
       if (newProps.scrollToRow && newProps.scrollToRow !== oldProps.scrollToRow) {
         state = scrollToRow(state, newProps.scrollToRow);
+        needsVisibleRowsUpdate = true;
+      }
+
+      if (needsVisibleRowsUpdate) {
         state = updateVisibleRows(state);
       }
 

--- a/src/reducers/scrollState.js
+++ b/src/reducers/scrollState.js
@@ -70,9 +70,23 @@ function scrollState(state = DEFAULT_STATE, action) {
       let { newProps, oldProps } = action;
       let needsVisibleRowsUpdate = false;
 
-      // TODO (jordan) Handle changes to default row height & viewport height
       if (newProps.rowsCount !== oldProps.rowsCount) {
         state = updateRowCount(state, newProps);
+        needsVisibleRowsUpdate = true;
+      }
+
+      if (newProps.rowHeight !== oldProps.rowHeight ||
+          newProps.rowHeightGetter !== oldProps.rowHeightGetter) {
+        state = updateRowHeights(state, newProps);
+        needsVisibleRowsUpdate = true;
+      }
+
+      if (newProps.height !== oldProps.height ||
+          newProps.maxHeight !== oldProps.maxHeight ||
+          newProps.headerHeight !== oldProps.headerHeight ||
+          newProps.footerHeight !== oldProps.footerHeight ||
+          newProps.groupHeaderHeight !== oldProps.groupHeaderHeight) {
+        state = updateViewHeight(state, newProps);
         needsVisibleRowsUpdate = true;
       }
 

--- a/src/reducers/scrollStateHelper.js
+++ b/src/reducers/scrollStateHelper.js
@@ -85,18 +85,6 @@ function _updateHeightsAboveViewport(state, firstRowIndex) {
 }
 
 /**
- * @param {!Object} props
- * @return {number}
- * @private
- */
-function _calculateViewportHeight(props) {
-  return (props.height === undefined ? props.maxHeight : props.height) -
-    (props.headerHeight || 0) -
-    (props.footerHeight || 0) -
-    (props.groupHeaderHeight || 0);
-};
-
-/**
  * @param {!Object} state
  * @param {number}
  * @return {number}

--- a/src/reducers/scrollStateHelper.js
+++ b/src/reducers/scrollStateHelper.js
@@ -339,6 +339,7 @@ export function scrollToRow(state, rowIndex) {
     var position = _getRowAtEndPosition(state, rowIndex);
     return scrollTo(state, position);
   }
+  return state;
 };
 
 /**

--- a/src/reducers/scrollStateHelper.js
+++ b/src/reducers/scrollStateHelper.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+import IntegerBufferSet from 'IntegerBufferSet';
 import PrefixIntervalTree from 'PrefixIntervalTree';
 import clamp from 'clamp';
 
@@ -258,6 +259,9 @@ export function updateRowCount(state, { rowsCount }) {
     state.storedHeights[i] = state.rowHeight;
   }
 
+  state.rows = [];
+  state.bufferSet = new IntegerBufferSet();
+
   return state;
 }
 
@@ -301,9 +305,6 @@ export function scrollTo(state, scrollPosition) {
       firstRowIndex: 0,
       firstRowOffset: 0,
       scrollY: scrollY,
-      // TODO (jordan) This overrides the scrollContentHeight changes made by _updateRowHeight
-      // Try removing
-      scrollContentHeight: scrollContentHeight,
     });
   } else if (scrollPosition >= scrollContentHeight - viewportHeight) {
     // If scrollPosition is equal to or greater than max scroll value, we need
@@ -324,9 +325,6 @@ export function scrollTo(state, scrollPosition) {
     firstRowIndex,
     firstRowOffset,
     scrollY: scrollPosition,
-    // TODO (jordan) This overrides the scrollContentHeight changes made by _updateRowHeight
-    // Try removing
-    scrollContentHeight,
   });
 };
 
@@ -353,8 +351,6 @@ export function scrollToRow(state, rowIndex) {
     var position = _getRowAtEndPosition(state, rowIndex);
     return scrollTo(state, position);
   }
-  // TODO (jordan) Should this be a no-op?
-  return scrollTo(state, scrollY);
 };
 
 /**

--- a/src/reducers/scrollStateHelper.js
+++ b/src/reducers/scrollStateHelper.js
@@ -56,6 +56,8 @@ function _updateRowHeight(state, rowIndex) {
  */
 function _updateHeightsInViewport(state, firstRowIndex, firstRowOffset) {
   let { rowsCount, storedHeights, viewportHeight } = state;
+
+  // NOTE (jordan) firstRowOffset is a negative value representing how much of the first row is off screen
   var top = firstRowOffset;
   var index = firstRowIndex;
   while (top <= viewportHeight && index < rowsCount) {
@@ -104,6 +106,8 @@ function _getRowAtEndPosition(state, rowIndex) {
   // We need to update enough rows above the selected one to be sure that when
   // we scroll to selected position all rows between first shown and selected
   // one have most recent heights computed and will not resize
+  // NOTE (jordan) We don't need to update leading buffered rows here because
+  // _updateHeightsAboveViewport updates scrollY accordingly
   _updateRowHeight(state, rowIndex);
   var currentRowIndex = rowIndex;
   var top = storedHeights[currentRowIndex];
@@ -165,12 +169,10 @@ function _updateRows(state) {
     rowsCount,
     viewportHeight,
     rowHeightGetter,
-    bufferRowsCount,
-    viewportRowsBegin
+    bufferRowsCount
   } = state;
 
-  let top = firstRowOffset;
-  let totalHeight = top;
+  let totalHeight = firstRowOffset;
   //let rowIndex = firstRowIndex;
   let rowIndex = Math.max(firstRowIndex - bufferRowsCount, 0);
   let endIndex = Math.min(firstRowIndex + maxVisibleRowCount + bufferRowsCount, rowsCount);
@@ -299,6 +301,8 @@ export function scrollTo(state, scrollPosition) {
       firstRowIndex: 0,
       firstRowOffset: 0,
       scrollY: scrollY,
+      // TODO (jordan) This overrides the scrollContentHeight changes made by _updateRowHeight
+      // Try removing
       scrollContentHeight: scrollContentHeight,
     });
   } else if (scrollPosition >= scrollContentHeight - viewportHeight) {
@@ -320,6 +324,8 @@ export function scrollTo(state, scrollPosition) {
     firstRowIndex,
     firstRowOffset,
     scrollY: scrollPosition,
+    // TODO (jordan) This overrides the scrollContentHeight changes made by _updateRowHeight
+    // Try removing
     scrollContentHeight,
   });
 };
@@ -347,6 +353,7 @@ export function scrollToRow(state, rowIndex) {
     var position = _getRowAtEndPosition(state, rowIndex);
     return scrollTo(state, position);
   }
+  // TODO (jordan) Should this be a no-op?
   return scrollTo(state, scrollY);
 };
 


### PR DESCRIPTION
Switch the redux store to be per FDT instance rather than a singleton.

## Motivation and Context
LiveDesign requires multiple FDT instances.  Let's make the redux store per component rather than a singleton to support this.

## How Has This Been Tested?
Tested in LiveDesign.  Things still blow up when switching Live Reports with different row counts

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
