### PR TITLE
update row heights before calculating state

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -896,11 +896,6 @@ var FixedDataTable = createReactClass({
   },
 
   _calculateState(/*object*/ props, /*?object*/ oldState) /*object*/ {
-    // update row heights
-    [...Array(props.rowsCount).keys()].forEach((index) => {
-      this._scrollHelper._updateRowHeight(index);
-    });
-
     invariant(
       props.height !== undefined || props.maxHeight !== undefined,
       'You must set either a height or a maxHeight'
@@ -978,6 +973,11 @@ var FixedDataTable = createReactClass({
       firstRowOffset = scrollState.offset;
       scrollY = scrollState.position;
     }
+
+    // update row heights
+    [...Array(props.rowsCount).keys()].forEach((index) => {
+      this._scrollHelper._updateRowHeight(index);
+    });
 
     var columnResizingData;
     if (props.isColumnResizing) {

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -896,6 +896,11 @@ var FixedDataTable = createReactClass({
   },
 
   _calculateState(/*object*/ props, /*?object*/ oldState) /*object*/ {
+    // update row heights
+    [...Array(props.rowsCount).keys()].forEach((index) => {
+      this._scrollHelper._updateRowHeight(index);
+    });
+
     invariant(
       props.height !== undefined || props.maxHeight !== undefined,
       'You must set either a height or a maxHeight'


### PR DESCRIPTION
This pull request fixes some bugs which occur while using dynamic row heights.

## Description
I updated the scrollHelper's row heights before calculating the table state as I noticed that sometimes the value of table's `scrollContentHeight` was incorrect which led to the scrollbar not updating correctly when the height of row changes.

## Motivation and Context
Fixes #69 , #9.

## How Has This Been Tested?
I used the slightly modified version of the existing 'collapsable rows' example to test this. I changed the number of rows to 10 and the dynamic height from 100 to 373. The scrollbar adjusts correctly upon expanding a row.
I also ran the existing test cases and all of them pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
