### PR TITLE
Don't display extra padding when there is no vertical scrollbar present

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -957,8 +957,13 @@ var FixedDataTable = createReactClass({
       children.push(child);
     });
 
+    var tableWidth = props.width;
+    var scrollContentHeight = this._scrollHelper.getContentHeight();
+
     // Allow room for the scrollbar, less 1px for the last column's border
-    var adjustedWidth = props.width - Scrollbar.SIZE - Scrollbar.OFFSET;
+    if (props.showScrollbarY && props.height < scrollContentHeight) {
+     tableWidth = tableWidth - Scrollbar.SIZE - Scrollbar.OFFSET;
+    }
 
     var useGroupHeader = false;
     if (children.length && children[0].type.__TableColumnGroup__) {
@@ -1040,14 +1045,14 @@ var FixedDataTable = createReactClass({
       var columnGroupSettings =
         FixedDataTableWidthHelper.adjustColumnGroupWidths(
           children,
-          adjustedWidth
+          tableWidth
       );
       columns = columnGroupSettings.columns;
       columnGroups = columnGroupSettings.columnGroups;
     } else {
       columns = FixedDataTableWidthHelper.adjustColumnWidths(
         children,
-        adjustedWidth
+        tableWidth
       );
     }
 
@@ -1084,7 +1089,7 @@ var FixedDataTable = createReactClass({
         }
 
         // Get width of scrollable columns in viewport
-        var availableScrollWidth = adjustedWidth - totalFixedColumnsWidth;
+        var availableScrollWidth = tableWidth - totalFixedColumnsWidth;
 
         // Get width of specified column
         var selectedColumnWidth = columnInfo.bodyScrollableColumns[
@@ -1120,7 +1125,7 @@ var FixedDataTable = createReactClass({
     var scrollContentWidth =
       FixedDataTableWidthHelper.getTotalWidth(columns);
 
-    var horizontalScrollbarVisible = scrollContentWidth > adjustedWidth &&
+    var horizontalScrollbarVisible = scrollContentWidth > tableWidth &&
       props.overflowX !== 'hidden' && props.showScrollbarX !== false;
 
     if (horizontalScrollbarVisible) {
@@ -1129,7 +1134,7 @@ var FixedDataTable = createReactClass({
       totalHeightReserved += Scrollbar.SIZE;
     }
 
-    var maxScrollX = Math.max(0, scrollContentWidth - adjustedWidth);
+    var maxScrollX = Math.max(0, scrollContentWidth - tableWidth);
     var maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
     scrollX = Math.min(scrollX, maxScrollX);
     scrollY = Math.min(scrollY, maxScrollY);

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -958,10 +958,11 @@ var FixedDataTable = createReactClass({
     });
 
     var tableWidth = props.width;
+    var reservedHeight = props.headerHeight + props.groupHeaderHeight + props.footerHeight;
     var scrollContentHeight = this._scrollHelper.getContentHeight();
 
     // Allow room for the scrollbar, less 1px for the last column's border
-    if (props.showScrollbarY && props.height < scrollContentHeight) {
+    if (props.showScrollbarY && props.height < scrollContentHeight + reservedHeight) {
      tableWidth = tableWidth - Scrollbar.SIZE - Scrollbar.OFFSET;
     }
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1040,7 +1040,7 @@ var FixedDataTable = createReactClass({
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;
-    if (props.scrollToRow !== null && (props.scrollToRow !== lastScrollToRow || viewportHeight !== oldViewportHeight)) {
+    if (props.scrollToRow != null && (props.scrollToRow !== lastScrollToRow || viewportHeight !== oldViewportHeight)) {
       scrollState = this._scrollHelper.scrollRowIntoView(props.scrollToRow);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -977,13 +977,13 @@ var FixedDataTable = createReactClass({
     var scrollX = oldState ? oldState.scrollX : 0;
 
     var lastScrollLeft = oldState ? oldState.scrollLeft : 0;
+
     if (props.scrollLeft !== undefined && props.scrollLeft !== lastScrollLeft) {
       scrollX = props.scrollLeft;
     }
 
     if (oldState && (props.rowsCount !== oldState.rowsCount || props.rowHeight !== oldState.rowHeight || props.height !== oldState.height)) {
-      // Number of rows changed, try to scroll to the row from before the
-      // change
+      // Number of rows changed, try to scroll to the row from before the change
       var viewportHeight =
         (props.height === undefined ? props.maxHeight : props.height) -
         (props.headerHeight || 0) -
@@ -1014,7 +1014,7 @@ var FixedDataTable = createReactClass({
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;
-    if (props.scrollToRow != null && (props.scrollToRow !== lastScrollToRow || viewportHeight !== oldViewportHeight)) {
+    if (props.scrollToRow !== null && (props.scrollToRow !== lastScrollToRow || viewportHeight !== oldViewportHeight)) {
       scrollState = this._scrollHelper.scrollRowIntoView(props.scrollToRow);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -957,18 +957,17 @@ var FixedDataTable = createReactClass({
       children.push(child);
     });
 
+    var useGroupHeader = children.length > 0 && children[0].type.__TableColumnGroup__ === true;
+    var groupHeaderHeight = useGroupHeader ? props.groupHeaderHeight : 0;
+
     var tableWidth = props.width;
-    var reservedHeight = props.headerHeight + props.groupHeaderHeight + props.footerHeight;
+    var totalHeightReserved = props.footerHeight + props.headerHeight +
+      groupHeaderHeight + 2 * BORDER_HEIGHT;
     var scrollContentHeight = this._scrollHelper.getContentHeight();
 
     // Allow room for the scrollbar, less 1px for the last column's border
-    if (props.showScrollbarY && props.height < scrollContentHeight + reservedHeight) {
+    if (props.showScrollbarY && props.height < scrollContentHeight + totalHeightReserved) {
      tableWidth = tableWidth - Scrollbar.SIZE - Scrollbar.OFFSET;
-    }
-
-    var useGroupHeader = false;
-    if (children.length && children[0].type.__TableColumnGroup__) {
-      useGroupHeader = true;
     }
 
     var scrollState;
@@ -981,8 +980,6 @@ var FixedDataTable = createReactClass({
     if (props.scrollLeft !== undefined && props.scrollLeft !== lastScrollLeft) {
       scrollX = props.scrollLeft;
     }
-
-    var groupHeaderHeight = useGroupHeader ? props.groupHeaderHeight : 0;
 
     if (oldState && (props.rowsCount !== oldState.rowsCount || props.rowHeight !== oldState.rowHeight || props.height !== oldState.height)) {
       // Number of rows changed, try to scroll to the row from before the
@@ -1118,8 +1115,6 @@ var FixedDataTable = createReactClass({
 
     var useMaxHeight = props.height === undefined;
     var height = Math.round(useMaxHeight ? props.maxHeight : props.height);
-    var totalHeightReserved = props.footerHeight + props.headerHeight +
-      groupHeaderHeight + 2 * BORDER_HEIGHT;
     var bodyHeight = height - totalHeightReserved;
     var scrollContentHeight = this._scrollHelper.getContentHeight();
     var totalHeightNeeded = scrollContentHeight + totalHeightReserved;


### PR DESCRIPTION
## Description

Don't run the vertical scrollbar offset calculations when no scrollbar will be present, as determined by either showScrollBarY === false or scrollContentHeight < table height.

## Motivation and Context

Fixes #203 

## How Has This Been Tested?

Manually tested:
* passing in showScrollBarY={false}
* with few enough rows that they would not exceed table height

## Screenshots (if appropriate):
Vertical Scrollbar Present
![selection_001](https://user-images.githubusercontent.com/294747/29412084-82c05cf8-8314-11e7-8782-894c444ad739.png)

Vertical Scrollbar Not Present:
![selection_002](https://user-images.githubusercontent.com/294747/29412086-85afb8d2-8314-11e7-9e88-c17ecfdd4155.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
