### PR TITLE
React not picking up changes in "collapsedRows".

### DIFF
--- a/examples/ExpandedExample.js
+++ b/examples/ExpandedExample.js
@@ -25,19 +25,19 @@ class ExpandedExample extends React.Component {
   }
 
   _handleCollapseClick(rowIndex) {
-    let {collapsedRows} = this.state;
-
+    const {collapsedRows} = this.state;
+    const shallowCopyOfCollapsedRows = new Set([...collapsedRows]);
     let scrollToRow = rowIndex;
-    if (collapsedRows.has(rowIndex)) {
-      collapsedRows.delete(rowIndex);
+    if (shallowCopyOfCollapsedRows.has(rowIndex)) {
+      shallowCopyOfCollapsedRows.delete(rowIndex);
       scrollToRow = null
     } else {
-      collapsedRows.add(rowIndex);
+      shallowCopyOfCollapsedRows.add(rowIndex);
     }
 
     this.setState({
       scrollToRow: scrollToRow,
-      collapsedRows: new Set([...collapsedRows])
+      collapsedRows: shallowCopyOfCollapsedRows
     });
   }
 

--- a/examples/ExpandedExample.js
+++ b/examples/ExpandedExample.js
@@ -37,7 +37,7 @@ class ExpandedExample extends React.Component {
 
     this.setState({
       scrollToRow: scrollToRow,
-      collapsedRows: collapsedRows
+      collapsedRows: new Set([...collapsedRows])
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The CollapseCell render was not being re-rendered unless recycled. E.G. ►  was not changing to ▼ in example "Expanded rows"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed an example to work how I assumed the developer designed it.
"Treat this.state as if it were immutable." from https://facebook.github.io/react/docs/react-component.html (bottom of page).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with my own example.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) in example code
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
