### PR TITLE
On row mouse up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "6"
   - "5"
   - "4"
-before_script:
-  - npm install react react-dom
+install:
+  - yarn install

--- a/examples/LongClickExample.js
+++ b/examples/LongClickExample.js
@@ -10,9 +10,10 @@ const { Table, Column, Cell } = require('fixed-data-table-2');
 const React = require('react');
 
 class LongClickExample extends React.Component {
-  
-  columns = [];
 
+  columns = [];
+  longClickTimer = null;
+  
   constructor(props) {
     super(props);
 

--- a/examples/LongClickExample.js
+++ b/examples/LongClickExample.js
@@ -11,45 +11,24 @@ const React = require('react');
 
 class LongClickExample extends React.Component {
 
-  columns = [];
   longClickTimer = null;
+  
+  displayColumns = {
+    firstName: 'First Name',
+    lastName: 'Last Name',
+    city: 'City',
+    street: 'zipCode',
+  };
   
   constructor(props) {
     super(props);
 
     var dataList = new FakeObjectDataListStore(1000000);
-    var displayColumns = {
-      firstName: 'First Name',
-      lastName: 'Last Name',
-      city: 'City',
-      street: 'zipCode'
-    };
-
-    Object.keys(displayColumns).forEach(columnKey => {
-      this.columns.push(
-        <Column
-          key={columnKey}
-          columnKey={columnKey}
-          flexGrow={2}
-          header={<Cell>{this.columns[columnKey]}</Cell>}
-          cell={({ rowIndex, columnKey }) => {
-            let isRowHighlighted = this.state.longPressedRowIndex === rowIndex;
-            return <TextCell style={{
-              backgroundColor: isRowHighlighted ? 'yellow' : 'transparent',
-              width: '100%',
-              height: '100%'
-            }}
-              data={dataList}
-              rowIndex={rowIndex}
-              columnKey={columnKey} />;
-          }
-          }
-          width={100}
-        />);
-    });
 
     this.state = {
-      dataList
+      dataList,
+      columns: this.getColumns(),
+      longPressedRowIndex: -1,
     };
   }
 
@@ -73,6 +52,39 @@ class LongClickExample extends React.Component {
     }
   }
 
+  getColumns() {
+    let columns = [];
+
+    Object.keys(this.displayColumns).forEach(columnKey => {
+      columns.push(
+        <Column
+          key={columnKey}
+          columnKey={columnKey}
+          flexGrow={2}
+          header={<Cell>{columns[columnKey]}</Cell>}
+          cell={cell => this.getCell(cell.rowIndex, cell.columnKey)}
+          width={100}
+        />);
+    });
+
+    return columns;
+  }
+
+  getCell(rowIndex, columnKey) {
+    let isCellHighlighted = this.state.longPressedRowIndex === rowIndex;
+      
+    let rowStyle = {
+      backgroundColor: isCellHighlighted ? 'yellow' : 'transparent',
+      width: '100%',
+      height: '100%'
+    } 
+
+    return <TextCell style={rowStyle}
+      data={this.state.dataList}
+      rowIndex={rowIndex}
+      columnKey={columnKey} />;
+  }
+
   render() {
     return (
       <Table
@@ -84,7 +96,7 @@ class LongClickExample extends React.Component {
         onRowMouseDown={(event, rowIndex) => { this.handleRowMouseDown(rowIndex); }}
         onRowMouseUp={(event, rowIndex) => { this.handleRowMouseUp(rowIndex); }}
         {...this.props}>
-        {this.columns}
+        {this.state.columns}
       </Table>
     );
   }

--- a/examples/LongClickExample.js
+++ b/examples/LongClickExample.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+'use strict';
+
+const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
+const { TextCell } = require('./helpers/cells');
+const { Table, Column, Cell } = require('fixed-data-table-2');
+const React = require('react');
+
+class LongClickExample extends React.Component {
+  
+  columns = [];
+
+  constructor(props) {
+    super(props);
+
+    var dataList = new FakeObjectDataListStore(1000000);
+    var displayColumns = {
+      firstName: 'First Name',
+      lastName: 'Last Name',
+      city: 'City',
+      street: 'zipCode'
+    };
+
+    Object.keys(displayColumns).forEach(columnKey => {
+      this.columns.push(
+        <Column
+          key={columnKey}
+          columnKey={columnKey}
+          flexGrow={2}
+          header={<Cell>{this.columns[columnKey]}</Cell>}
+          cell={({ rowIndex, columnKey }) => {
+            let isRowHighlighted = this.state.longPressedRowIndex === rowIndex;
+            return <TextCell style={{
+              backgroundColor: isRowHighlighted ? 'yellow' : 'transparent',
+              width: '100%',
+              height: '100%'
+            }}
+              data={dataList}
+              rowIndex={rowIndex}
+              columnKey={columnKey} />;
+          }
+          }
+          width={100}
+        />);
+    });
+
+    this.state = {
+      dataList
+    };
+  }
+
+  handleRowMouseDown(rowIndex) {
+    this.cancelLongClick();
+    this.longClickTimer = setTimeout(() => {
+      this.setState({
+        longPressedRowIndex: rowIndex
+      });
+    }, 1000);
+  }
+
+  handleRowMouseUp() {
+    this.cancelLongClick();
+  }
+
+  cancelLongClick() {
+    if (this.longClickTimer) {
+      clearTimeout(this.longClickTimer);
+      this.longClickTimer = null;
+    }
+  }
+
+  render() {
+    return (
+      <Table
+        rowHeight={50}
+        headerHeight={50}
+        rowsCount={this.state.dataList.getSize()}
+        width={1000}
+        height={500}
+        onRowMouseDown={(event, rowIndex) => { this.handleRowMouseDown(rowIndex); }}
+        onRowMouseUp={(event, rowIndex) => { this.handleRowMouseUp(rowIndex); }}
+        {...this.props}>
+        {this.columns}
+      </Table>
+    );
+  }
+}
+
+module.exports = LongClickExample;

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -126,6 +126,12 @@ exports.ExamplePages = {
     title: 'Tooltips',
     description: 'A table example that displays additional information in a tooltip.'
   },
+  LONG_CLICK_EXAMPLE: {
+    location: 'example-long-click.html',
+    fileName: 'LongClickExample.js',
+    title: 'Row Long Click',
+    description: 'A table example that highlights a row after a long click',
+  },
   CONTEXT_EXAMPLE: {
     location: 'example-context.html',
     fileName: 'ContextExample.js',

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -43,6 +43,7 @@ var EXAMPLE_COMPONENTS = {
   [ExamplePages.RESPONSIVE_EXAMPLE.location]: require('../../examples/ResponsiveExample'),
   [ExamplePages.STYLING_EXAMPLE.location]: require('../../examples/StylingExample'),
   [ExamplePages.TOOLTIP_EXAMPLE.location]: require('../../examples/TooltipExample'),
+  [ExamplePages.LONG_CLICK_EXAMPLE.location]: require('../../examples/LongClickExample'),
   [ExamplePages.CONTEXT_EXAMPLE.location]: require('../../examples/ContextExample'),
 };
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -307,6 +307,11 @@ var FixedDataTable = createReactClass({
     onRowMouseDown: PropTypes.func,
 
     /**
+     * Callback that is called when a mouse-up event happens on a row.
+     */
+    onRowMouseUp: PropTypes.func,
+
+    /**
      * Callback that is called when a mouse-enter event happens on a row.
      */
     onRowMouseEnter: PropTypes.func,
@@ -724,6 +729,7 @@ var FixedDataTable = createReactClass({
         onRowClick={state.onRowClick}
         onRowDoubleClick={state.onRowDoubleClick}
         onRowMouseDown={state.onRowMouseDown}
+        onRowMouseUp={state.onRowMouseUp}
         onRowMouseEnter={state.onRowMouseEnter}
         onRowMouseLeave={state.onRowMouseLeave}
         rowClassNameGetter={state.rowClassNameGetter}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -35,6 +35,7 @@ var FixedDataTableBufferedRows = createReactClass({
     onRowClick: PropTypes.func,
     onRowDoubleClick: PropTypes.func,
     onRowMouseDown: PropTypes.func,
+    onRowMouseUp: PropTypes.func,
     onRowMouseEnter: PropTypes.func,
     onRowMouseLeave: PropTypes.func,
     rowClassNameGetter: PropTypes.func,
@@ -170,6 +171,7 @@ var FixedDataTableBufferedRows = createReactClass({
           onClick={props.onRowClick}
           onDoubleClick={props.onRowDoubleClick}
           onMouseDown={props.onRowMouseDown}
+          onMouseUp={props.onRowMouseUp}
           onMouseEnter={props.onRowMouseEnter}
           onMouseLeave={props.onRowMouseLeave}
           className={joinClasses(

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -188,6 +188,7 @@ class FixedDataTableRowImpl extends React.Component {
         onClick={this.props.onClick ? this._onClick : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}
         onMouseDown={this.props.onMouseDown ? this._onMouseDown : null}
+        onMouseUp={this.props.onMouseUp ? this._onMouseUp : null}
         onMouseEnter={this.props.onMouseEnter ? this._onMouseEnter : null}
         onMouseLeave={this.props.onMouseLeave ? this._onMouseLeave : null}
         style={style}>
@@ -268,6 +269,10 @@ class FixedDataTableRowImpl extends React.Component {
 
   _onDoubleClick = (/*object*/ event) => {
     this.props.onDoubleClick(event, this.props.index);
+  };
+
+  _onMouseUp = (/*object*/ event) => {
+    this.props.onMouseUp(event, this.props.index);
   };
 
   _onMouseDown = (/*object*/ event) => {


### PR DESCRIPTION
Add onMouseUp in the returned div of FixedDataTableRowImpl and bind props similarly to onMouseDown.

## Description
* Add onMouseUp in returned div in FixedDataTableRow.js to detect the mouseup event on the row.
* Expose onRowMouseUp as a prop inside FixedDataTable.js.
* Make sure that onRowMouseUp is assigned to onMouseUp inside FixedDataTableBufferedRows.js.
* Added LongClickExample.js in the example folder to showcase one way of using the onRowMouseUp callback.
* Modified the site to include aforementioned example by changing ExamplesPage.js and Constants.js.

## Motivation and Context
It provides the ability to detect mouseup events on row. Something that someone might want to do given that the ability to detect mousedown is already there.

## How Has This Been Tested?
Tested mainly on IE11 and the latest chrome version on windows 10.
I tested it by running the application that is using fixed-data-table-2 and relies on the onRowMouseUp event to be called. I also tested the example provided as part of this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (Not sure how to do this)
- [x] I have read the **CONTRIBUTING** document.
