### PR TITLE
Adding onRowTouchStart, onRowTouchEnd and onRowTouchMove callbacks on Table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "6"
   - "5"
   - "4"
-before_script:
-  - npm install react react-dom
+install:
+  - yarn install

--- a/examples/LongClickExample.js
+++ b/examples/LongClickExample.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+'use strict';
+
+const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
+const { TextCell } = require('./helpers/cells');
+const { Table, Column, Cell } = require('fixed-data-table-2');
+const React = require('react');
+
+class LongClickExample extends React.Component {
+
+  longClickTimer = null;
+  
+  displayColumns = {
+    firstName: 'First Name',
+    lastName: 'Last Name',
+    city: 'City',
+    street: 'zipCode',
+  };
+  
+  constructor(props) {
+    super(props);
+
+    var dataList = new FakeObjectDataListStore(1000000);
+
+    this.state = {
+      dataList,
+      columns: this.getColumns(),
+      longPressedRowIndex: -1,
+    };
+  }
+
+  handleRowMouseDown(rowIndex) {
+    this.cancelLongClick();
+    this.longClickTimer = setTimeout(() => {
+      this.setState({
+        longPressedRowIndex: rowIndex
+      });
+    }, 1000);
+  }
+
+  handleRowMouseUp() {
+    this.cancelLongClick();
+  }
+
+  cancelLongClick() {
+    if (this.longClickTimer) {
+      clearTimeout(this.longClickTimer);
+      this.longClickTimer = null;
+    }
+  }
+
+  getColumns() {
+    let columns = [];
+
+    Object.keys(this.displayColumns).forEach(columnKey => {
+      columns.push(
+        <Column
+          key={columnKey}
+          columnKey={columnKey}
+          flexGrow={2}
+          header={<Cell>{columns[columnKey]}</Cell>}
+          cell={cell => this.getCell(cell.rowIndex, cell.columnKey)}
+          width={100}
+        />);
+    });
+
+    return columns;
+  }
+
+  getCell(rowIndex, columnKey) {
+    let isCellHighlighted = this.state.longPressedRowIndex === rowIndex;
+      
+    let rowStyle = {
+      backgroundColor: isCellHighlighted ? 'yellow' : 'transparent',
+      width: '100%',
+      height: '100%'
+    } 
+
+    return <TextCell style={rowStyle}
+      data={this.state.dataList}
+      rowIndex={rowIndex}
+      columnKey={columnKey} />;
+  }
+
+  render() {
+    return (
+      <Table
+        rowHeight={50}
+        headerHeight={50}
+        rowsCount={this.state.dataList.getSize()}
+        width={1000}
+        height={500}
+        onRowMouseDown={(event, rowIndex) => { this.handleRowMouseDown(rowIndex); }}
+        onRowMouseUp={(event, rowIndex) => { this.handleRowMouseUp(rowIndex); }}
+        {...this.props}>
+        {this.state.columns}
+      </Table>
+    );
+  }
+}
+
+module.exports = LongClickExample;

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -126,6 +126,12 @@ exports.ExamplePages = {
     title: 'Tooltips',
     description: 'A table example that displays additional information in a tooltip.'
   },
+  LONG_CLICK_EXAMPLE: {
+    location: 'example-long-click.html',
+    fileName: 'LongClickExample.js',
+    title: 'Row Long Click',
+    description: 'A table example that highlights a row after a long click',
+  },
   CONTEXT_EXAMPLE: {
     location: 'example-context.html',
     fileName: 'ContextExample.js',

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -43,6 +43,7 @@ var EXAMPLE_COMPONENTS = {
   [ExamplePages.RESPONSIVE_EXAMPLE.location]: require('../../examples/ResponsiveExample'),
   [ExamplePages.STYLING_EXAMPLE.location]: require('../../examples/StylingExample'),
   [ExamplePages.TOOLTIP_EXAMPLE.location]: require('../../examples/TooltipExample'),
+  [ExamplePages.LONG_CLICK_EXAMPLE.location]: require('../../examples/LongClickExample'),
   [ExamplePages.CONTEXT_EXAMPLE.location]: require('../../examples/ContextExample'),
 };
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -307,6 +307,11 @@ var FixedDataTable = createReactClass({
     onRowMouseDown: PropTypes.func,
 
     /**
+     * Callback that is called when a mouse-up event happens on a row.
+     */
+    onRowMouseUp: PropTypes.func,
+
+    /**
      * Callback that is called when a mouse-enter event happens on a row.
      */
     onRowMouseEnter: PropTypes.func,
@@ -739,6 +744,7 @@ var FixedDataTable = createReactClass({
         onRowClick={state.onRowClick}
         onRowDoubleClick={state.onRowDoubleClick}
         onRowMouseDown={state.onRowMouseDown}
+        onRowMouseUp={state.onRowMouseUp}
         onRowMouseEnter={state.onRowMouseEnter}
         onRowMouseLeave={state.onRowMouseLeave}
         onRowTouchStart={state.touchScrollEnabled ? state.onRowTouchStart : null}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -317,6 +317,21 @@ var FixedDataTable = createReactClass({
     onRowMouseLeave: PropTypes.func,
 
     /**
+     * Callback that is called when a touch-start event happens on a row.
+     */
+    onRowTouchStart: PropTypes.func,
+
+    /**
+     * Callback that is called when a touch-end event happens on a row.
+     */
+    onRowTouchEnd: PropTypes.func,
+
+    /**
+     * Callback that is called when a touch-move event happens on a row.
+     */
+    onRowTouchMove: PropTypes.func,
+
+    /**
      * Callback that is called when resizer has been released
      * and column needs to be updated.
      *
@@ -726,6 +741,9 @@ var FixedDataTable = createReactClass({
         onRowMouseDown={state.onRowMouseDown}
         onRowMouseEnter={state.onRowMouseEnter}
         onRowMouseLeave={state.onRowMouseLeave}
+        onRowTouchStart={state.touchScrollEnabled ? state.onRowTouchStart : null}
+        onRowTouchEnd={state.touchScrollEnabled ? state.onRowTouchEnd : null}
+        onRowTouchMove={state.touchScrollEnabled ? state.onRowTouchMove : null}
         rowClassNameGetter={state.rowClassNameGetter}
         rowsCount={state.rowsCount}
         rowGetter={state.rowGetter}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -35,6 +35,7 @@ var FixedDataTableBufferedRows = createReactClass({
     onRowClick: PropTypes.func,
     onRowDoubleClick: PropTypes.func,
     onRowMouseDown: PropTypes.func,
+    onRowMouseUp: PropTypes.func,
     onRowMouseEnter: PropTypes.func,
     onRowMouseLeave: PropTypes.func,
     onRowTouchStart: PropTypes.func,
@@ -173,6 +174,7 @@ var FixedDataTableBufferedRows = createReactClass({
           onClick={props.onRowClick}
           onDoubleClick={props.onRowDoubleClick}
           onMouseDown={props.onRowMouseDown}
+          onMouseUp={props.onRowMouseUp}
           onMouseEnter={props.onRowMouseEnter}
           onMouseLeave={props.onRowMouseLeave}
           onTouchStart={props.onRowTouchStart}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -37,6 +37,9 @@ var FixedDataTableBufferedRows = createReactClass({
     onRowMouseDown: PropTypes.func,
     onRowMouseEnter: PropTypes.func,
     onRowMouseLeave: PropTypes.func,
+    onRowTouchStart: PropTypes.func,
+    onRowTouchEnd: PropTypes.func,
+    onRowTouchMove: PropTypes.func,
     rowClassNameGetter: PropTypes.func,
     rowsCount: PropTypes.number.isRequired,
     rowHeightGetter: PropTypes.func,
@@ -172,6 +175,9 @@ var FixedDataTableBufferedRows = createReactClass({
           onMouseDown={props.onRowMouseDown}
           onMouseEnter={props.onRowMouseEnter}
           onMouseLeave={props.onRowMouseLeave}
+          onTouchStart={props.onRowTouchStart}
+          onTouchEnd={props.onRowTouchEnd}
+          onTouchMove={props.onRowTouchMove}
           className={joinClasses(
             rowClassNameGetter(rowIndex),
             cx('public/fixedDataTable/bodyRow'),

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -188,6 +188,7 @@ class FixedDataTableRowImpl extends React.Component {
         onClick={this.props.onClick ? this._onClick : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}
         onMouseDown={this.props.onMouseDown ? this._onMouseDown : null}
+        onMouseUp={this.props.onMouseUp ? this._onMouseUp : null}
         onMouseEnter={this.props.onMouseEnter ? this._onMouseEnter : null}
         onMouseLeave={this.props.onMouseLeave ? this._onMouseLeave : null}
         onTouchStart={this.props.onTouchStart ? this._onTouchStart : null}
@@ -271,6 +272,10 @@ class FixedDataTableRowImpl extends React.Component {
 
   _onDoubleClick = (/*object*/ event) => {
     this.props.onDoubleClick(event, this.props.index);
+  };
+
+  _onMouseUp = (/*object*/ event) => {
+    this.props.onMouseUp(event, this.props.index);
   };
 
   _onMouseDown = (/*object*/ event) => {

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -190,6 +190,9 @@ class FixedDataTableRowImpl extends React.Component {
         onMouseDown={this.props.onMouseDown ? this._onMouseDown : null}
         onMouseEnter={this.props.onMouseEnter ? this._onMouseEnter : null}
         onMouseLeave={this.props.onMouseLeave ? this._onMouseLeave : null}
+        onTouchStart={this.props.onTouchStart ? this._onTouchStart : null}
+        onTouchEnd={this.props.onTouchEnd ? this._onTouchEnd : null}
+        onTouchMove={this.props.onTouchMove ? this._onTouchMove : null}
         style={style}>
         <div className={cx('fixedDataTableRowLayout/body')}>
           {fixedColumns}
@@ -280,6 +283,18 @@ class FixedDataTableRowImpl extends React.Component {
 
   _onMouseLeave = (/*object*/ event) => {
     this.props.onMouseLeave(event, this.props.index);
+  };
+
+  _onTouchStart = (/*object*/ event) => {
+    this.props.onTouchStart(event, this.props.index);
+  };
+
+  _onTouchEnd = (/*object*/ event) => {
+    this.props.onTouchEnd(event, this.props.index);
+  };
+
+  _onTouchMove = (/*object*/ event) => {
+    this.props.onTouchMove(event, this.props.index);
   };
 }
 


### PR DESCRIPTION
Add onRowTouchStart, onRowTouchEnd and onRowTouchMove to table.

## Description
Changes are similar to PR #234 with the only difference that the touch listeners are bound only when touchScrollEnabled is set to true as suggested in issue #236.

## Motivation and Context
It provides the ability to detect touchstart, touchend and touchmove events on rows. This allows developers to implement similar behaviors between touch and non-touch devices given the similarities between mouse down and up and touch start and end.

## How Has This Been Tested?
Tested in Chrome using dev tools device simulators and on iPad running iOS 10+.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
