### PR TITLE
Add new optional prop cellGroupWrapperHeight

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -245,6 +245,20 @@ var FixedDataTable = createReactClass({
     /**
      * Pixel height of fixedDataTableCellGroupLayout/cellGroupWrapper.
      * Default is headerHeight and groupHeaderHeight.
+     *
+     * This can be used with CSS to make a header cell span both the group & normal header row.
+     * Setting this to a value larger than height will cause the content to
+     * overflow the height. This is useful when adding a 2nd table as the group
+     * header and vertically merging the 2 headers when a column is not part
+     * of a group. Here are the necessary CSS changes:
+     *
+     * Both headers:
+     *  - cellGroupWrapper needs overflow-x: hidden and pointer-events: none
+     *  - cellGroup needs pointer-events: auto to reenable them on child els
+     * Group header:
+     *  - Layout/main needs overflow: visible and a higher z-index
+     *  - CellLayout/main needs overflow-y: visible
+     *  - cellGroup needs overflow: visible
      */
     cellGroupWrapperHeight: PropTypes.number,
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -245,10 +245,6 @@ var FixedDataTable = createReactClass({
     /**
      * Pixel height of fixedDataTableCellGroupLayout/cellGroupWrapper.
      * Default is headerHeight and groupHeaderHeight.
-     * By being able to target this class specifically, we can do things
-     * like make some cells of a header smaller/bigger than those with
-     * the actual header height, with just a bit of additional css
-     * (override the overflow property of some other classes).
      */
     cellGroupWrapperHeight: PropTypes.number,
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -243,6 +243,16 @@ var FixedDataTable = createReactClass({
     headerHeight: PropTypes.number.isRequired,
 
     /**
+     * Pixel height of fixedDataTableCellGroupLayout/cellGroupWrapper.
+     * Default is headerHeight and groupHeaderHeight.
+     * By being able to target this class specifically, we can do things
+     * like make some cells of a header smaller/bigger than those with
+     * the actual header height, with just a bit of additional css
+     * (override the overflow property of some other classes).
+     */
+    cellGroupWrapperHeight: PropTypes.number,
+
+    /**
      * Pixel height of footer.
      */
     footerHeight: PropTypes.number,
@@ -529,6 +539,7 @@ var FixedDataTable = createReactClass({
           )}
           width={state.width}
           height={state.groupHeaderHeight}
+          cellGroupWrapperHeight={state.cellGroupWrapperHeight}
           index={0}
           zIndex={1}
           offsetTop={0}
@@ -641,6 +652,7 @@ var FixedDataTable = createReactClass({
         )}
         width={state.width}
         height={state.headerHeight}
+        cellGroupWrapperHeight={state.cellGroupWrapperHeight}
         index={-1}
         zIndex={1}
         offsetTop={headerOffsetTop}
@@ -1170,6 +1182,8 @@ var FixedDataTable = createReactClass({
       scrollY = scrollState.position;
     }
 
+    var cellGroupWrapperHeight = props.cellGroupWrapperHeight;
+
     // The order of elements in this object metters and bringing bodyHeight,
     // height or useGroupHeader to the top can break various features
     var newState = {
@@ -1196,6 +1210,7 @@ var FixedDataTable = createReactClass({
       // columnInfo and props
       bodyHeight,
       height,
+      cellGroupWrapperHeight,
       groupHeaderHeight,
       useGroupHeader,
     };

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -48,6 +48,13 @@ var FixedDataTableCellGroupImpl = createReactClass({
     onColumnReorderMove: PropTypes.func,
     onColumnReorderEnd: PropTypes.func,
 
+    height: PropTypes.number.isRequired,
+
+    /**
+     * Height of fixedDataTableCellGroupLayout/cellGroupWrapper.
+     */
+    cellGroupWrapperHeight: PropTypes.number,
+
     rowHeight: PropTypes.number.isRequired,
 
     rowIndex: PropTypes.number.isRequired,
@@ -211,7 +218,7 @@ var FixedDataTableCellGroup = createReactClass({
     var {offsetLeft, ...props} = this.props;
 
     var style = {
-      height: props.height,
+      height: props.cellGroupWrapperHeight || props.height,
       width: props.width
     };
 

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -20,6 +20,9 @@ import cx from 'cx';
 import joinClasses from 'joinClasses';
 import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
 
+// .fixedDataTableLayout/header border-bottom-width
+var HEADER_BORDER_BOTTOM_WIDTH = 1;
+
 /**
  * Component that renders the row for <FixedDataTable />.
  * This component should not be used directly by developer. Instead,
@@ -248,8 +251,8 @@ class FixedDataTableRowImpl extends React.Component {
       'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
       'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
      });
-     // Subtract 1 to account for .fixedDataTableLayout/header border-bottom-width
-     var dividerHeight = this.props.cellGroupWrapperHeight ? this.props.cellGroupWrapperHeight - 1 : this.props.height;
+     var dividerHeight = this.props.cellGroupWrapperHeight ?
+       this.props.cellGroupWrapperHeight - HEADER_BORDER_BOTTOM_WIDTH : this.props.height;
      var style = {
        left: left,
        height: dividerHeight

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -41,6 +41,11 @@ class FixedDataTableRowImpl extends React.Component {
     height: PropTypes.number.isRequired,
 
     /**
+     * Height of fixedDataTableCellGroupLayout/cellGroupWrapper.
+     */
+    cellGroupWrapperHeight: PropTypes.number,
+
+    /**
      * Height of the content to be displayed below the row.
      */
     subRowHeight: PropTypes.number,
@@ -140,6 +145,7 @@ class FixedDataTableRowImpl extends React.Component {
         key="fixed_cells"
         isScrolling={this.props.isScrolling}
         height={this.props.height}
+        cellGroupWrapperHeight={this.props.cellGroupWrapperHeight}
         left={0}
         width={fixedColumnsWidth}
         zIndex={2}
@@ -159,6 +165,7 @@ class FixedDataTableRowImpl extends React.Component {
         key="scrollable_cells"
         isScrolling={this.props.isScrolling}
         height={this.props.height}
+        cellGroupWrapperHeight={this.props.cellGroupWrapperHeight}
         left={this.props.scrollLeft}
         offsetLeft={fixedColumnsWidth}
         width={this.props.width - fixedColumnsWidth}
@@ -241,9 +248,11 @@ class FixedDataTableRowImpl extends React.Component {
       'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
       'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
      });
+     // Subtract 1 for the border
+     var dividerHeight = this.props.cellGroupWrapperHeight ? this.props.cellGroupWrapperHeight - 1 : this.props.height;
      var style = {
        left: left,
-       height: this.props.height
+       height: dividerHeight
      };
      return <div className={className} style={style} />;
    };

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -248,7 +248,7 @@ class FixedDataTableRowImpl extends React.Component {
       'public/fixedDataTableRow/fixedColumnsDivider': left > 0,
       'public/fixedDataTableRow/columnsShadow': this.props.scrollLeft > 0,
      });
-     // Subtract 1 for the border
+     // Subtract 1 to account for .fixedDataTableLayout/header border-bottom-width
      var dividerHeight = this.props.cellGroupWrapperHeight ? this.props.cellGroupWrapperHeight - 1 : this.props.height;
      var style = {
        left: left,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add new optional prop cellGroupWrapperHeight to control the height of the cellGroupWrapper class for headers only.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need a way to override this class' height specifically, so that we can dynamically adjust it to our needs. Specifically, in our table, we use two tables that are just headers (no rows) to create the illusion of vertically merged cells, like the first picture in this comment https://github.com/schrodinger/fixed-data-table-2/issues/27#issue-164797788 . To be clear, we use a two table implementation to create ColumnGroups instead of using ColumnGroups themselves, to avoid the limitation in the linked issue.

Now that we have access to the cellGroupWrapper, we can build a resizer to dynamically adjust both header heights.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the modified FDT in our codebase.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
-- Sort of - I added a description to the propTypes in FDT.js. Should I update [this](http://schrodinger.github.io/fixed-data-table-2/api-table.html) as well?
- [x] I have read the **CONTRIBUTING** document.
