### PR TITLE
Fix rows not being shown

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1010,32 +1010,6 @@ var FixedDataTable = createReactClass({
       children.push(child);
     });
 
-    // Figure out if the vertical scrollbar will be visible first, 
-    // because it will determine the width of the table
-    var useGroupHeader = false;
-    var groupHeaderHeight = 0;
-
-    if (children.length && children[0].type.__TableColumnGroup__) {
-      useGroupHeader = true;
-      groupHeaderHeight = props.groupHeaderHeight;
-    }
-
-    var useMaxHeight = props.height === undefined;
-    var height = Math.round(useMaxHeight ? props.maxHeight : props.height);
-    var totalHeightReserved = props.footerHeight + props.headerHeight +
-        groupHeaderHeight + 2 * BORDER_HEIGHT;
-    var bodyHeight = height - totalHeightReserved;
-
-    var scrollContentHeight = this._scrollHelper.getContentHeight();
-    var totalHeightNeeded = scrollContentHeight + totalHeightReserved;
-    var maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
-
-    // If vertical scrollbar is necessary, adjust the table width to give it room
-    var adjustedWidth = props.width; 
-    if (maxScrollY) {
-      adjustedWidth = adjustedWidth - Scrollbar.SIZE - 1;
-    }
-
     var scrollState;
     var firstRowIndex = (oldState && oldState.firstRowIndex) || 0;
     var firstRowOffset = (oldState && oldState.firstRowOffset) || 0;
@@ -1066,10 +1040,6 @@ var FixedDataTable = createReactClass({
         props.subRowHeight,
         props.subRowHeightGetter,
       );
-      // We need to recalculate these now, or we'll be operating on outdated height information
-      scrollContentHeight = this._scrollHelper.getContentHeight();
-      totalHeightNeeded = scrollContentHeight + totalHeightReserved;
-
       scrollState = this._scrollHelper.scrollToRow(firstRowIndex, firstRowOffset);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;
@@ -1081,6 +1051,31 @@ var FixedDataTable = createReactClass({
       if (props.subRowHeightGetter !== oldState.subRowHeightGetter) {
         this._scrollHelper.setSubRowHeightGetter(props.subRowHeightGetter);
       }
+    }
+
+    // Figure out if the vertical scrollbar will be visible first, 
+    // because it will determine the width of the table
+    var useGroupHeader = false;
+    var groupHeaderHeight = 0;
+
+    if (children.length && children[0].type.__TableColumnGroup__) {
+      useGroupHeader = true;
+      groupHeaderHeight = props.groupHeaderHeight;
+    }
+
+    var useMaxHeight = props.height === undefined;
+    var height = Math.round(useMaxHeight ? props.maxHeight : props.height);
+    var totalHeightReserved = props.footerHeight + props.headerHeight +
+        groupHeaderHeight + 2 * BORDER_HEIGHT;
+    var bodyHeight = height - totalHeightReserved;
+    var scrollContentHeight = this._scrollHelper.getContentHeight();
+    var totalHeightNeeded = scrollContentHeight + totalHeightReserved;
+    var maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
+
+    // If vertical scrollbar is necessary, adjust the table width to give it room
+    var adjustedWidth = props.width; 
+    if (maxScrollY) {
+      adjustedWidth = adjustedWidth - Scrollbar.SIZE - 1;
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1025,6 +1025,7 @@ var FixedDataTable = createReactClass({
     var totalHeightReserved = props.footerHeight + props.headerHeight +
         groupHeaderHeight + 2 * BORDER_HEIGHT;
     var bodyHeight = height - totalHeightReserved;
+
     var scrollContentHeight = this._scrollHelper.getContentHeight();
     var totalHeightNeeded = scrollContentHeight + totalHeightReserved;
     var maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
@@ -1068,7 +1069,6 @@ var FixedDataTable = createReactClass({
       // We need to recalculate these now, or we'll be operating on outdated height information
       scrollContentHeight = this._scrollHelper.getContentHeight();
       totalHeightNeeded = scrollContentHeight + totalHeightReserved;
-      maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
 
       scrollState = this._scrollHelper.scrollToRow(firstRowIndex, firstRowOffset);
       firstRowIndex = scrollState.index;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1065,6 +1065,11 @@ var FixedDataTable = createReactClass({
         props.subRowHeight,
         props.subRowHeightGetter,
       );
+      // We need to recalculate these now, or we'll be operating on outdated height information
+      scrollContentHeight = this._scrollHelper.getContentHeight();
+      totalHeightNeeded = scrollContentHeight + totalHeightReserved;
+      maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
+
       scrollState = this._scrollHelper.scrollToRow(firstRowIndex, firstRowOffset);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;


### PR DESCRIPTION
## Description
When we first check for scrollContentHeight, we may be using outdated data because we do this check _before_ determining if the rows have changed (thereby re-initializing the scrollHelper).  If the rows have changed, we need to recalculate scrollContentHeight & totalHeightNeeded since they are used in determining bodyHeight later on.

## Motivation and Context
When the row count changes, we will incorrectly calculate bodyHeight

## How Has This Been Tested?
In our company's product.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
