### PR TITLE
Execute the onMouseLeave correct row index

### DIFF
--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -311,7 +311,10 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   _onMouseLeave = (/*object*/ event) => {
-    this.props.onMouseLeave(event, this.mouseLeaveIndex || this.props.index);
+    if(this.mouseLeaveIndex === null) {
+      this.mouseLeaveIndex = this.props.index;
+    }
+    this.props.onMouseLeave(event, this.mouseLeaveIndex);
     this.mouseLeaveIndex = null;
   };
 

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -311,7 +311,7 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   _onMouseLeave = (/*object*/ event) => {
-    this.props.onMouseLeave(event, this.mouseLeaveIndex);
+    this.props.onMouseLeave(event, this.mouseLeaveIndex || this.props.index);
     this.mouseLeaveIndex = null;
   };
 

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -205,7 +205,7 @@ class FixedDataTableRowImpl extends React.Component {
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}
         onMouseDown={this.props.onMouseDown ? this._onMouseDown : null}
         onMouseUp={this.props.onMouseUp ? this._onMouseUp : null}
-        onMouseEnter={this.props.onMouseEnter ? this._onMouseEnter : null}
+        onMouseEnter={this.props.onMouseEnter || this.props.onMouseLeave ? this._onMouseEnter : null}
         onMouseLeave={this.props.onMouseLeave ? this._onMouseLeave : null}
         onTouchStart={this.props.onTouchStart ? this._onTouchStart : null}
         onTouchEnd={this.props.onTouchEnd ? this._onTouchEnd : null}
@@ -307,7 +307,9 @@ class FixedDataTableRowImpl extends React.Component {
      * when scrolling.
      */
     this.mouseLeaveIndex = this.props.index;
-    this.props.onMouseEnter(event, this.props.index);
+    if (this.props.onMouseEnter) {
+      this.props.onMouseEnter(event, this.props.index);
+    }
   };
 
   _onMouseLeave = (/*object*/ event) => {

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -31,15 +31,9 @@ var HEADER_BORDER_BOTTOM_WIDTH = 1;
 class FixedDataTableRowImpl extends React.Component {
 
   /**
-   * Whether the mouseEnter has been detected on this row and we
-   * are waiting for the mouseLeave event to be fired or not.
-   */
-  waitingForMouseLeave = false;
-
-  /**
    * The index of a row for which to fire the onMouseLeave event.
    */
-  mouseLeaveIndex = -1;
+  mouseLeaveIndex = null;
 
   static propTypes = {
 
@@ -140,19 +134,6 @@ class FixedDataTableRowImpl extends React.Component {
      */
     onColumnReorderEnd: PropTypes.func,
   };
-
-  componentWillUpdate(nextProps, nextState){
-    if(this.waitingForMouseLeave &&
-      this.props.index !== nextProps.index){
-        /**
-         * This is necessary so that onMouseLeave is fired for the initial
-         * rowIndex and not for the one this row is replaced with.
-         */
-        if(this.mouseLeaveIndex === -1){
-          this.mouseLeaveIndex = this.props.index;
-        }
-    }
-  }
 
   render() /*object*/ {
     var subRowHeight = this.props.subRowHeight || 0;
@@ -320,17 +301,18 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   _onMouseEnter = (/*object*/ event) => {
-    this.waitingForMouseLeave = true;
+    /**
+     * This is necessary so that onMouseLeave is fired with the initial
+     * row index since this row could be updated with a different index
+     * when scrolling.
+     */
+    this.mouseLeaveIndex = this.props.index;
     this.props.onMouseEnter(event, this.props.index);
   };
 
   _onMouseLeave = (/*object*/ event) => {
-    this.waitingForMouseLeave = false;
-    var mouseLeaveRowIndex = this.props.index;
-    if(this.mouseLeaveIndex !== -1) {
-      mouseLeaveRowIndex = this.mouseLeaveIndex;
-    }
-    this.props.onMouseLeave(event, mouseLeaveRowIndex);
+    this.props.onMouseLeave(event, this.mouseLeaveIndex);
+    this.mouseLeaveIndex = null;
   };
 
   _onTouchStart = (/*object*/ event) => {


### PR DESCRIPTION
## Description
Store original row index in _ComponentWillUpdate_ inside _FixedDataTableRow_. Store the original row index only if _onMouseEnter_ method was executed but not the corresponding _onMouseLeave_ one. If the stored original index was set, execute _onMouseLeave_ with it.

## Motivation and Context
Described in issue #247 

## How Has This Been Tested?
Tested on Chrome with developer tools on to make sure that the correct method with the correct properties. Also tested in codebase that uses this library with the scenario mentioned in related issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
