### PR TITLE
Fix issues related to fixRight columns.

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1157,6 +1157,12 @@ var FixedDataTable = createReactClass({
           totalFixedColumnsWidth += column.props.width;
         }
 
+        var j;
+        for(j = 0; j < columnInfo.bodyFixedRightColumns.length; ++j) {
+          column = columnInfo.bodyFixedRightColumns[j];
+          totalFixedColumnsWidth += column.props.width;
+        }
+
         // Convert column index (0 indexed) to scrollable index (0 indexed)
         // and clamp to max scrollable index
         var scrollableColumnIndex = Math.min(

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -89,7 +89,7 @@ var FixedDataTableCellGroupImpl = createReactClass({
     for (var i = 0, j = columns.length; i < j; i++) {
       var columnProps = columns[i].props;
       var recycable = columnProps.allowCellsRecycling && !isColumnReordering;
-      if (!recycable || (
+      if (!recycable || columnProps.fixedRight || (
             currentPosition - props.left <= props.width &&
             currentPosition - props.left + columnProps.width >= 0)) {
         var key = columnProps.columnKey || 'cell_' + i;
@@ -255,7 +255,7 @@ var FixedDataTableCellGroup = createReactClass({
   ) {
     this.props.onColumnResize && this.props.onColumnResize(
       this.props.offsetLeft,
-      left - this.props.left + width,
+      left - (this.props.left || 0) + width,
       width,
       minWidth,
       maxWidth,

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -89,7 +89,7 @@ var FixedDataTableCellGroupImpl = createReactClass({
     for (var i = 0, j = columns.length; i < j; i++) {
       var columnProps = columns[i].props;
       var recycable = columnProps.allowCellsRecycling && !isColumnReordering;
-      if (!recycable || columnProps.fixedRight || (
+      if (!recycable || (
             currentPosition - props.left <= props.width &&
             currentPosition - props.left + columnProps.width >= 0)) {
         var key = columnProps.columnKey || 'cell_' + i;
@@ -213,6 +213,7 @@ var FixedDataTableCellGroup = createReactClass({
 
   getDefaultProps() /*object*/ {
     return {
+      left: 0,
       offsetLeft: 0,
     };
   },
@@ -255,7 +256,7 @@ var FixedDataTableCellGroup = createReactClass({
   ) {
     this.props.onColumnResize && this.props.onColumnResize(
       this.props.offsetLeft,
-      left - (this.props.left || 0) + width,
+      left - this.props.left + width,
       width,
       minWidth,
       maxWidth,

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -184,7 +184,7 @@ class FixedDataTableRowImpl extends React.Component {
         isScrolling={this.props.isScrolling}
         height={this.props.height}
         cellGroupWrapperHeight={this.props.cellGroupWrapperHeight}
-        left={-this.props.width + fixedRightColumnsWidth}
+        offsetLeft={this.props.width - fixedRightColumnsWidth}
         width={fixedRightColumnsWidth}
         zIndex={2}
         columns={this.props.fixedRightColumns}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Change the positioning of the `fixedRight` columns by using the `offsetLeft` rather than the `left` prop.
* Include `fixedRight` columns in calculation of fixed columns width.
* Set default value of `left` prop for `FixedDataTableCellGroup` to 0 so existing calculations will still work when fixedRight columns don't have a `left` prop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This all fixes this issue: https://github.com/schrodinger/fixed-data-table-2/issues/252

The biggest problem was that the table cell group that was rendered for the `fixedRight` columns would on the far left of the table, overlaid on top of the columns there. This prevented the user from being able to click on any of those columns and thus breaks sorting on them. This fix will render the cell group on the right side of the table instead so it doesn't block anything anymore.

It also fixes some other bugs in regards to `fixedRight` columns that I ran across, such as resizing them, and jumping to different columns. When resizing, the resize indicator line would be rendered in the wrong position in the table, due to a potential `NaN` being returned by `this.props.left`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added `fixedRight` columns to examples in the docs that demonstrate the different features of the table to make sure there wasn't any fishy behaviour. If there were, then I corrected them in this PR. I also ran `npm run test`

## Screenshots (if appropriate):
None.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
