### PR TITLE
Add rounding to horizontal scroll

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1406,11 +1406,13 @@ var FixedDataTable = createReactClass({
       x = x < 0 ? 0 : x;
       x = x > this.state.maxScrollX ? this.state.maxScrollX : x;
 
+      var roundedX = Math.round(x);
+
       //NOTE (asif) This is a hacky workaround to prevent FDT from setting its internal state
       var onHorizontalScroll = this.props.onHorizontalScroll;
-      if (onHorizontalScroll ? onHorizontalScroll(x) : true) {
+      if (onHorizontalScroll ? onHorizontalScroll(roundedX) : true) {
         this.setState({
-          scrollX: x,
+          scrollX: roundedX,
         });
       }
     }
@@ -1426,10 +1428,13 @@ var FixedDataTable = createReactClass({
     if (!this._isScrolling) {
       this._didScrollStart();
     }
+
+    var roundedScrollPos = Math.round(scrollPos);
+
     var onHorizontalScroll = this.props.onHorizontalScroll;
-    if (onHorizontalScroll ? onHorizontalScroll(scrollPos) : true) {
+    if (onHorizontalScroll ? onHorizontalScroll(roundedScrollPos) : true) {
       this.setState({
-        scrollX: scrollPos,
+        scrollX: roundedScrollPos,
       });
     }
     this._didScrollStop();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add rounding to horizontal scroll to avoid content blurring (in case translate3d is used).

## Motivation and Context
Fixes issue:
https://github.com/schrodinger/fixed-data-table-2/issues/254

## How Has This Been Tested?
Manually tested in Chrome, Safairi, FF of latest release versions.

## Screenshots (if appropriate):

Unrounded
![2017-12-01 17 18 21](https://user-images.githubusercontent.com/368385/33486653-f23f154c-d6bb-11e7-9e47-82a9bd940c7b.png)

Rounded
![2017-12-01 17 18 45](https://user-images.githubusercontent.com/368385/33486644-e243b29c-d6bb-11e7-9537-97382900bcb9.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
