### PR TITLE
Fix regression around column resize state being retained too aggresively

### DIFF
--- a/examples/ObjectDataExample.js
+++ b/examples/ObjectDataExample.js
@@ -9,109 +9,78 @@ const { DateCell, ImageCell, LinkCell, TextCell } = require('./helpers/cells');
 const { Table, Column, Cell } = require('fixed-data-table-2');
 const React = require('react');
 
-const numOfRows = 5;
-const numOfCols = 4;
-const width = 800;
-const height = 500;
+class ObjectDataExample extends React.Component {
+  constructor(props) {
+    super(props);
 
-class Example extends React.Component {
-	constructor(props) {
-  	super(props);
     this.state = {
-      columnText: 'No resize yet',
-      _rows: [],
-      dataLoading: false,
-      buttonText: "Start Data Load",
-      interval: ""
+      dataList: new FakeObjectDataListStore(1000000),
     };
-    this.onColumnResizeEndCallback = this.onColumnResizeEndCallback.bind(this);
-    this.render = this.render.bind(this);
-  }
-
-  componentWillMount() {
-    this.createRows();
-
-    this._columns = [];
-    for(var i = 0; i < numOfCols; i++) {
-    	this._columns.push({ key: i, name: 'Col ' + i });
-    }
-  }
-
-  createRows() {
-    let rows = [];
-    for (let i = 0; i < numOfRows; i++) {
-      let rowValues = {};
-      for(var j=0; j < numOfCols; j++) {
-    		rowValues[j] = (i * numOfCols + j);
-    	}
-      rows.push(rowValues);
-    }
-
-    this.setState({_rows: rows});
-  }
-
-  onColumnResizeEndCallback(newWidth, columnKey) {
-  	this.setState({columnText: 'Column ' + columnKey + ' updated with width ' + newWidth});
-  }
-
-  handleButtonClick() {
-  	if (this.state.dataLoading) {
-    	clearInterval(this.state.interval);
-      this.setState({dataLoading: false, buttonText: "Start Data Load"});
-    }
-    else {
-      let v = setInterval(() => {
-      	let rows = this.state._rows;
-        let rowValues = {};
-        for (var j=0; j < numOfCols; j++) {
-        	rowValues[j] = (numOfCols + j);
-        }
-        rows.push(rowValues);
-        this.setState({_rows: rows});
-      }, 100);
-			this.setState({dataLoading: true, buttonText: "Stop Data Load", interval: v});
-    }
   }
 
   render() {
-    return  (
-    	<div>
-        {this.state.columnText}
-        <button
-          onClick={this.handleButtonClick.bind(this)}
-          classname="btn btn-primary">{this.state.buttonText}
-        </button>
-    	  <Table
-          rowsCount={this.state._rows.length}
-          headerHeight={50}
-          rowHeight={50}
-          width={width}
-          height={height}
-          onColumnResizeEndCallback={this.onColumnResizeEndCallback}
-          >
-          {
-            this._columns
-              .map(c => c.key)
-              .map(field => (
-                <Column
-              		columnKey={field}
-                  key={field}
-                  header={<Cell>{'Col' + field}</Cell>}
-                  isResizable={true}
-                  cell={({rowIndex}) => (
-                  	<Cell className="text-cell">
-        							{this.state._rows[rowIndex][field]}
-  									</Cell>
-                  )}
-                  allowCellsRecycling={true}
-                  width={200}
-                />
-            ))
-          }
-        </Table>
-    	</div>
+    var {dataList} = this.state;
+    return (
+      <Table
+        rowHeight={50}
+        headerHeight={50}
+        rowsCount={dataList.getSize()}
+        width={1000}
+        height={500}
+        {...this.props}>
+        <Column
+          columnKey="avatar"
+          cell={<ImageCell data={dataList} />}
+          fixed={true}
+          width={50}
+        />
+        <Column
+          columnKey="firstName"
+          header={<Cell>First Name</Cell>}
+          cell={<LinkCell data={dataList} />}
+          fixed={true}
+          width={100}
+        />
+        <Column
+          columnKey="lastName"
+          header={<Cell>Last Name</Cell>}
+          cell={<TextCell data={dataList} />}
+          fixed={true}
+          width={100}
+        />
+        <Column
+          columnKey="city"
+          header={<Cell>City</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={100}
+        />
+        <Column
+          columnKey="street"
+          header={<Cell>Street</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="zipCode"
+          header={<Cell>Zip Code</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="email"
+          header={<Cell>Email</Cell>}
+          cell={<LinkCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="date"
+          header={<Cell>DOB</Cell>}
+          cell={<DateCell data={dataList} />}
+          width={200}
+        />
+      </Table>
     );
   }
-};
+}
 
-module.exports = Example;
+module.exports = ObjectDataExample;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1135,7 +1135,7 @@ var FixedDataTable = createReactClass({
       }
     }
 
-    // Figure out if the vertical scrollbar will be visible first, 
+    // Figure out if the vertical scrollbar will be visible first,
     // because it will determine the width of the table
     var useGroupHeader = false;
     var groupHeaderHeight = 0;
@@ -1155,7 +1155,7 @@ var FixedDataTable = createReactClass({
     var maxScrollY = Math.max(0, scrollContentHeight - bodyHeight);
 
     // If vertical scrollbar is necessary, adjust the table width to give it room
-    var adjustedWidth = props.width; 
+    var adjustedWidth = props.width;
     if (maxScrollY) {
       adjustedWidth = adjustedWidth - Scrollbar.SIZE - 1;
     }
@@ -1177,7 +1177,9 @@ var FixedDataTable = createReactClass({
     }
 
     var columnResizingData;
-    if (props.isColumnResizing || (oldState && oldState.isColumnResizing)) {
+    var continuingResizing = props.isColumnResizing === undefined &&
+      oldState && oldState.isColumnResizing;
+    if (props.isColumnResizing || continuingResizing) {
       columnResizingData = oldState && oldState.columnResizingData;
     } else {
       columnResizingData = EMPTY_OBJECT;
@@ -1208,7 +1210,7 @@ var FixedDataTable = createReactClass({
     );
 
     var lastScrollToColumn = oldState ? oldState.scrollToColumn : undefined;
-    if (props.scrollToColumn !== null 
+    if (props.scrollToColumn !== null
         && props.scrollToColumn !== lastScrollToColumn
         && columnInfo.bodyScrollableColumns.length > 0) {
       // If selected column is a fixed column, don't scroll


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Only retain when the prop is undefined, not when explicitly set to false.

@miskreant @quixotically could one of you take a look when you get a chance?

## Description
<!--- Describe your changes in detail -->
#276 is happening because we're retaining the old column state even when resizing is stopped.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #276 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the test case from #268 and the column resize example.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
