### PR TITLE
Fixed column resize on Android.

### DIFF
--- a/examples/ResizeExample.js
+++ b/examples/ResizeExample.js
@@ -44,6 +44,7 @@ class ResizeExample extends React.Component {
         rowsCount={dataList.getSize()}
         onColumnResizeEndCallback={this._onColumnResizeEndCallback}
         isColumnResizing={false}
+        touchScrollEnabled={true}
         width={1000}
         height={500}
         {...this.props}>

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -245,14 +245,18 @@ var FixedDataTableCell = createReactClass({
       var columnResizerStyle = {
         height
       };
+      function suppress(event) {
+        event.preventDefault();
+        event.stopPropagation();
+      };
       columnResizerComponent = (
         <div
           className={cx('fixedDataTableCellLayout/columnResizerContainer')}
           style={columnResizerStyle}
           onMouseDown={this._onColumnResizerMouseDown}
           onTouchStart={this.props.touchEnabled ? this._onColumnResizerMouseDown : null}
-          onTouchEnd={this.props.touchEnabled ? e => e.stopPropagation() : null}
-          onTouchMove={this.props.touchEnabled ? e => e.stopPropagation() : null}>
+          onTouchEnd={this.props.touchEnabled ? suppress : null}
+          onTouchMove={this.props.touchEnabled ? suppress : null}>
           <div
             className={joinClasses(
               cx('fixedDataTableCellLayout/columnResizerKnob'),
@@ -324,7 +328,8 @@ var FixedDataTableCell = createReactClass({
      * This prevents the rows from moving around when we resize the
      * headers on touch devices.
      */
-    if(this.props.touchEnabled) {
+    if (this.props.touchEnabled) {
+      event.preventDefault();
       event.stopPropagation();
     }
   },

--- a/src/vendor_upstream/dom/DOMMouseMoveTracker.js
+++ b/src/vendor_upstream/dom/DOMMouseMoveTracker.js
@@ -54,8 +54,7 @@ class DOMMouseMoveTracker {
    * in order to grab inital state.
    */
   captureMouseMoves(/*object*/ event) {
-    if (!this._eventMoveToken && !this._eventUpToken &&
-        !this._eventLeaveToken && !this._eventOutToken) {
+    if (!this._eventMoveToken && !this._eventUpToken && !this._eventLeaveToken) {
       this._eventMoveToken = EventListener.listen(
         this._domNode,
         'mousemove',
@@ -70,11 +69,6 @@ class DOMMouseMoveTracker {
         this._domNode,
         'mouseleave',
         this._onMouseEnd
-      );
-      this._eventOutToken = EventListener.listen(
-        this._domNode,
-        'mouseout',
-        this.onMouseEnd
       );
     }
 
@@ -111,29 +105,26 @@ class DOMMouseMoveTracker {
   }
 
   /**
-   * These releases all of the listeners on document.body.
+   * This releases all of the listeners on document.body.
    */
   releaseMouseMoves() {
-    if (this._eventMoveToken && this._eventUpToken &&
-        this._eventLeaveToken && this._eventOutToken) {
+    if (this._eventMoveToken && this._eventUpToken && this._eventLeaveToken) {
       this._eventMoveToken.remove();
       this._eventMoveToken = null;
       this._eventUpToken.remove();
       this._eventUpToken = null;
       this._eventLeaveToken.remove();
       this._eventLeaveToken = null;
-      this._eventOutToken.remove();
-      this._eventOutToken = null;
     }
 
     if (this._isTouchEnabled && this._eventTouchStartToken &&
         this._eventTouchMoveToken && this._eventTouchEndToken) {
-        this._eventTouchStartToken.remove();
-        this._eventTouchStartToken = null;
-        this._eventTouchMoveToken.remove();
-        this._eventTouchMoveToken = null;
-        this._eventTouchEndToken.remove();
-        this._eventTouchEndToken = null;
+      this._eventTouchStartToken.remove();
+      this._eventTouchStartToken = null;
+      this._eventTouchMoveToken.remove();
+      this._eventTouchMoveToken = null;
+      this._eventTouchEndToken.remove();
+      this._eventTouchEndToken = null;
     }
 
     if (this._animationFrameID !== null) {


### PR DESCRIPTION
## Description
1. In FixedDataTableCell.js, fixed event handling in columnResizerComponent. The ignored events must have `event.preventDefault` called as well as `event.stopPropagation`.
2. In vendor_upstream/dom/DOMMouseMoveTracker.js, removed handling for `mouse out` event.

## Motivation and Context
Release 0.8.8 makes column resize work on iOS, and _almost_ makes column resize work on Android. Our app requires that this feature work on Android.

Fixes https://github.com/schrodinger/fixed-data-table-2/issues/277

I have not modified the width of fixedDataTableCell_columnResizerKnob. Instead, I styled `.public_fixedDataTableCell_columnResizerKnob` in our app, increasing its width to 10px, but styling it with a linear gradient so it doesn't look twice as big.

## How Has This Been Tested?
I tested this change, using our fork of fixed-data-table, in our app, on the following platforms:
- Chrome/Android
- Cordova/Android
- Safari/iOS11
- Cordova/iOS11
- Chrome/Mac
- Safari/Mac
- Firefox/Mac
- IE11/Win7
- Edge/Win10
Both column resize and touch scroll are configured.

`npm run test`: all succeed.

`npm run site-dev-server`: all applicable demos work as expected. There really needs to be a demo with both column resize and touch scroll configured. I'm glad to add one, but I have not done so yet.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project. (I think)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
