### PR TITLE
Custom renderer capabilities for cases without data implemented

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -410,6 +410,13 @@ var FixedDataTable = createReactClass({
      * half of the number of visible rows.
      */
     bufferRowCount: PropTypes.number,
+
+    /**
+     * Renderer used in case of data is empty
+     *
+     * Usefull when data gets filtered globally or column based
+     */
+    noDataRenderer: PropTypes.func,
   },
 
   getDefaultProps() /*object*/ {
@@ -784,6 +791,23 @@ var FixedDataTable = createReactClass({
           )}
           style={{top: footOffsetTop}}
         />;
+    }
+
+    /**
+     * Show indicator in case of no data is available
+     */
+    if (props.rowsCount === 0 && props.noDataRenderer) {
+      // Calculate total header height
+      const totalHeaderHeight = props.headerHeight * (state.useGroupHeader ? 2 : 1);
+
+      rows = (
+        <div style={{
+          marginTop: totalHeaderHeight,
+          height: (props.height - props.footerHeight - totalHeaderHeight)
+        }}>
+          { this.props.noDataRenderer() }
+        </div>
+      );
     }
 
     return (


### PR DESCRIPTION
Renderer will be invoked when rowsCount is equal 0 and a renderer is provided via props. Otherwise table body will stay empty like before. The default behavior will be consistent.

## Description
FixedDataTable has a new property called "noDataRenderer" which is invoked in cases the table does not receive any data.

## Motivation and Context
When filtering the data before passing it down to DataTable it is usefull to provide a extra view which will be shown when the filter has no results. Otherwise the user only sees an empty table without any message. That looks more like an error then regular handling. 

Doing this by providing a single column which indicates that the data is empty does not preserve the regular headers and footers of the table. In my case the footers include a text input which are responsible for column based filtering. By  providing a single column i am not able to change the filter which results in an empty dataset.

## How Has This Been Tested?
I tested it manually in different scenarios. The important part of the changes i made is the calculation of the margin and the height. I think this can only be influenced by header, footer and columnGroups. These parts are part of the calculation actually. Please let me know of other relevant parameters.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
