### PR TITLE
Convert element refs to functions.

### DIFF
--- a/src/FixedDataTableRoot-test.js
+++ b/src/FixedDataTableRoot-test.js
@@ -47,13 +47,15 @@ describe('FixedDataTableRoot', function() {
      * @return {!Object}
      */
     getTableState() {
-      return this.refs['table'].state;
+      return this.table.state;
     }
+
+    tableRef = ref => (this.table = ref);
 
     render() {
       return (
         <Table
-          ref="table"
+          ref={this.tableRef}
           width={600}
           height={400}
           rowsCount={50}

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -97,6 +97,10 @@ var Scrollbar = createReactClass({
     };
   },
 
+  faceRef(ref) {
+    this.face = ref;
+  },
+
   render() /*?object*/ {
     if (!this.state.scrollable) {
       return null;
@@ -167,7 +171,7 @@ var Scrollbar = createReactClass({
         style={mainStyle}
         tabIndex={0}>
         <div
-          ref="face"
+          ref={this.faceRef}
           className={faceClassName}
           style={faceStyle}
         />
@@ -322,7 +326,7 @@ var Scrollbar = createReactClass({
   _onMouseDown(/*object*/ event) {
     var nextState;
 
-    if (event.target !== ReactDOM.findDOMNode(this.refs.face)) {
+    if (event.target !== ReactDOM.findDOMNode(this.face)) {
       // Both `offsetX` and `layerX` are non-standard DOM property but they are
       // magically available for browsers somehow.
       var nativeEvent = event.nativeEvent;


### PR DESCRIPTION
React 16.3+  no longer supports string references (`ref={string}`) but rather require a callback function.
This PR replaces the two `ref` usages within the project to use functions.

