### PR TITLE
Fix issue with changing data on scroll

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -88,6 +88,7 @@ var FixedDataTableBufferedRows = createReactClass({
   },
 
   componentWillReceiveProps(/*object*/ nextProps) {
+    var createdNewRowBuffer = false;
     if (nextProps.rowsCount !== this.props.rowsCount ||
         nextProps.defaultRowHeight !== this.props.defaultRowHeight ||
         nextProps.height !== this.props.height) {
@@ -99,8 +100,9 @@ var FixedDataTableBufferedRows = createReactClass({
           this._getRowHeight,
           this.props.bufferRowCount
         );
+      createdNewRowBuffer = true;
     }
-    if (this.props.isScrolling && !nextProps.isScrolling) {
+    if (!createdNewRowBuffer && this.props.isScrolling && !nextProps.isScrolling) {
       this._updateBuffer();
     } else {
       this.setState({


### PR DESCRIPTION
If the rowsCount changed in the onVerticalScroll callback, a new buffer gets created so make sure getRows is called instead of getRowsWithUpdatedBuffer.

## Description
Add a flag within componentWillReceiveProps that when a new buffer is created we update the state.rowsToRender to the return value of getRows and not getRowsWithUpdatedBuffer.

## Motivation and Context
In my usage of the fixed-data-table-2 I was adding more data when the user scrolled near the end. I didn't want to use onScrollEnd because then they would be able to scroll all the way to the bottom before I got notified. So using onVerticalScroll callback I added data and changed the rowsCount. Without this change only the first rows were getting rendered and they were getting rendered out side of the viewport.

## How Has This Been Tested?
Manually tested scrolling scenarios when I was both adding data and not adding data.

## Screenshots (if appropriate):
Empty viewport:
![image](https://user-images.githubusercontent.com/41756724/43280766-6ff94306-90d7-11e8-83de-c72f1e7b52fb.png)

DOM:
![image](https://user-images.githubusercontent.com/41756724/43280819-90b28f44-90d7-11e8-998d-29b6f9ac991f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
