### PR TITLE
Replace legacy string refs with callback refs

### DIFF
--- a/examples/helpers/cells.js
+++ b/examples/helpers/cells.js
@@ -139,7 +139,7 @@ class TooltipCell extends React.PureComponent {
         {...props}
         onMouseEnter={() => { ReactTooltip.show(); }}
         onMouseLeave={() => { ReactTooltip.hide(); }}>
-        <div ref='valueDiv' data-tip={value}>
+        <div ref={(r) => this._valueDivRef = r} data-tip={value}>
           {value}
         </div>
       </Cell>

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -160,7 +160,7 @@ class Scrollbar extends React.PureComponent {
         style={mainStyle}
         tabIndex={0}>
         <div
-          ref="face"
+          ref={(r) => this._faceRef = r}
           className={faceClassName}
           style={faceStyle}
         />
@@ -315,7 +315,7 @@ class Scrollbar extends React.PureComponent {
   _onMouseDown = (/*object*/ event) => {
     var nextState;
 
-    if (event.target !== ReactDOM.findDOMNode(this.refs.face)) {
+    if (event.target !== ReactDOM.findDOMNode(this._faceRef)) {
       // Both `offsetX` and `layerX` are non-standard DOM property but they are
       // magically available for browsers somehow.
       var nativeEvent = event.nativeEvent;

--- a/test/FixedDataTableRoot-test.js
+++ b/test/FixedDataTableRoot-test.js
@@ -45,13 +45,13 @@ describe('FixedDataTableRoot', function() {
      * @return {!Object}
      */
     getTableState() {
-      return this.refs['table'].state;
+      return this._tableRef.state;
     }
 
     render() {
       return (
         <Table
-          ref="table"
+          ref={(r) => this._tableRef = r}
           width={600}
           height={400}
           rowsCount={50}


### PR DESCRIPTION
String refs have issues discussed in [this issue](https://github.com/facebook/react/issues/1373) on the React repo and are considered [legacy](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs) from React guidance. This PR replaces them with a simple callback instead.

## Description
Replaced all string refs with callback refs in source.

## Motivation and Context
Removes a legacy usage that could trigger a Refs Must Have Owner Warning and a subsequent crash.

## How Has This Been Tested?
Running `npm test`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
