### PR TITLE
Remove data property from Table example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the default stylesheet `dist/fixed-data-table.css` using a link tag or impor
 
 Implementing a table involves three component types- `<Table/>`,`<Column/>`, and `<Cell/>`.
 
-`<Table />` contains configuration information for the entire table, like dimensions and row count. It's also where you pass down the data to be rendered in the table. 
+`<Table />` contains configuration information for the entire table, like dimensions and row count.
 
 ```javascript
 
@@ -50,7 +50,6 @@ Implementing a table involves three component types- `<Table/>`,`<Column/>`, and
     width={5000}
     height={5050}
     headerHeight={50}
-    data={rows}>
     ...
   </Table>
 ```    


### PR DESCRIPTION
## Description
I copied the first table example that has the `data` property and Typescript is complain that this `data` property does not exists.
I looked the other examples and no one is using the `data` property.

## Motivation and Context
Fix README.md example code

## How Has This Been Tested?
Typescript was complaining, the others code examples are not using this `data` property

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
