### PR TITLE
Add Scrollbar Container CSS Class Prop

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -244,6 +244,11 @@ class FixedDataTable extends React.Component {
     footerHeight: PropTypes.number,
 
     /**
+     * Class name to be passed into scrollbar container
+     */
+    scrollbarClassName: PropTypes.string,
+
+    /**
      * Value of horizontal scroll.
      */
     scrollLeft: PropTypes.number,
@@ -538,6 +543,7 @@ class FixedDataTable extends React.Component {
       scrollbarY =
         <Scrollbar
           size={visibleRowsHeight}
+          className={this.props.scrollbarClassName}
           contentSize={scrollContentHeight}
           onScroll={this._onVerticalScroll}
           verticalTop={bodyOffsetTop}
@@ -549,6 +555,7 @@ class FixedDataTable extends React.Component {
     if (scrollEnabledX) {
       scrollbarX =
         <HorizontalScrollbar
+          className={this.props.scrollbarClassName}
           contentSize={width + maxScrollX}
           offset={scrollbarXOffsetTop}
           onScroll={this._onHorizontalScroll}

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -20,6 +20,7 @@ import ReactWheelHandler from 'ReactWheelHandler';
 import cssVar from 'cssVar';
 import cx from 'cx';
 import emptyFunction from 'emptyFunction';
+import joinClasses from 'joinClasses';
 import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
 
 var UNSCROLLABLE_STATE = {
@@ -36,6 +37,7 @@ var _lastScrolledScrollbar = null;
 
 class Scrollbar extends React.PureComponent {
   static propTypes = {
+    className: PropTypes.string,
     contentSize: PropTypes.number.isRequired,
     defaultPosition: PropTypes.number,
     isOpaque: PropTypes.bool,
@@ -83,6 +85,7 @@ class Scrollbar extends React.PureComponent {
   }
 
   static defaultProps = /*object*/ {
+    className: '',
     defaultPosition: 0,
     isOpaque: false,
     onScroll: emptyFunction,
@@ -105,14 +108,17 @@ class Scrollbar extends React.PureComponent {
     var isOpaque = this.props.isOpaque;
     var verticalTop = this.props.verticalTop || 0;
 
-    var mainClassName = cx({
-      'ScrollbarLayout/main': true,
-      'ScrollbarLayout/mainVertical': isVertical,
-      'ScrollbarLayout/mainHorizontal': isHorizontal,
-      'public/Scrollbar/main': true,
-      'public/Scrollbar/mainOpaque': isOpaque,
-      'public/Scrollbar/mainActive': isActive,
-    });
+    var mainClassName = joinClasses(
+      this.props.className,
+      cx({
+        'ScrollbarLayout/main': true,
+        'ScrollbarLayout/mainVertical': isVertical,
+        'ScrollbarLayout/mainHorizontal': isHorizontal,
+        'public/Scrollbar/main': true,
+        'public/Scrollbar/mainOpaque': isOpaque,
+        'public/Scrollbar/mainActive': isActive,
+      })
+    );
 
     var faceClassName = cx({
       'ScrollbarLayout/face': true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the property `scrollbarClassName` to Table, which is passed to the Scrollbar and joined with the `mainClassName` in order to custom style the scrollbar container.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adds the ability to custom style the scrollbar container similar to `className` for the primary container and `rowClassNameGetter` for row styling.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual verification that expected CSS class is added to scrollbar.
`npm run test` passes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
