### PR TITLE
Does not call onHorizontalScroll after scrollToColumn

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1357,6 +1357,8 @@ var FixedDataTable = createReactClass({
       maxScrollY,
       reservedHeight: totalHeightReserved,
       scrollContentHeight,
+      lastScrollLeft,
+      lastScrollTop,
       scrollX,
       scrollY,
       // These properties may overwrite properties defined in
@@ -1451,7 +1453,7 @@ var FixedDataTable = createReactClass({
   },
 
   _onHorizontalScroll(/*number*/ scrollPos) {
-    if (scrollPos === this.state.scrollX) {
+    if (scrollPos === this.state.lastScrollLeft) {
       return;
     }
 
@@ -1471,7 +1473,7 @@ var FixedDataTable = createReactClass({
   },
 
   _onVerticalScroll(/*number*/ scrollPos) {
-    if (scrollPos === this.state.scrollY) {
+    if (scrollPos === this.state.lastScrollTop) {
       return;
     }
 

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -528,6 +528,10 @@ var Scrollbar = createReactClass({
       var callback = willScroll ? this._didScroll : undefined;
       this.setState(nextState, callback);
     } else if (controlledPosition === nextState.position) {
+      // Also notify owner when code-triggered scrolling occurs
+      if (willScroll) {
+        this.props.onScroll(nextState.position);
+      }
       this.setState(nextState);
     } else {
       // Scrolling is controlled. Don't update the state and let the owner


### PR DESCRIPTION
Currently onHorizontalScroll is only called when the user scrolls, not when the scrolling is done programmatically, like with scrollToColumn. 

## Expected Behavior
When scrollToColumn triggers a scroll event, onHorizontalScroll should be called.

## Current Behavior
scrollToColumn scrolls the table to the right, but onHorizontalScroll is never called.

## Possible Solution
I have a possible PR solution.

## Steps to Reproduce (for bugs)
Create a table with multiple columns wider than the specified table width (specifically, so that one column is half-visible). Set an onHorizontalScroll callback. Set an onClick handler for each column to change the table's scrollToColumn when clicked. Click the farthest right column you can partially see, so that it scrolls into complete view. onHorizontalScroll is not called.

## Context
I am trying to accurately place an element over the table and I can't get an accurate scrollX value when scrollToColumn is in play.

## Your Environment
* Version used: 0.8.15
* Browser Name and version: Chrome
* Operating System and version (desktop or mobile): OSX 10.13.6
* Link to your project: N/A
