### PR TITLE
call onHorizontalScroll after scrollToColumn (previously #352)

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -837,9 +837,10 @@ class FixedDataTable extends React.Component {
       onHorizontalScroll,
       scrollActions,
       scrollX,
+      lastScrollX,
     } = this.props;
 
-    if (scrollPos === scrollX) {
+    if (scrollPos === lastScrollX) {
       return;
     }
 
@@ -858,9 +859,10 @@ class FixedDataTable extends React.Component {
       onVerticalScroll,
       scrollActions,
       scrollY,
+      lastScrollY,
     } = this.props;
 
-    if (scrollPos === scrollY) {
+    if (scrollPos === lastScrollY) {
       return;
     }
 

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -101,6 +101,7 @@ class FixedDataTableContainer extends React.Component {
       'tableSize',
     ]);
 
+    this.setState({lastScrollX: this.state && this.state.scrollX, lastScrollY: this.state && this.state.scrollY});
     this.setState(boundState);
   }
 }

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -482,6 +482,10 @@ class Scrollbar extends React.PureComponent {
       var callback = willScroll ? this._didScroll : undefined;
       this.setState(nextState, callback);
     } else if (controlledPosition === nextState.position) {
+      // Also notify owner when code-triggered scrolling occurs
+      if (willScroll) {
+        this.props.onScroll(nextState.position);
+      }
       this.setState(nextState);
     } else {
       // Scrolling is controlled. Don't update the state and let the owner


### PR DESCRIPTION
Currently onHorizontalScroll is only called when the user scrolls, not when the scrolling is done programmatically, like with scrollToColumn. 

## Expected Behavior
When scrollToColumn triggers a scroll event, onHorizontalScroll should be called.

## Current Behavior
scrollToColumn scrolls the table to the right, but onHorizontalScroll is never called.

## Possible Solution
I have a possible PR solution.

## Steps to Reproduce (for bugs)
Create a table with multiple columns wider than the specified table width (specifically, so that one column is half-visible). Set an onHorizontalScroll callback. Set an onClick handler for each column to change the table's scrollToColumn when clicked. Click the farthest right column you can partially see, so that it scrolls into complete view. onHorizontalScroll is not called.

## Context
I am trying to accurately place an element over the table and I can't get an accurate scrollX value when scrollToColumn is in play.

## Your Environment
* Version used: 0.8.15
* Browser Name and version: Chrome
* Operating System and version (desktop or mobile): OSX 10.13.6
* Link to your project: N/A
