### PR TITLE
Remove scrollbar-thumb disappearance and jitter on IE11

### DIFF
--- a/src/css/layout/ScrollbarLayout.css
+++ b/src/css/layout/ScrollbarLayout.css
@@ -42,8 +42,9 @@
   overflow: hidden;
   position: absolute;
   z-index: 1;
+  transition-duration: 250ms;
   transition-timing-function: ease;
-  transition-property: background-color width position;
+  transition-property: width;
 }
 
 /**

--- a/src/css/layout/ScrollbarLayout.css
+++ b/src/css/layout/ScrollbarLayout.css
@@ -42,7 +42,6 @@
   overflow: hidden;
   position: absolute;
   z-index: 1;
-  transition-duration: 250ms;
   transition-timing-function: ease;
   transition-property: background-color width position;
 }

--- a/src/vendor_upstream/dom/translateDOMPositionXY.js
+++ b/src/vendor_upstream/dom/translateDOMPositionXY.js
@@ -30,7 +30,6 @@ var translateDOMPositionXY = (function() {
     if (!isSafari && BrowserSupportCore.hasCSS3DTransforms()) {
       return function(/*object*/ style, /*number*/ x, /*number*/ y) {
         style[TRANSFORM] ='translate3d(' + x + 'px,' + y + 'px,0)';
-        style[BACKFACE_VISIBILITY] = 'hidden';
       };
     } else {
       return function(/*object*/ style, /*number*/ x, /*number*/ y) {


### PR DESCRIPTION
## Description
Removed the transition-duration property of the ScrollbarLayout/face CSS rule, to prevent jittering of the scrollbar thumb on IE11 while dragging it with the mouse.
Changed translateDOMPositionXY() to no longer hide the backface, in order to prevent the scrollbar thumb from disappearing on IE11 when dragging it with the mouse.

## Motivation and Context
Fixes #285 and at least portions of #233 

## How Has This Been Tested?
Tested manually on IE11, as well as the current versions of Chrome and Firefox

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
