### PR TITLE
Merge commits from '0a26dd1' (inclusive) till 'ff24111', from master into v1.0-beta

### DIFF
--- a/examples/FixedRightColumnsExample.js
+++ b/examples/FixedRightColumnsExample.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+"use strict";
+
+const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
+const { DateCell, ImageCell, LinkCell, TextCell } = require('./helpers/cells');
+const { Table, Column, Cell } = require('fixed-data-table-2');
+const React = require('react');
+
+class FixedRightColumnsExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dataList: new FakeObjectDataListStore(1000000),
+    };
+  }
+
+  render() {
+    var {dataList} = this.state;
+    return (
+      <Table
+        rowHeight={50}
+        headerHeight={50}
+        rowsCount={dataList.getSize()}
+        width={1000}
+        height={500}
+        {...this.props}>
+        <Column
+          columnKey="avatar"
+          cell={<ImageCell data={dataList} />}
+          fixed={true}
+          width={50}
+        />
+        <Column
+          columnKey="firstName"
+          header={<Cell>First Name</Cell>}
+          cell={<LinkCell data={dataList} />}
+          fixedRight={true}
+          width={100}
+        />
+        <Column
+          columnKey="lastName"
+          header={<Cell>Last Name</Cell>}
+          cell={<TextCell data={dataList} />}
+          fixedRight={true}
+          width={100}
+        />
+        <Column
+          columnKey="city"
+          header={<Cell>City</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={100}
+        />
+        <Column
+          columnKey="street"
+          header={<Cell>Street</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="zipCode"
+          header={<Cell>Zip Code</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="email"
+          header={<Cell>Email</Cell>}
+          cell={<LinkCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="date"
+          header={<Cell>DOB</Cell>}
+          cell={<DateCell data={dataList} />}
+          width={200}
+        />
+      </Table>
+    );
+  }
+}
+
+module.exports = FixedRightColumnsExample;

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -36,6 +36,12 @@ exports.ExamplePages = {
     title: 'With JSON Data',
     description: 'A basic table example with two fixed columns, fed in some JSON data.',
   },
+  FIXED_RIGHT_COLUMNS_EXAMPLE: {
+    location: 'fixed-right-columns.html',
+    fileName: 'FixedRightColumnsExample.js',
+    title: 'Fixed Right Columns',
+    description: 'A table example that has a columns fixed to the right side of the table.',
+  },
   FLEXGROW_EXAMPLE: {
     location: 'example-flexgrow.html',
     fileName: 'FlexGrowExample.js',

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -48,6 +48,7 @@ var EXAMPLE_COMPONENTS = {
   [ExamplePages.OWNER_HEIGHT_EXAMPLE.location]: require('../../examples/OwnerHeightExample'),
   [ExamplePages.LONG_CLICK_EXAMPLE.location]: require('../../examples/LongClickExample'),
   [ExamplePages.CONTEXT_EXAMPLE.location]: require('../../examples/ContextExample'),
+  [ExamplePages.FIXED_RIGHT_COLUMNS_EXAMPLE.location]: require('../../examples/FixedRightColumnsExample'),
 };
 
 class ExamplesPage extends React.Component {

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -21,6 +21,7 @@ class FixedDataTableBufferedRows extends React.Component {
   static propTypes = {
     isScrolling: PropTypes.bool,
     fixedColumns: PropTypes.array.isRequired,
+    fixedRightColumns: PropTypes.array.isRequired,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
@@ -118,6 +119,7 @@ class FixedDataTableBufferedRows extends React.Component {
           offsetTop={Math.round(rowOffsetTop)}
           visible={true}
           fixedColumns={props.fixedColumns}
+          fixedRightColumns={props.fixedRightColumns}
           scrollableColumns={props.scrollableColumns}
           onClick={props.onRowClick}
           onDoubleClick={props.onRowDoubleClick}

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -201,6 +201,7 @@ class FixedDataTableCellGroup extends React.Component {
   }
 
   static defaultProps = /*object*/ {
+    left: 0,
     offsetLeft: 0,
   }
 

--- a/src/FixedDataTableColumn.js
+++ b/src/FixedDataTableColumn.js
@@ -32,6 +32,11 @@ class FixedDataTableColumn extends React.Component {
    fixed: PropTypes.bool,
 
    /**
+    * Controls if the column is fixed to the right side of the table when scrolling in the X axis.
+    */
+   fixedRight: PropTypes.bool,
+
+   /**
     * The header cell for this column.
     * This can either be a string a React element, or a function that generates
     * a React Element. Passing in a string will render a default header cell
@@ -181,6 +186,7 @@ class FixedDataTableColumn extends React.Component {
  static defaultProps = {
    allowCellsRecycling: false,
    fixed: false,
+   fixedRight: false,
  };
 
  render() {

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -45,6 +45,11 @@ class FixedDataTableRowImpl extends React.Component {
     fixedColumns: PropTypes.array.isRequired,
 
     /**
+     * Array of <FixedDataTableColumn /> for the fixed columns positioned at end of the table.
+     */
+    fixedRightColumns: PropTypes.array.isRequired,
+
+    /**
      * Height of the row.
      */
     height: PropTypes.number.isRequired,
@@ -181,15 +186,39 @@ class FixedDataTableRowImpl extends React.Component {
         rowIndex={this.props.index}
       />;
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
+    var fixedRightColumnsWidth = sumPropWidths(this.props.fixedRightColumns);
+    var fixedRightColumns = 
+      <FixedDataTableCellGroup
+        key="fixed_right_cells"
+        isScrolling={this.props.isScrolling}
+        height={this.props.height}
+        cellGroupWrapperHeight={this.props.cellGroupWrapperHeight}
+        offsetLeft={this.props.width - fixedRightColumnsWidth}
+        width={fixedRightColumnsWidth}
+        zIndex={2}
+        columns={this.props.fixedRightColumns}
+        touchEnabled={this.props.touchEnabled}
+        onColumnResize={this.props.onColumnResize}
+        onColumnReorder={this.props.onColumnReorder}
+        onColumnReorderMove={this.props.onColumnReorderMove}
+        onColumnReorderEnd={this.props.onColumnReorderEnd}
+        isColumnReordering={this.props.isColumnReordering}
+        columnReorderingData={this.props.columnReorderingData}
+        rowHeight={this.props.height}
+        rowIndex={this.props.index}
+      />;
+    var fixedRightColumnsShdadow = fixedRightColumnsWidth ?
+      this._renderFixedRightColumnsShadow(this.props.width - fixedRightColumnsWidth - 5) : null;
     var scrollableColumns =
       <FixedDataTableCellGroup
         key="scrollable_cells"
         isScrolling={this.props.isScrolling}
         height={this.props.height}
         cellGroupWrapperHeight={this.props.cellGroupWrapperHeight}
+        align="right"
         left={this.props.scrollLeft}
         offsetLeft={fixedColumnsWidth}
-        width={this.props.width - fixedColumnsWidth}
+        width={this.props.width - fixedColumnsWidth - fixedRightColumnsWidth}
         zIndex={0}
         columns={this.props.scrollableColumns}
         touchEnabled={this.props.touchEnabled}
@@ -228,6 +257,8 @@ class FixedDataTableRowImpl extends React.Component {
           {fixedColumns}
           {scrollableColumns}
           {columnsLeftShadow}
+          {fixedRightColumns}
+          {fixedRightColumnsShdadow}
         </div>
         {rowExpanded && <div
           className={cx('fixedDataTableRowLayout/rowExpanded')}
@@ -272,6 +303,22 @@ class FixedDataTableRowImpl extends React.Component {
        height: dividerHeight
      };
      return <div className={className} style={style} />;
+  };
+
+  _renderFixedRightColumnsShadow = (/*number*/ left) => /*?object*/ {
+    var className = cx(
+      'fixedDataTableRowLayout/columnsShadow',
+      'fixedDataTableRowLayout/columnsRightShadow',
+      'fixedDataTableRowLayout/fixedColumnsDivider',
+      'public/fixedDataTableRow/columnsShadow',
+      'public/fixedDataTableRow/columnsRightShadow',
+      'public/fixedDataTableRow/fixedColumnsDivider'
+    );
+    var style = {
+      height: this.props.height,
+      left: left
+    };
+    return <div className={className} style={style} />;
   };
 
   _renderColumnsRightShadow = (/*number*/ totalWidth) => /*?object*/ {

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -25,6 +25,7 @@ function _extractProps(column) {
     'columnKey',
     'flexGrow',
     'fixed',
+    'fixedRight',
     'maxWidth',
     'minWidth',
     'isReorderable',

--- a/src/selectors/columnTemplates.js
+++ b/src/selectors/columnTemplates.js
@@ -36,7 +36,6 @@ let columnDetails;
  * @param {{
  *   columnGroupProps: !Array.<!Object>,
  *   columnProps: !Array.<!Object>,
- *   }>,
  * }} columnWidths
  * @param {{
  *   cell: !Array.<ReactElement>,
@@ -46,8 +45,10 @@ let columnDetails;
  * }} elementTemplates
  * @return {{
  *   fixedColumnGroups: !Array.<cellDetails>,
+ *   fixedRightColumnGroups: !Array.<cellDetails>,
  *   scrollableColumnGroups: !Array.<cellDetails>,
  *   fixedColumns: !Array.<columnDetails>,
+ *   fixedRightColumns: !Array.<columnDetails>,
  *   scrollableColumns: !Array.<columnDetails>,
  * }}
  */
@@ -58,6 +59,7 @@ function columnTemplates(columnWidths, elementTemplates) {
   // TODO (jordan) figure out if this can efficiently be merged with
   // the result of convertColumnElementsToData.
   const fixedColumnGroups = [];
+  const fixedRightColumnGroups = [];
   const scrollableColumnGroups = [];
   forEach(columnGroupProps, (columnGroup, index) => {
     const groupData = {
@@ -66,12 +68,19 @@ function columnTemplates(columnWidths, elementTemplates) {
     };
     if (columnGroup.fixed) {
       fixedColumnGroups.push(groupData);
+    } else if (columnGroup.fixedRight) {
+      fixedRightColumnGroups.push(groupData);
     } else {
       scrollableColumnGroups.push(groupData);
     }
   });
 
   const fixedColumns = {
+    cell: [],
+    header: [],
+    footer: [],
+  };
+  const fixedRightColumns = {
     cell: [],
     header: [],
     footer: [],
@@ -85,6 +94,8 @@ function columnTemplates(columnWidths, elementTemplates) {
     let columnContainer = scrollableColumns;
     if (column.fixed) {
       columnContainer = fixedColumns;
+    } else if (column.fixedRight) {
+      columnContainer = fixedRightColumns;
     }
 
     columnContainer.cell.push({
@@ -104,6 +115,8 @@ function columnTemplates(columnWidths, elementTemplates) {
   return {
     fixedColumnGroups,
     fixedColumns,
+    fixedRightColumnGroups,
+    fixedRightColumns,
     scrollableColumnGroups,
     scrollableColumns,
   };

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -11,14 +11,15 @@
 import { getTotalFlexGrow, getTotalWidth } from 'widthHelper';
 import Scrollbar from 'Scrollbar';
 import forEach from 'lodash/forEach';
+import groupBy from 'lodash/groupBy';
 import map from 'lodash/map';
-import partition from 'lodash/partition';
 import scrollbarsVisible from 'scrollbarsVisible';
 import shallowEqualSelector from 'shallowEqualSelector';
 
 /**
  * @typedef {{
  *   fixed: boolean,
+ *   fixedRight: boolean,
  *   flexGrow: number,
  *   width: number,
  * }}
@@ -47,10 +48,11 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     newColumnGroupProps,
     newColumnProps,
   } = flexWidths(columnGroupProps, columnProps, viewportWidth);
-  const [
+  const {
     fixedColumns,
+    fixedRightColumns,
     scrollableColumns,
-  ] = partition(newColumnProps, column => column.fixed);
+  } = groupBy(newColumnProps, getColumnCategory);
 
   const availableScrollWidth = viewportWidth - getTotalWidth(fixedColumns);
   const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
@@ -59,6 +61,7 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     columnProps: newColumnProps,
     availableScrollWidth,
     fixedColumns,
+    fixedRightColumns,
     scrollableColumns,
     maxScrollX,
   };
@@ -118,6 +121,20 @@ function flexWidths(columnGroupProps, columnProps, viewportWidth) {
     newColumnGroupProps,
     newColumnProps,
   };
+}
+
+/**
+ * @param {!columnDefinition} columnProp
+ * @return {!string}
+ */
+function getColumnCategory(columnProp) {
+  if (columnProp.fixed) {
+    return 'fixedColumns';
+  } else if (columnProp.fixedRight) {
+    return 'fixedRightColumns';
+  } else {
+    return 'scrollableColumns';
+  }
 }
 
 export default shallowEqualSelector([

--- a/src/selectors/tableHeights.js
+++ b/src/selectors/tableHeights.js
@@ -36,6 +36,7 @@ import shallowEqualSelector from 'shallowEqualSelector';
  *   contentHeight: number,
  *   footOffsetTop: number,
  *   scrollbarXOffsetTop: number,
+ *   scrollbarYHeight: number,
  *   visibleRowsHeight: number,
  * }}
  */
@@ -80,6 +81,7 @@ function tableHeights(elementHeights, ownerHeight, reservedHeight,
   const bodyOffsetTop = groupHeaderHeight + headerHeight;
   const footOffsetTop = bodyOffsetTop + visibleRowsHeight;
   const scrollbarXOffsetTop = footOffsetTop + footerHeight;
+  const scrollbarYHeight = Math.max(0, footOffsetTop - bodyOffsetTop);
 
   return {
     bodyHeight,
@@ -88,6 +90,7 @@ function tableHeights(elementHeights, ownerHeight, reservedHeight,
     contentHeight,
     footOffsetTop,
     scrollbarXOffsetTop,
+    scrollbarYHeight,
     visibleRowsHeight,
   };
 }


### PR DESCRIPTION
This PR is for merging commits from '0a26dd1' (inclusive) till 'ff24111', from master into v1.0-beta.
Changes made through release bumps (dist + root version) were undone.
## List of commits
1. Added support to fix columns to the right side of the table. (#250) 0a26dd1
2. Version 0.8.4 b7e8f8b
3. Fix issues related to fixRight columns. (#253) 4924419
4. Version 0.8.5 13ca6c3
5. Handle page up/down events on the table (#207) 9581f91
6. Version 0.8.6 ff24111

## How Has This Been Tested?
For 9581f91 (Keyboard navigation), used existing example and passed in the two props. Verified that the props `keyboardPageEnabled `and `keyboardScrollEnabled `control scrolling via page keys and arrow keys, respectively.
For 0a26dd1 (Fix Columns to right), verified that the new example works just like the one in master (see [here](http://schrodinger.github.io/fixed-data-table-2/fixed-right-columns.html)).
