### PR TITLE
Changes for the merging range of commits [ff24111, aeddac0] from master into v1.0-beta

### DIFF
--- a/site/Constants.js
+++ b/site/Constants.js
@@ -40,7 +40,7 @@ exports.ExamplePages = {
     location: 'fixed-right-columns.html',
     fileName: 'FixedRightColumnsExample.js',
     title: 'Fixed Right Columns',
-    description: 'A table example that has a columns fixed to the right side of the table.',
+    description: 'A table example that has its columns fixed to the right side of the table.',
   },
   FLEXGROW_EXAMPLE: {
     location: 'example-flexgrow.html',

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -642,6 +642,7 @@ class FixedDataTable extends React.Component {
           onColumnResize={this._onColumnResize}
           onColumnReorder={onColumnReorder}
           onColumnReorderMove={this._onColumnReorderMove}
+          showScrollbarY={scrollEnabledY}
         />
       );
     }
@@ -705,6 +706,7 @@ class FixedDataTable extends React.Component {
           fixedRightColumns={fixedRightColumns.footer}
           scrollableColumns={scrollableColumns.footer}
           scrollLeft={scrollX}
+          showScrollbarY={scrollEnabledY}
         />;
     }
 
@@ -737,6 +739,7 @@ class FixedDataTable extends React.Component {
         onColumnReorderEnd={this._onColumnReorderEnd}
         isColumnReordering={!!isColumnReordering}
         columnReorderingData={columnReorderingData}
+        showScrollbarY={scrollEnabledY}
       />;
 
     let topShadow;
@@ -807,6 +810,7 @@ class FixedDataTable extends React.Component {
 
   _renderRows = (/*number*/ offsetTop, fixedCellTemplates, fixedRightCellTemplates, scrollableCellTemplates,
     bodyHeight) /*object*/ => {
+    const { scrollEnabledY } = scrollbarsVisible(this.props);
     const props = this.props;
     return (
       <FixedDataTableBufferedRows
@@ -835,6 +839,7 @@ class FixedDataTable extends React.Component {
         width={props.tableSize.width}
         rowsToRender={props.rows}
         rowHeights={props.rowHeights}
+        showScrollbarY={scrollEnabledY}
       />
     );
   }
@@ -949,9 +954,13 @@ class FixedDataTable extends React.Component {
       x = x < 0 ? 0 : x;
       x = x > maxScrollX ? maxScrollX : x;
 
+      // This is a workaround to prevent content blurring. This happens when translate3d
+      // is applied with non-rounded values to elements having text.
+      var roundedX = Math.round(x);
+
       //NOTE (asif) This is a hacky workaround to prevent FDT from setting its internal state
-      if (onHorizontalScroll ? onHorizontalScroll(x) : true) {
-        scrollActions.scrollToX(x);
+      if (onHorizontalScroll ? onHorizontalScroll(roundedX) : true) {
+        scrollActions.scrollToX(roundedX);
       }
     }
 
@@ -973,8 +982,12 @@ class FixedDataTable extends React.Component {
       this._didScrollStart();
     }
 
-    if (onHorizontalScroll ? onHorizontalScroll(scrollPos) : true) {
-      scrollActions.scrollToX(scrollPos);
+    // This is a workaround to prevent content blurring. This happens when translate3d
+    // is applied with non-rounded values to elements having text.
+    var roundedScrollPos = Math.round(scrollPos);
+
+    if (onHorizontalScroll ? onHorizontalScroll(roundedScrollPos) : true) {
+      scrollActions.scrollToX(roundedScrollPos);
     }
     this._didScrollStop();
   }

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -50,6 +50,7 @@ class FixedDataTableBufferedRows extends React.Component {
     scrollTop: PropTypes.number.isRequired,
     scrollableColumns: PropTypes.array.isRequired,
     showLastRowBorder: PropTypes.bool,
+    showScrollbarY: PropTypes.bool,
     width: PropTypes.number.isRequired,
   }
 
@@ -130,6 +131,7 @@ class FixedDataTableBufferedRows extends React.Component {
           onTouchStart={props.onRowTouchStart}
           onTouchEnd={props.onRowTouchEnd}
           onTouchMove={props.onRowTouchMove}
+          showScrollbarY={props.showScrollbarY}
           className={joinClasses(
             rowClassNameGetter(rowIndex),
             cx('public/fixedDataTable/bodyRow'),

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -16,6 +16,7 @@ import FixedDataTableCellGroup from 'FixedDataTableCellGroup';
 import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
 import PropTypes from 'prop-types';
 import React from 'React';
+import Scrollbar from 'Scrollbar';
 import cx from 'cx';
 import joinClasses from 'joinClasses';
 import { sumPropWidths } from 'widthHelper';
@@ -187,13 +188,14 @@ class FixedDataTableRowImpl extends React.Component {
       />;
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
     var fixedRightColumnsWidth = sumPropWidths(this.props.fixedRightColumns);
+    var scrollbarOffset = this.props.showScrollbarY ? Scrollbar.SIZE : 0;
     var fixedRightColumns = 
       <FixedDataTableCellGroup
         key="fixed_right_cells"
         isScrolling={this.props.isScrolling}
         height={this.props.height}
         cellGroupWrapperHeight={this.props.cellGroupWrapperHeight}
-        offsetLeft={this.props.width - fixedRightColumnsWidth}
+        offsetLeft={this.props.width - fixedRightColumnsWidth - scrollbarOffset}
         width={fixedRightColumnsWidth}
         zIndex={2}
         columns={this.props.fixedRightColumns}
@@ -207,8 +209,8 @@ class FixedDataTableRowImpl extends React.Component {
         rowHeight={this.props.height}
         rowIndex={this.props.index}
       />;
-    var fixedRightColumnsShdadow = fixedRightColumnsWidth ?
-      this._renderFixedRightColumnsShadow(this.props.width - fixedRightColumnsWidth - 5) : null;
+    var fixedRightColumnsShadow = fixedRightColumnsWidth ?
+      this._renderFixedRightColumnsShadow(this.props.width - fixedRightColumnsWidth - scrollbarOffset - 5) : null;
     var scrollableColumns =
       <FixedDataTableCellGroup
         key="scrollable_cells"
@@ -218,7 +220,7 @@ class FixedDataTableRowImpl extends React.Component {
         align="right"
         left={this.props.scrollLeft}
         offsetLeft={fixedColumnsWidth}
-        width={this.props.width - fixedColumnsWidth - fixedRightColumnsWidth}
+        width={this.props.width - fixedColumnsWidth - fixedRightColumnsWidth - scrollbarOffset}
         zIndex={0}
         columns={this.props.scrollableColumns}
         touchEnabled={this.props.touchEnabled}
@@ -240,6 +242,20 @@ class FixedDataTableRowImpl extends React.Component {
       width: this.props.width,
     };
 
+    let scrollbarSpacer = null;
+    if (this.props.showScrollbarY) {
+      var spacerStyles = {
+        width: scrollbarOffset,
+        height: this.props.height,
+        left: this.props.width - scrollbarOffset,
+      };
+      scrollbarSpacer =
+        <div 
+          style={spacerStyles} 
+          className={cx('public/fixedDataTable/scrollbarSpacer')}
+        />;
+    }
+
     return (
       <div
         className={joinClasses(className, this.props.className)}
@@ -258,7 +274,8 @@ class FixedDataTableRowImpl extends React.Component {
           {scrollableColumns}
           {columnsLeftShadow}
           {fixedRightColumns}
-          {fixedRightColumnsShdadow}
+          {fixedRightColumnsShadow}
+          {scrollbarSpacer}
         </div>
         {rowExpanded && <div
           className={cx('fixedDataTableRowLayout/rowExpanded')}

--- a/src/css/style/fixedDataTable.css
+++ b/src/css/style/fixedDataTable.css
@@ -27,9 +27,15 @@
 }
 
 .public/fixedDataTable/header,
+.public/fixedDataTable/scrollbarSpacer,
 .public/fixedDataTable/header .public/fixedDataTableCell/main {
   background-color: var(--fbui-desktop-background-light);
   background-image: linear-gradient(#fff, #efefef);
+}
+
+.public/fixedDataTable/scrollbarSpacer {
+  position: absolute;
+  z-index: 99;
 }
 
 .public/fixedDataTable/footer .public/fixedDataTableCell/main {

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -71,9 +71,10 @@ function scrollTo(state, props, oldScrollToColumn, scrollX) {
   } = columnWidths(state);
   const fixedColumnsCount = fixedColumns.length;
 
-  const scrollToUnchanged = scrollToColumn === oldScrollToColumn
+  const noScrollableColumns = scrollableColumns.length === 0;
+  const scrollToUnchanged = scrollToColumn === oldScrollToColumn;
   const selectedColumnFixed = scrollToColumn < fixedColumnsCount;
-  if (isNil(scrollToColumn) || scrollToUnchanged || selectedColumnFixed) {
+  if (isNil(scrollToColumn) || scrollToUnchanged || selectedColumnFixed || noScrollableColumns) {
     return scrollX;
   }
 

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -64,17 +64,23 @@ function initialize(state, props, oldProps) {
  */
 function scrollTo(state, props, oldScrollToColumn, scrollX) {
   const { scrollToColumn } = props;
+  if (isNil(scrollToColumn)) {
+    return scrollX;
+  }
+
   const {
     availableScrollWidth,
     fixedColumns,
     scrollableColumns,
   } = columnWidths(state);
   const fixedColumnsCount = fixedColumns.length;
+  const scrollableColumnsCount = scrollableColumns.length;
 
-  const noScrollableColumns = scrollableColumns.length === 0;
+  const noScrollableColumns = scrollableColumnsCount === 0;
   const scrollToUnchanged = scrollToColumn === oldScrollToColumn;
   const selectedColumnFixed = scrollToColumn < fixedColumnsCount;
-  if (isNil(scrollToColumn) || scrollToUnchanged || selectedColumnFixed || noScrollableColumns) {
+  const selectedColumnFixedRight = scrollToColumn >= fixedColumnsCount + scrollableColumnsCount;
+  if (scrollToUnchanged || selectedColumnFixed || selectedColumnFixedRight || noScrollableColumns) {
     return scrollX;
   }
 

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -54,7 +54,7 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     scrollableColumns,
   } = groupColumns(newColumnProps);
 
-  const availableScrollWidth = viewportWidth - getTotalWidth(fixedColumns);
+  const availableScrollWidth = viewportWidth - getTotalWidth(fixedColumns) - getTotalWidth(fixedRightColumns);
   const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
   return {
     columnGroupProps: newColumnGroupProps,


### PR DESCRIPTION
This PR is for merging commits from ff24111 till aeddac0 (inclusive), from master into v1.0-beta.
Changes made through release bumps (dist + root version) were undone.

## List of commits

1. Version 0.8.6 ff24111
2. Add rounding to horizontal scroll (#262) e8f5a72
3. Version 0.8.7 59b74ef
4. Check old state while resizing (#269) b852bf2
5. scrollableColumnIndex and columnInfo.bodyScrollableColumn fix. (#259) 349c257
6. Scrollbar Padding With Fixed Right Columns (#265) 99c5df1
7. Version 0.8.8 6d3c02a
8. Fix regression around column resize state being retained too aggressively (#278) Fixes #276 a483994
9. Version 0.8.9 aeddac0

## How Has This Been Tested?
- For e8f5a72 (anti aliasing when horizontally scrolled?), used [existing example](https://schrodinger.github.io/fixed-data-table-2/example-resize.html). Verified that text is blurred (when horizontal scroll offset is not rounded to a integer)
- For a483994 and b852bf2, verified that the column width is set for the correct column while data is loading (mix of [js fiddle](https://jsfiddle.net/L60ae8bz/1/) found [here](https://github.com/schrodinger/fixed-data-table-2/issues/268#issuecomment-350039306) with [existing example](https://schrodinger.github.io/fixed-data-table-2/example-resize.html)).
- For 99c5df1, verified that spacing is correct with and without presence of scrollbar and/or fixed right columns.

## Notes
Verified that the issue I'd reffered [here](https://github.com/schrodinger/fixed-data-table-2/pull/375#issuecomment-451072404) has been fixed through this merge (because of 99c5df1).

