### PR TITLE
Changes for the merging range of commits [839dc0f, f3696c1] from master into v1.0-beta

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 ## Steps to Reproduce (for bugs)
 <!--- Provide a link to a live example, or - -->
-<!--- Fork the jsfiddle to reproduce https://jsfiddle.net/uq8osbp1/ ->
+<!--- Fork the jsfiddle to reproduce https://codepen.io/alphalpha/pen/oqKJgG ->
 
 ## Context
 <!--- How has this issue affected you? What are you trying to accomplish? -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 ## Steps to Reproduce (for bugs)
 <!--- Provide a link to a live example, or - -->
-<!--- Fork the jsfiddle to reproduce https://codepen.io/alphalpha/pen/oqKJgG ->
+<!--- Fork the CodePen to reproduce https://codepen.io/alphalpha/pen/oqKJgG ->
 
 ## Context
 <!--- How has this issue affected you? What are you trying to accomplish? -->

--- a/examples/ResizeExample.js
+++ b/examples/ResizeExample.js
@@ -44,6 +44,7 @@ class ResizeExample extends React.Component {
         rowsCount={dataList.getSize()}
         onColumnResizeEndCallback={this._onColumnResizeEndCallback}
         isColumnResizing={false}
+        touchScrollEnabled={true}
         width={1000}
         height={500}
         {...this.props}>

--- a/examples/SortExample.js
+++ b/examples/SortExample.js
@@ -99,7 +99,7 @@ class SortExample extends React.Component {
       if (valueA < valueB) {
         sortVal = -1;
       }
-      if (sortVal !== 0 && sortDir === SortTypes.ASC) {
+      if (sortVal !== 0 && sortDir === SortTypes.DESC) {
         sortVal = sortVal * -1;
       }
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -309,6 +309,11 @@ class FixedDataTable extends React.Component {
     /**
      * If enabled scroll events will not be propagated outside of the table.
      */
+    stopReactWheelPropagation: PropTypes.bool,
+
+    /**
+     * If enabled scroll events will not be propagated outside of the table.
+     */
     stopScrollPropagation: PropTypes.bool,
 
     /**
@@ -322,6 +327,11 @@ class FixedDataTable extends React.Component {
      * Callback that is called when a row is clicked.
      */
     onRowClick: PropTypes.func,
+
+    /**
+     * Callback that is called when a contextual-menu event happens on a row.
+     */
+    onRowContextMenu: PropTypes.func,
 
     /**
      * Callback that is called when a row is double clicked.
@@ -784,6 +794,7 @@ class FixedDataTable extends React.Component {
         onTouchEnd={this._touchHandler.onTouchEnd}
         onTouchMove={this._touchHandler.onTouchMove}
         onTouchCancel={this._touchHandler.onTouchCancel}
+        ref={this._onRef}
         style={{
           height: componentHeight,
           width
@@ -820,6 +831,7 @@ class FixedDataTable extends React.Component {
         height={bodyHeight}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}
+        onRowContextMenu={props.onRowContextMenu}
         onRowDoubleClick={props.onRowDoubleClick}
         onRowMouseUp={props.onRowMouseUp}
         onRowMouseDown={props.onRowMouseDown}
@@ -842,6 +854,12 @@ class FixedDataTable extends React.Component {
         showScrollbarY={scrollEnabledY}
       />
     );
+  }
+
+  _onRef = (div) => {
+    if (this.props.stopReactWheelPropagation) {
+      this._wheelHandler.setRoot(div);
+    }
   }
 
   /**

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -95,7 +95,7 @@ class FixedDataTableBufferedRows extends React.Component {
             scrollLeft={Math.round(props.scrollLeft)}
             visible={false}
             fixedColumns={props.fixedColumns}
-            fixedRightColumns={props.fixedColumns}
+            fixedRightColumns={props.fixedRightColumns}
             scrollableColumns={props.scrollableColumns}
           />
         );

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -25,6 +25,7 @@ class FixedDataTableBufferedRows extends React.Component {
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
+    onRowContextMenu: PropTypes.func,
     onRowDoubleClick: PropTypes.func,
     onRowMouseDown: PropTypes.func,
     onRowMouseUp: PropTypes.func,
@@ -94,6 +95,7 @@ class FixedDataTableBufferedRows extends React.Component {
             scrollLeft={Math.round(props.scrollLeft)}
             visible={false}
             fixedColumns={props.fixedColumns}
+            fixedRightColumns={props.fixedColumns}
             scrollableColumns={props.scrollableColumns}
           />
         );
@@ -123,6 +125,7 @@ class FixedDataTableBufferedRows extends React.Component {
           fixedRightColumns={props.fixedRightColumns}
           scrollableColumns={props.scrollableColumns}
           onClick={props.onRowClick}
+          onContextMenu={props.onRowContextMenu}
           onDoubleClick={props.onRowDoubleClick}
           onMouseDown={props.onRowMouseDown}
           onMouseUp={props.onRowMouseUp}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -242,8 +242,8 @@ class FixedDataTableCell extends React.Component {
           style={columnResizerStyle}
           onMouseDown={this._onColumnResizerMouseDown}
           onTouchStart={this.props.touchEnabled ? this._onColumnResizerMouseDown : null}
-          onTouchEnd={this.props.touchEnabled ? e => e.stopPropagation() : null}
-          onTouchMove={this.props.touchEnabled ? e => e.stopPropagation() : null}>
+          onTouchEnd={this.props.touchEnabled ? _suppressEvent : null}
+          onTouchMove={this.props.touchEnabled ? _suppressEvent : null}>
           <div
             className={joinClasses(
               cx('fixedDataTableCellLayout/columnResizerKnob'),
@@ -315,7 +315,8 @@ class FixedDataTableCell extends React.Component {
      * This prevents the rows from moving around when we resize the
      * headers on touch devices.
      */
-    if(this.props.touchEnabled) {
+    if (this.props.touchEnabled) {
+      event.preventDefault();
       event.stopPropagation();
     }
   }
@@ -327,6 +328,11 @@ class FixedDataTableCell extends React.Component {
       this.props.left,
       event
     );
+  }
+
+  _suppressEvent = (/*object*/ event) => {
+    event.preventDefault();
+    event.stopPropagation();
   }
 };
 

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -242,8 +242,8 @@ class FixedDataTableCell extends React.Component {
           style={columnResizerStyle}
           onMouseDown={this._onColumnResizerMouseDown}
           onTouchStart={this.props.touchEnabled ? this._onColumnResizerMouseDown : null}
-          onTouchEnd={this.props.touchEnabled ? _suppressEvent : null}
-          onTouchMove={this.props.touchEnabled ? _suppressEvent : null}>
+          onTouchEnd={this.props.touchEnabled ? this._suppressEvent : null}
+          onTouchMove={this.props.touchEnabled ? this._suppressEvent : null}>
           <div
             className={joinClasses(
               cx('fixedDataTableCellLayout/columnResizerKnob'),

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -105,6 +105,11 @@ class FixedDataTableRowImpl extends React.Component {
     onClick: PropTypes.func,
 
     /**
+     * Fire when a contextual-menu is requested above a row.
+     */
+    onContextMenu: PropTypes.func,
+
+    /**
      * Fire when a row is double clicked.
      */
     onDoubleClick: PropTypes.func,
@@ -260,6 +265,7 @@ class FixedDataTableRowImpl extends React.Component {
       <div
         className={joinClasses(className, this.props.className)}
         onClick={this.props.onClick ? this._onClick : null}
+        onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}
         onMouseDown={this.props.onMouseDown ? this._onMouseDown : null}
         onMouseUp={this.props.onMouseUp ? this._onMouseUp : null}
@@ -355,6 +361,10 @@ class FixedDataTableRowImpl extends React.Component {
 
   _onClick = (/*object*/ event) => {
     this.props.onClick(event, this.props.index);
+  };
+
+  _onContextMenu = (/*object*/ event) => {
+    this.props.onContextMenu(event, this.props.index)
   };
 
   _onDoubleClick = (/*object*/ event) => {

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -90,6 +90,8 @@ class Scrollbar extends React.PureComponent {
     zIndex: 99,
   }
 
+  _onRefFace = (ref) => this._faceRef = ref;
+
   render() /*?object*/ {
     if (!this.state.scrollable) {
       return null;
@@ -160,7 +162,7 @@ class Scrollbar extends React.PureComponent {
         style={mainStyle}
         tabIndex={0}>
         <div
-          ref={(r) => this._faceRef = r}
+          ref={this._onRefFace}
           className={faceClassName}
           style={faceStyle}
         />

--- a/src/vendor_upstream/dom/DOMMouseMoveTracker.js
+++ b/src/vendor_upstream/dom/DOMMouseMoveTracker.js
@@ -54,8 +54,7 @@ class DOMMouseMoveTracker {
    * in order to grab inital state.
    */
   captureMouseMoves(/*object*/ event) {
-    if (!this._eventMoveToken && !this._eventUpToken &&
-        !this._eventLeaveToken && !this._eventOutToken) {
+    if (!this._eventMoveToken && !this._eventUpToken && !this._eventLeaveToken) {
       this._eventMoveToken = EventListener.listen(
         this._domNode,
         'mousemove',
@@ -70,11 +69,6 @@ class DOMMouseMoveTracker {
         this._domNode,
         'mouseleave',
         this._onMouseEnd
-      );
-      this._eventOutToken = EventListener.listen(
-        this._domNode,
-        'mouseout',
-        this.onMouseEnd
       );
     }
 
@@ -111,29 +105,26 @@ class DOMMouseMoveTracker {
   }
 
   /**
-   * These releases all of the listeners on document.body.
+   * This releases all of the listeners on document.body.
    */
   releaseMouseMoves() {
-    if (this._eventMoveToken && this._eventUpToken &&
-        this._eventLeaveToken && this._eventOutToken) {
+    if (this._eventMoveToken && this._eventUpToken && this._eventLeaveToken) {
       this._eventMoveToken.remove();
       this._eventMoveToken = null;
       this._eventUpToken.remove();
       this._eventUpToken = null;
       this._eventLeaveToken.remove();
       this._eventLeaveToken = null;
-      this._eventOutToken.remove();
-      this._eventOutToken = null;
     }
 
     if (this._isTouchEnabled && this._eventTouchStartToken &&
         this._eventTouchMoveToken && this._eventTouchEndToken) {
-        this._eventTouchStartToken.remove();
-        this._eventTouchStartToken = null;
-        this._eventTouchMoveToken.remove();
-        this._eventTouchMoveToken = null;
-        this._eventTouchEndToken.remove();
-        this._eventTouchEndToken = null;
+      this._eventTouchStartToken.remove();
+      this._eventTouchStartToken = null;
+      this._eventTouchMoveToken.remove();
+      this._eventTouchMoveToken = null;
+      this._eventTouchEndToken.remove();
+      this._eventTouchEndToken = null;
     }
 
     if (this._animationFrameID !== null) {

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -36,6 +36,8 @@ class ReactWheelHandler {
     this._deltaX = 0;
     this._deltaY = 0;
     this._didWheel = this._didWheel.bind(this);
+    this._rootRef = null;
+
     if (typeof handleScrollX !== 'function') {
       handleScrollX = handleScrollX ?
         emptyFunction.thatReturnsTrue :
@@ -71,6 +73,10 @@ class ReactWheelHandler {
       return;
     }
 
+    if (this._rootRef && !this._contains(event.target)) {
+      return;
+    }
+
     this._deltaX += handleScrollX ? normalizedEvent.pixelX : 0;
     this._deltaY += handleScrollY ? normalizedEvent.pixelY : 0;
     event.preventDefault();
@@ -88,11 +94,26 @@ class ReactWheelHandler {
     }
   }
 
+  setRoot(rootRef) {
+    this._rootRef = rootRef;
+  }
+
   _didWheel() {
     this._animationFrameID = null;
     this._onWheelCallback(this._deltaX, this._deltaY);
     this._deltaX = 0;
     this._deltaY = 0;
+  }
+
+  _contains(target) {
+    var parent = target;
+    while (parent != document.body) {
+      if (parent === this._rootRef) {
+        return true;
+      }
+      parent = parent.parentNode;
+    }
+    return false;
   }
 }
 

--- a/test/FixedDataTableRoot-test.js
+++ b/test/FixedDataTableRoot-test.js
@@ -48,10 +48,12 @@ describe('FixedDataTableRoot', function() {
       return this._tableRef.state;
     }
 
+    _onRef = (ref) => this._tableRef = ref;
+
     render() {
       return (
         <Table
-          ref={(r) => this._tableRef = r}
+          ref={this._onRef}
           width={600}
           height={400}
           rowsCount={50}


### PR DESCRIPTION
This PR is for merging commits from 839dc0f till f3696c1(inclusive), from master into v1.0-beta.
Changes made through release bumps (dist + root version) were undone.

## List of commits
1. Fixed column resize on Android. (#280) 839dc0f
2. Version 0.8.10 89fa9ae
3. On row context menu (#301) 7af58f1
4. Version 0.8.11 f6c72f0
5. Reverse the direction of the header arrow in SortExample (#312) 7ddb0cd
6. Convert element refs to functions. (#315) 312e0f1
7. Updated issue template example reproduction link (#318) a29e7ec
8. Version 0.8.12 bc6651d
9. Suppress bubbling of onWheel events to FDT when child...  (#321) 333525d
10. Version 0.8.13 f3696c1

## How Has This Been Tested?
- For 7af58f1, verified that function handler passed as a prop (`onRowContextMenu`) is called with the correct row index.
- For 7ddb0cd, verified that both the sorting and the sort arrow is correct.
- For a29e7ec, checked that the new link is valid (is that all?)
- For 333525d, verified that passing the FF (`stopReactWheelPropagation`) as true, fixes the issue described [here](https://github.com/schrodinger/fixed-data-table-2/issues/316#issue-314234351).

## Notes
I couldn't test #280 839dc0f. The changes are present in this branch though.