### PR TITLE
Fix 'Touch scroll' example: Prevent touch events propagating out of FDT via inline CSS

### DIFF
--- a/examples/TouchScrollExample.js
+++ b/examples/TouchScrollExample.js
@@ -18,10 +18,18 @@ class TouchScrollExample extends React.Component {
   }
 
   render() {
-    let {dataList, collapsedRows} = this.state;
+    const { dataList } = this.state;
+
+    // Recent browser versions are making touch events passive by default. Unfortunately, React doesn't allow us
+    // to specify the event handlers as passive/active (see #6436 on facebook/react). This can lead to unneeded
+    // scrolling of parent containers of FDT. This style is a work around to fix this. By applying 'none' to
+    // touch-action, we are disabling touch events from propagating.
+    const tableParentStyle = {
+      'touch-action': 'none'
+    };
 
     return (
-      <div>
+      <div style={tableParentStyle}>
         <Table
           rowHeight={50}
           rowsCount={dataList.getSize()}


### PR DESCRIPTION
## Description
Added an inline style to the parent container of FDT, which sets 'touch-action' as 'none'. This will let touch events (occuring in FDT) to not propagate out of the parent container.

## Motivation and Context
Workaround for #225.

Recent browser versions are making touch events passive by default. Unfortunately, React doesn't allow us to specify the event handlers as passive/active (see #6436 on facebook/react). This can lead to unneeded scrolling of parent containers of FDT. By applying `touch-action: none` to an element, we are disabling the touch events from propagating (from said element).

## How Has This Been Tested?
Tested it in chrome on the [Touch scroll Example](https://schrodinger.github.io/fixed-data-table-2/example-touch-scroll.html). Verified that without the style, we'll have the issue described in #255.