### PR TITLE
Fix performance of scrolling

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -576,10 +576,6 @@ class FixedDataTable extends React.Component {
       this.props.scrollLeft !== nextProps.scrollLeft) {
       this._didScrollStart();
     }
-
-    // Cancel any pending debounced scroll handling and handle immediately.
-    this._didScrollStop.reset();
-    this._didScrollStopSync();
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Fix performance of scrolling

## Description
    
Done by not setting _isScrolling to false in componentWillReceiveProps
Now that scroll is performed by passing in updated props
we can allow the component to handle the scroll state rather than
setting it to false on receiving props

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #382 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in examples and verified we perform scroll optimizations of the CellGroup rendering after the fix is applied.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
