### PR TITLE
Replace base64 encoded shadow png images with css linear gradients

### DIFF
--- a/src/css/style/fixedDataTable.css
+++ b/src/css/style/fixedDataTable.css
@@ -44,11 +44,11 @@
 }
 
 .public/fixedDataTable/topShadow {
-  background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAYAAABP2FU6AAAAF0lEQVR4AWPUkNeSBhHCjJoK2twgFisAFagCCp3pJlAAAAAASUVORK5CYII=) repeat-x;
+  background-image: linear-gradient(180deg,rgba(0,0,0,0.1),rgba(0,0,0,0));
 }
 
 .public/fixedDataTable/bottomShadow {
-  background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAYAAABP2FU6AAAAHElEQVQI12MwNjZmZdAT1+Nm0JDWEGZQk1GTBgAWkwIeAEp52AAAAABJRU5ErkJggg==) repeat-x;
+  background-image: linear-gradient(0deg,rgba(0,0,0,0.1),rgba(0,0,0,0));
 }
 
 .public/fixedDataTable/horizontalScrollbar .public/Scrollbar/mainHorizontal {

--- a/src/css/style/fixedDataTableRow.css
+++ b/src/css/style/fixedDataTableRow.css
@@ -26,7 +26,7 @@
 }
 
 .public/fixedDataTableRow/columnsShadow {
-  background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAABCAYAAAD5PA/NAAAAFklEQVQIHWPSkNeSBmJhTQVtbiDNCgASagIIuJX8OgAAAABJRU5ErkJggg==) repeat-y;
+  background-image: linear-gradient(90deg, rgba(0,0,0,0.1), rgba(0,0,0,0));
 }
 
 .public/fixedDataTableRow/columnsRightShadow {


### PR DESCRIPTION
## Description
Replace base64 encoded png shadow images with equivalent CSS linear gradients.

## Motivation and Context
Allows component to be used with strict CSP policies.
Fixes issue #388 

## How Has This Been Tested?
Compared side by side that shadows looks the same as before.
Tested with latest Chrome, Firefox, IE11 and Edge browsers.
OS: Windows 10

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
