### PR TITLE
Customize scroll speed via props

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -27,10 +27,8 @@ import cx from 'cx';
 import debounceCore from 'debounceCore';
 import joinClasses from 'joinClasses';
 import scrollbarsVisible from 'scrollbarsVisible';
+import configSelector from 'config';
 import tableHeightsSelector from 'tableHeights';
-
-var ARROW_SCROLL_SPEED = 25;
-
 
 /**
  * Data grid component with fixed or scrollable header and columns.
@@ -436,6 +434,8 @@ class FixedDataTable extends React.Component {
   }
 
   componentWillMount() {
+    const { touchConfig } = configSelector(this.props);
+
     this._didScrollStop = debounceCore(this._didScrollStopSync, 200, this);
     this._onKeyDown = this._onKeyDown.bind(this);
 
@@ -450,7 +450,8 @@ class FixedDataTable extends React.Component {
       this._onScroll,
       this._shouldHandleTouchX,
       this._shouldHandleTouchY,
-      this.props.stopScrollPropagation
+      this.props.stopScrollPropagation,
+      touchConfig
     );
   }
 
@@ -509,6 +510,8 @@ class FixedDataTable extends React.Component {
 
   _onKeyDown(event) {
     const { scrollbarYHeight } = tableHeightsSelector(this.props);
+    const { scrollAmpltiude } = configSelector(this.props).keyboardConfig;
+
     if (this.props.keyboardPageEnabled) {
       switch (event.key) {
         case 'PageDown':
@@ -529,22 +532,22 @@ class FixedDataTable extends React.Component {
       switch (event.key) {
 
         case 'ArrowDown':
-          this._onScroll(0, ARROW_SCROLL_SPEED);
+          this._onScroll(0, scrollAmpltiude);
           event.preventDefault();
           break;
 
         case 'ArrowUp':
-          this._onScroll(0, ARROW_SCROLL_SPEED * -1);
+          this._onScroll(0, scrollAmpltiude * -1);
           event.preventDefault();
           break;
 
         case 'ArrowRight':
-          this._onScroll(ARROW_SCROLL_SPEED, 0);
+          this._onScroll(scrollAmpltiude, 0);
           event.preventDefault();
           break;
 
         case 'ArrowLeft':
-          this._onScroll(ARROW_SCROLL_SPEED * -1, 0);
+          this._onScroll(scrollAmpltiude * -1, 0);
           event.preventDefault();
           break;
 

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -84,6 +84,7 @@ class FixedDataTableContainer extends React.Component {
       'columnProps',
       'columnReorderingData',
       'columnResizingData',
+      'config',
       'elementHeights',
       'elementTemplates',
       'firstRowIndex',

--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -19,10 +19,12 @@
 import emptyFunction from 'emptyFunction';
 import requestAnimationFramePolyfill from 'requestAnimationFramePolyfill';
 
-var MOVE_AMPLITUDE = 1.6;
-var DECELERATION_AMPLITUDE = 1.6;
-var DECELERATION_FACTOR = 325;
-var TRACKER_TIMEOUT = 100;
+let DEFAULT_TOUCH_CONFIG = {
+  MOVE_AMPLITUDE: 1.6,
+  DECELERATION_AMPLITUDE: 1.6,
+  DECELERATION_FACTOR: 325,
+  TRACKER_TIMEOUT: 100,
+};
 
 class ReactTouchHandler {
   /**
@@ -35,7 +37,8 @@ class ReactTouchHandler {
     /*function*/ onTouchScroll,
     /*boolean|function*/ handleScrollX,
     /*boolean|function*/ handleScrollY,
-    /*?boolean|?function*/ stopPropagation
+    /*?boolean|?function*/ stopPropagation,
+    /*?object*/ touchConfig
   ) {
 
     // The animation frame id for the drag scroll
@@ -87,6 +90,7 @@ class ReactTouchHandler {
 
     this._handleScrollX = handleScrollX;
     this._handleScrollY = handleScrollY;
+    this._touchConfig = Object.extend({}, DEFAULT_TOUCH_CONFIG, touchConfig);
     this._stopPropagation = stopPropagation;
     this._onTouchScrollCallback = onTouchScroll;
 
@@ -101,6 +105,7 @@ class ReactTouchHandler {
   }
 
   onTouchStart(/*object*/ event) {
+    var TRACKER_TIMEOUT = this._touchConfig.TRACKER_TIMEOUT;
 
     // Start tracking drag delta for scrolling
     this._lastTouchX = event.touches[0].pageX;
@@ -149,6 +154,7 @@ class ReactTouchHandler {
 
   onTouchMove(/*object*/ event) {
 
+    var MOVE_AMPLITUDE = this._touchConfig.MOVE_AMPLITUDE;
     var moveX = event.touches[0].pageX;
     var moveY = event.touches[0].pageY;
 
@@ -215,6 +221,7 @@ class ReactTouchHandler {
     var elapsed = now - this._lastFrameTimestamp;
     var oldVelocityX = this._velocityX;
     var oldVelocityY = this._velocityY;
+    var TRACKER_TIMEOUT = this._touchConfig.TRACKER_TIMEOUT;
 
     // We compute velocity using a weighted average of the current velocity and the previous velocity
     // If the previous velocity is 0, put the full weight on the last 100 ms
@@ -262,6 +269,9 @@ class ReactTouchHandler {
    * This is called recursively on animation frames until the delta is below a threshold (5 pixels)
    */
   _autoScroll() {
+    var DECELERATION_AMPLITUDE = this._touchConfig.DECELERATION_AMPLITUDE;
+    var DECELERATION_FACTOR = this._touchConfig.DECELERATION_FACTOR;
+
     var elapsed = Date.now() - this._autoScrollTimestamp;
     var factor = DECELERATION_AMPLITUDE * Math.exp(-elapsed / DECELERATION_FACTOR);
     var deltaX = factor * this._velocityX;

--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -20,9 +20,10 @@ import emptyFunction from 'emptyFunction';
 import requestAnimationFramePolyfill from 'requestAnimationFramePolyfill';
 
 let DEFAULT_TOUCH_CONFIG = {
-  MOVE_AMPLITUDE: 1.6,
   DECELERATION_AMPLITUDE: 1.6,
-  DECELERATION_FACTOR: 325,
+  DECELERATION_FACTOR: 0.325,
+  DECELERATION_THRESHOLD: 5,
+  MOVE_AMPLITUDE: 1.6,
   TRACKER_TIMEOUT: 100,
 };
 
@@ -90,7 +91,7 @@ class ReactTouchHandler {
 
     this._handleScrollX = handleScrollX;
     this._handleScrollY = handleScrollY;
-    this._touchConfig = Object.extend({}, DEFAULT_TOUCH_CONFIG, touchConfig);
+    this._setTouchConfig(touchConfig);
     this._stopPropagation = stopPropagation;
     this._onTouchScrollCallback = onTouchScroll;
 
@@ -271,16 +272,17 @@ class ReactTouchHandler {
   _autoScroll() {
     var DECELERATION_AMPLITUDE = this._touchConfig.DECELERATION_AMPLITUDE;
     var DECELERATION_FACTOR = this._touchConfig.DECELERATION_FACTOR;
+    var DECELERATION_THRESHOLD = this._touchConfig.DECELERATION_THRESHOLD;
 
-    var elapsed = Date.now() - this._autoScrollTimestamp;
+    var elapsed = (Date.now() - this._autoScrollTimestamp)/1000;
     var factor = DECELERATION_AMPLITUDE * Math.exp(-elapsed / DECELERATION_FACTOR);
     var deltaX = factor * this._velocityX;
     var deltaY = factor * this._velocityY;
 
-    if (Math.abs(deltaX) <= 5 || !this._handleScrollX(deltaX, deltaY)) {
+    if (Math.abs(deltaX) <= DECELERATION_THRESHOLD || !this._handleScrollX(deltaX, deltaY)) {
       deltaX = 0;
     }
-    if (Math.abs(deltaY) <= 5 || !this._handleScrollY(deltaY, deltaX)) {
+    if (Math.abs(deltaY) <= DECELERATION_THRESHOLD || !this._handleScrollY(deltaY, deltaX)) {
       deltaY = 0;
     }
 
@@ -288,6 +290,11 @@ class ReactTouchHandler {
       this._onTouchScrollCallback(deltaX, deltaY);
       requestAnimationFramePolyfill(this._autoScroll);
     }
+  }
+
+  /* Sets the configuration. */
+  _setTouchConfig(/*object*/ touchConfig) {
+    this._touchConfig = Object.assign({}, DEFAULT_TOUCH_CONFIG, touchConfig);
   }
 }
 

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -503,11 +503,11 @@ class Scrollbar extends React.PureComponent {
   }
 
   getTouchX = (/*object*/ e) => {
-    return Math.round(e.targetTouches[0].pageX - e.target.getBoundingClientRect().x);
+    return Math.round(e.targetTouches[0].clientX - e.target.getBoundingClientRect().x);
   }
 
   getTouchY = (/*object*/ e) => {
-    return Math.round(e.targetTouches[0].pageY - e.target.getBoundingClientRect().y);
+    return Math.round(e.targetTouches[0].clientY - e.target.getBoundingClientRect().y);
   }
 
   _setNextState = (/*object*/ nextState, /*?object*/ props) => {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -35,6 +35,7 @@ function getInitialState() {
      */
     columnProps: [],
     columnGroupProps: [],
+    config: {},
     elementTemplates: {
       cell: [],
       footer: [],
@@ -224,6 +225,21 @@ function setStateFromProps(state, props) {
 
   const newState = Object.assign({}, state,
     { columnGroupProps, columnProps, elementTemplates });
+
+  newState.config = Object.assign({}, newState.config, pick(props.config, [
+      'touchAmplitude',
+      'touchDeceleration',
+      'touchDecelerationFactor',
+      'touchDecelerationThreshold',
+      'touchTimeout',
+      'touchThreshold',
+      'keyboardScrollAmplitude',
+      'wheelBaseFactor',
+      'wheelPixelAmplitude',
+      'wheelLineAmplitude',
+      'wheelPageAmplitude'
+    ])
+  );
 
   newState.elementHeights = Object.assign({}, newState.elementHeights,
     pick(props, ['cellGroupWrapperHeight', 'footerHeight', 'groupHeaderHeight', 'headerHeight']));

--- a/src/selectors/config.js
+++ b/src/selectors/config.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule config
+ */
+import shallowEqualSelector from 'shallowEqualSelector';
+
+const DEFAULT_CONFIG = {
+  keyboardConfig: {
+    scrollAmplitude: 25,
+  },
+  // react touch handler already provides the default values
+  touchConfig: {},
+  // react wheel handler already provides the default values
+  wheelConfig: {},
+};
+
+/**
+ * Compute the necessary heights for rendering parts of the table
+ *
+ * @param {{
+ *   keyboardScollAmplitude: number,
+ *   touchAmplitude: number,
+ *   touchDecelaration: number,
+ *   touchDecelarationFactor: number,
+ *   touchTimeout: number,
+ *   wheelPixelAmplitude: number,
+ *   wheelLineAmplitude: number,
+ *   wheelPageAmplitude: number
+ * }} config
+ * @return {{
+ *   keyboardConfig: {
+ *     scrollAmplitude: number
+ *   },
+ *   touchConfig: {
+ *     MOVE_AMPLITUDE: number,
+ *     DECELERATION_AMPLITUDE: number,
+ *     DECELERATION_FACTOR: number,
+ *     TRACKER_TIMEOUT: number
+ *   },
+ *   wheelConfig: {
+ *     PIXEL_STEP: number,
+ *     LINE_HEIGHT: number,
+ *     PAGE_HEIGHT: number
+ *   }
+ * }}
+ */
+function config(config) {
+  const touchConfig = {
+    MOVE_AMPLITUDE: config.touchAmplitude,
+    DECELERATION_AMPLITUDE: config.touchDecelaration,
+    DECELERATION_FACTOR: config.touchDecelarationFactor,
+    TRACKER_TIMEOUT: config.touchTimeout,
+  };
+
+  const keyboardConfig = {
+    scrollAmplitude: config.keyboardScollAmplitude,
+  };
+
+  const wheelConfig = {
+    PIXEL_STEP: config.wheelPixelAmplitude,
+    LINE_HEIGHT: config.wheelLineAmplitude,
+    PAGE_HEIGHT: config.wheelPageAmplitude,
+  };
+
+  return _.merge({}, DEFAULT_CONFIG, {
+    keyboardConfig,
+    touchConfig,
+    wheelConfig,
+  });
+}
+
+export default shallowEqualSelector(state.config, config);

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -30,8 +30,9 @@ class ReactWheelHandler {
     /*function*/ onWheel,
     /*boolean|function*/ handleScrollX,
     /*boolean|function*/ handleScrollY,
-    /*?boolean|?function*/ stopPropagation
-  ) {
+    /*?boolean|?function*/ stopPropagation,
+    /*?object*/ wheelConfig
+) {
     this._animationFrameID = null;
     this._deltaX = 0;
     this._deltaY = 0;
@@ -59,12 +60,13 @@ class ReactWheelHandler {
     this._handleScrollX = handleScrollX;
     this._handleScrollY = handleScrollY;
     this._stopPropagation = stopPropagation;
+    this._wheelConfig = wheelConfig;
     this._onWheelCallback = onWheel;
     this.onWheel = this.onWheel.bind(this);
   }
 
   onWheel(/*object*/ event) {
-    var normalizedEvent = normalizeWheel(event);
+    var normalizedEvent = normalizeWheel(event, this._wheelConfig);
     var deltaX = this._deltaX + normalizedEvent.pixelX;
     var deltaY = this._deltaY + normalizedEvent.pixelY;
     var handleScrollX = this._handleScrollX(deltaX, deltaY);

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -60,13 +60,16 @@ class ReactWheelHandler {
     this._handleScrollX = handleScrollX;
     this._handleScrollY = handleScrollY;
     this._stopPropagation = stopPropagation;
-    this._wheelConfig = wheelConfig;
+    this._setWheelConfig(wheelConfig);
     this._onWheelCallback = onWheel;
     this.onWheel = this.onWheel.bind(this);
   }
 
   onWheel(/*object*/ event) {
     var normalizedEvent = normalizeWheel(event, this._wheelConfig);
+    normalizedEvent.pixelX *= this._wheelConfig.baseFactor;
+    normalizedEvent.pixelY *= this._wheelConfig.baseFactor;
+
     var deltaX = this._deltaX + normalizedEvent.pixelX;
     var deltaY = this._deltaY + normalizedEvent.pixelY;
     var handleScrollX = this._handleScrollX(deltaX, deltaY);
@@ -116,6 +119,11 @@ class ReactWheelHandler {
       parent = parent.parentNode;
     }
     return false;
+  }
+
+  /* Sets the configuration. */
+  _setWheelConfig(/*object*/ wheelConfig) {
+    this._wheelConfig = wheelConfig;
   }
 }
 

--- a/src/vendor_upstream/dom/normalizeWheel.js
+++ b/src/vendor_upstream/dom/normalizeWheel.js
@@ -18,9 +18,11 @@ import isEventSupported from 'isEventSupported';
 
 
 // Reasonable defaults
-var PIXEL_STEP  = 10;
-var LINE_HEIGHT = 40;
-var PAGE_HEIGHT = 800;
+var DEFAULT_WHEEL_CONFIG = {
+  PIXEL_STEP: 10,
+  LINE_HEIGHT: 40,
+  PAGE_HEIGHT: 800,
+};
 
 /**
  * Mouse wheel (and 2-finger trackpad) support on the web sucks.  It is
@@ -122,7 +124,11 @@ var PAGE_HEIGHT = 800;
  *         Firefox v4/Win7  |     undefined    |       3
  *
  */
-function normalizeWheel(/*object*/ event) /*object*/ {
+function normalizeWheel(/*object*/ event, /*?object*/wheelConfig = {}) /*object*/ {
+  var PIXEL_STEP = wheelConfig.PIXEL_STEP || DEFAULT_WHEEL_CONFIG.PIXEL_STEP;
+  var LINE_HEIGHT = wheelConfig.LINE_HEIGHT || DEFAULT_WHEEL_CONFIG.PIXEL_STEP;
+  var PAGE_HEIGHT = wheelConfig.PAGE_HEIGHT || DEFAULT_WHEEL_CONFIG.PIXEL_STEP;
+  
   var sX = 0, sY = 0,       // spinX, spinY
       pX = 0, pY = 0;       // pixelX, pixelY
 

--- a/src/vendor_upstream/dom/normalizeWheel.js
+++ b/src/vendor_upstream/dom/normalizeWheel.js
@@ -19,9 +19,9 @@ import isEventSupported from 'isEventSupported';
 
 // Reasonable defaults
 var DEFAULT_WHEEL_CONFIG = {
-  PIXEL_STEP: 10,
   LINE_HEIGHT: 40,
   PAGE_HEIGHT: 800,
+  PIXEL_STEP: 10,
 };
 
 /**
@@ -126,8 +126,8 @@ var DEFAULT_WHEEL_CONFIG = {
  */
 function normalizeWheel(/*object*/ event, /*?object*/wheelConfig = {}) /*object*/ {
   var PIXEL_STEP = wheelConfig.PIXEL_STEP || DEFAULT_WHEEL_CONFIG.PIXEL_STEP;
-  var LINE_HEIGHT = wheelConfig.LINE_HEIGHT || DEFAULT_WHEEL_CONFIG.PIXEL_STEP;
-  var PAGE_HEIGHT = wheelConfig.PAGE_HEIGHT || DEFAULT_WHEEL_CONFIG.PIXEL_STEP;
+  var LINE_HEIGHT = wheelConfig.LINE_HEIGHT || DEFAULT_WHEEL_CONFIG.LINE_HEIGHT;
+  var PAGE_HEIGHT = wheelConfig.PAGE_HEIGHT || DEFAULT_WHEEL_CONFIG.PAGE_HEIGHT;
   
   var sX = 0, sY = 0,       // spinX, spinY
       pX = 0, pY = 0;       // pixelX, pixelY


### PR DESCRIPTION
FDT currently has no support for configuring the scroll speed through props.

## Description
Added a config prop that is used by FDT to customize props.
This prop contains all the values used for customizing scrolling.
The config selector will return the grouped configuration and also handle default/undefined values.
Most of these are used by ReactTouchHandler and ReactWheelHandler.

## Motivation and Context
Fixes (#220)
Helps (#309)

## How Has This Been Tested?
This isn't heavily tested, although I did verify that scroll behavior is changed according to values from config prop. I wanted to see if the current approach is in the right direction before I spend too much time on this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.