### PR TITLE
Fix controlled scrolling

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -575,6 +575,7 @@ class FixedDataTable extends React.Component {
       this.props.scrollTop !== nextProps.scrollTop ||
       this.props.scrollLeft !== nextProps.scrollLeft) {
       this._didScrollStart();
+      this._didScrollStop();
     }
 
     this._didScrollJump(nextProps);

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -575,7 +575,7 @@ class FixedDataTable extends React.Component {
       this.props.scrollTop !== nextProps.scrollTop ||
       this.props.scrollLeft !== nextProps.scrollLeft) {
       this._didScrollStart();
-      this._didScrollStop();
+      this._didScrollStopSync();
     }
 
     this._didScrollJump(nextProps);

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -14,6 +14,7 @@
 import emptyFunction from 'emptyFunction';
 import isNil from 'lodash/isNil';
 import columnWidths from 'columnWidths';
+import clamp from 'lodash/clamp';
 
 const DRAG_SCROLL_SPEED = 15;
 const DRAG_SCROLL_BUFFER = 100;
@@ -43,7 +44,7 @@ function initialize(state, props, oldProps) {
   const scrollJumpedX = scrollX != scrollXAfterScrollLeft;
 
   const { maxScrollX } = columnWidths(state);
-  scrollX = Math.min(scrollX, maxScrollX);
+  scrollX = clamp(scrollX, 0, maxScrollX);
 
   // isColumnResizing should be overwritten by value from props if available
   isColumnResizing = props.isColumnResizing !== undefined ? props.isColumnResizing : isColumnResizing;

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -37,11 +37,7 @@ function initialize(state, props, oldProps) {
     scrollX = scrollLeft;
   }
 
-  const scrollXAfterScrollLeft = scrollX;
   scrollX = scrollTo(state, props, oldProps.scrollToColumn, scrollX);
-
-  // if scrollX changed due to scrollToColumn, then set scrollJumpedX
-  const scrollJumpedX = scrollX != scrollXAfterScrollLeft;
 
   const { maxScrollX } = columnWidths(state);
   scrollX = clamp(scrollX, 0, maxScrollX);
@@ -50,6 +46,7 @@ function initialize(state, props, oldProps) {
   isColumnResizing = props.isColumnResizing !== undefined ? props.isColumnResizing : isColumnResizing;
   columnResizingData = isColumnResizing ? columnResizingData : {};
 
+  const scrollJumpedX = scrollX != state.scrollX;
 
   return Object.assign({}, state, {
     columnResizingData,

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -36,10 +36,11 @@ function initialize(state, props, oldProps) {
     scrollX = scrollLeft;
   }
 
+  const scrollXAfterScrollLeft = scrollX;
   scrollX = scrollTo(state, props, oldProps.scrollToColumn, scrollX);
 
-  // if scrollX changed due to scrollLeft or scrollToColumn, then set scrollJumpedX
-  const scrollJumpedX = scrollX != state.scrollX;
+  // if scrollX changed due to scrollToColumn, then set scrollJumpedX
+  const scrollJumpedX = scrollX != scrollXAfterScrollLeft;
 
   const { maxScrollX } = columnWidths(state);
   scrollX = Math.min(scrollX, maxScrollX);

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+import clamp from 'lodash/clamp';
 import updateRowHeight from 'updateRowHeight';
 import roughHeightsSelector from 'roughHeights';
 import scrollbarsVisibleSelector from 'scrollbarsVisible';
@@ -58,7 +59,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
   if (rowsCount > 0) {
     scrollY = newState.rowHeights[rowRange.firstViewportIdx] - newState.firstRowOffset;
   }
-  scrollY = Math.min(scrollY, maxScrollY);
+  scrollY = clamp(scrollY, 0, maxScrollY);
 
   return Object.assign(newState, {
     maxScrollY,

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -29,6 +29,7 @@ import tableHeightsSelector from 'tableHeights';
  *   firstIndex: number,
  *   firstOffset: number,
  *   lastIndex: number,
+ *   scrollJumpedY: boolean,
  * }} scrollAnchor
  * @return {!Object} The updated state object
  */
@@ -59,11 +60,13 @@ export default function computeRenderedRows(state, scrollAnchor) {
   if (rowsCount > 0) {
     scrollY = newState.rowHeights[rowRange.firstViewportIdx] - newState.firstRowOffset;
   }
+  const scrollJumpedY = (scrollAnchor.scrollJumpedY === true) && (scrollY !== state.scrollY);
   scrollY = clamp(scrollY, 0, maxScrollY);
 
   return Object.assign(newState, {
     maxScrollY,
     scrollY,
+    scrollJumpedY,
   });
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -135,8 +135,6 @@ function reducers(state = getInitialState(), action) {
         newState = computeRenderedRows(newState, scrollAnchor);
       }
 
-      newState.scrollJumpedY = scrollAnchor.didScrollToRow;
-
       newState = columnStateHelper.initialize(newState, newProps, oldProps);
 
       // TODO REDUX_MIGRATION solve w/ evil-diff

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,7 +15,6 @@ import { getScrollAnchor, scrollTo } from 'scrollAnchor';
 import * as ActionTypes from 'ActionTypes';
 import IntegerBufferSet from 'IntegerBufferSet';
 import PrefixIntervalTree from 'PrefixIntervalTree';
-import clamp from 'lodash/clamp';
 import columnStateHelper from 'columnStateHelper'
 import computeRenderedRows from 'computeRenderedRows';
 import convertColumnElementsToData from 'convertColumnElementsToData';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,6 +15,7 @@ import { getScrollAnchor, scrollTo } from 'scrollAnchor';
 import * as ActionTypes from 'ActionTypes';
 import IntegerBufferSet from 'IntegerBufferSet';
 import PrefixIntervalTree from 'PrefixIntervalTree';
+import clamp from 'lodash/clamp';
 import columnStateHelper from 'columnStateHelper'
 import computeRenderedRows from 'computeRenderedRows';
 import convertColumnElementsToData from 'convertColumnElementsToData';

--- a/src/reducers/scrollAnchor.js
+++ b/src/reducers/scrollAnchor.js
@@ -29,7 +29,7 @@ import scrollbarsVisibleSelector from 'scrollbarsVisible';
  *   firstOffset: number,
  *   lastIndex: number,
  *   changed: boolean,
- *   didScrollToRow: (boolean|undefined),
+ *   scrollJumpedY: boolean,
  * }}
  */
 export function getScrollAnchor(state, newProps, oldProps) {
@@ -37,13 +37,16 @@ export function getScrollAnchor(state, newProps, oldProps) {
       newProps.scrollToRow !== null &&
       (!oldProps || newProps.scrollToRow !== oldProps.scrollToRow)) {
     const scrollAnchor = scrollToRow(state, newProps.scrollToRow);
-    return set(scrollAnchor, 'didScrollToRow', scrollAnchor.changed);
+    return set(scrollAnchor, 'scrollJumpedY', scrollAnchor.changed);
   }
 
   if (newProps.scrollTop !== undefined &&
       newProps.scrollTop !== null &&
       (!oldProps || newProps.scrollTop !== oldProps.scrollTop)) {
-    return scrollTo(state, newProps.scrollTop);
+    const scrollAnchor = scrollTo(state, newProps.scrollTop);
+    // 'changed' might give false positives to scrollJumpedY,
+    // but that's fine as the final value is determined by computeRenderedRows.
+    return set(scrollAnchor, 'scrollJumpedY', scrollAnchor.changed);
   }
 
   return {
@@ -51,6 +54,7 @@ export function getScrollAnchor(state, newProps, oldProps) {
     firstOffset: state.firstRowOffset,
     lastIndex: undefined,
     changed: false,
+    scrollJumpedY: false,
   }
 }
 

--- a/test/reducers/columnStateHelper-test.js
+++ b/test/reducers/columnStateHelper-test.js
@@ -238,6 +238,7 @@ describe('columnStateHelper', function() {
       assert.deepEqual(result, Object.assign({}, oldState, {
         maxScrollX: 400,
         scrollX: 400,
+        scrollJumpedX: true,
       }));
     });
 
@@ -249,6 +250,7 @@ describe('columnStateHelper', function() {
       assert.deepEqual(result, Object.assign({}, oldState, {
         maxScrollX: 400,
         scrollX: 100,
+        scrollJumpedX: true,
       }));
     });
 

--- a/test/reducers/columnStateHelper-test.js
+++ b/test/reducers/columnStateHelper-test.js
@@ -249,7 +249,6 @@ describe('columnStateHelper', function() {
       assert.deepEqual(result, Object.assign({}, oldState, {
         maxScrollX: 400,
         scrollX: 100,
-        scrollJumpedX: true,
       }));
     });
 

--- a/test/reducers/computeRenderedRows-test.js
+++ b/test/reducers/computeRenderedRows-test.js
@@ -48,6 +48,7 @@ describe('computeRenderedRows', function() {
         },
         storedHeights: initialStoredHeights,
         scrollContentHeight: 10000,
+        scrollJumpedY: false,
       };
     });
 

--- a/test/reducers/scrollAnchor-test.js
+++ b/test/reducers/scrollAnchor-test.js
@@ -37,6 +37,7 @@ describe('scrollAnchor', function() {
         firstOffset: -50,
         lastIndex: undefined,
         changed: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -47,6 +48,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: undefined,
         changed: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -57,6 +59,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: 99,
         changed: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -69,6 +72,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: undefined,
         changed: true,
+        scrollJumpedY: true,
       });
     });
   });
@@ -102,7 +106,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: 40,
         changed: true,
-        didScrollToRow: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -115,7 +119,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: undefined,
         changed: true,
-        didScrollToRow: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -130,7 +134,7 @@ describe('scrollAnchor', function() {
         firstOffset: 50,
         lastIndex: undefined,
         changed: false,
-        didScrollToRow: false,
+        scrollJumpedY: false,
       });
     });
 
@@ -145,7 +149,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: undefined,
         changed: true,
-        didScrollToRow: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -158,7 +162,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: undefined,
         changed: true,
-        didScrollToRow: true,
+        scrollJumpedY: true,
       });
     });
 
@@ -171,7 +175,7 @@ describe('scrollAnchor', function() {
         firstOffset: 0,
         lastIndex: 99,
         changed: true,
-        didScrollToRow: true,
+        scrollJumpedY: true,
       });
     });
   });


### PR DESCRIPTION
Unset scrolling state after controlled scrolling.

## Description
In componentWillReceiveProps, we are calling _didScrollStart when controlled scrolling has occured. In v1.0-beta, due to [removal of _didScrollStop](https://github.com/schrodinger/fixed-data-table-2/commit/675a7b9ba65490eb27568e958650d41a5ed1d598#diff-293ddd101833c33e0069803f5068f2f7L580) via 675a7b9, scrolling state is never being unset.

## Motivation and Context
In our product we use scrollLeft and scrollTop for controlled scrolling. We noticed that after such a scroll has happened, the scrolling state is not turned back off. This leads to column resizing issues.

## How Has This Been Tested?
Verified that scrolling state is turned off and column resizing works as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
