### PR TITLE
Fix scrollbarSpacer being pushed down.

### DIFF
--- a/src/css/style/fixedDataTable.css
+++ b/src/css/style/fixedDataTable.css
@@ -36,6 +36,7 @@
 .public/fixedDataTable/scrollbarSpacer {
   position: absolute;
   z-index: 99;
+  top: 0;
 }
 
 .public/fixedDataTable/footer .public/fixedDataTableCell/main {


### PR DESCRIPTION
Pull scrollbarSpacer correctly on a vertical level.

## Description
When no scrolling is applied, ColumnsLeftShadow is rendered without any style but implicitly has height of the row ([see render](https://github.com/schrodinger/fixed-data-table-2/blob/master/src/FixedDataTableRow.js#L314)).
Now, scrollbarSpacer will be rendered **below** the ColumnsLeftShadow (normal div behavior), and hence there's no one to cover the space above the scrollbar.

The fix is to either make ColumnsLeftShadow be positioned absolutely so that it won't affect scrollbarSpacer, just set top as 0.

## Motivation and Context
Fixes #291. 

## How Has This Been Tested?
Tested using the example found in #291

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
