### PR TITLE
Replace didScrollStopSync() call with async one when props are about to change

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -594,11 +594,8 @@ var FixedDataTable = createReactClass({
         this.props.scrollTop !== nextProps.scrollTop ||
         this.props.scrollLeft !== nextProps.scrollLeft) {
       this._didScrollStart();
+      this._didScrollStop();
     }
-
-    // Cancel any pending debounced scroll handling and handle immediately.
-    this._didScrollStop.reset();
-    this._didScrollStop();
 
     this.setState(this._calculateState(nextProps, this.state));
   },

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -598,7 +598,7 @@ var FixedDataTable = createReactClass({
 
     // Cancel any pending debounced scroll handling and handle immediately.
     this._didScrollStop.reset();
-    this._didScrollStopSync();
+    this._didScrollStop();
 
     this.setState(this._calculateState(nextProps, this.state));
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
when controlling the scroll position, there is a significant drop in performance with scrolling after the changes in PR #226. `didScrollStopSync()` should indeed be called in `componentWillUnmount()` to prevent `setState` from getting called after the component is unmounted, but i'm pretty sure that the async version can still be called in `componentWillReceiveProps`.

when calling the synchronous (non-debounced) version in `componentWillUnmount`, the `onScrollEnd` callback is called on every scroll "step". we are doing some pretty heavy re-rendering after that function is called which explains the dramatic drop in performance.

## Motivation and Context
we are stuck in 0.8.0 since the performance in 0.8.1 is so much worse.

## How Has This Been Tested?
i manually tested unmounting the component while scrolling was in action and there was no warning about calling `setState` on an unmounted component.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
