### PR TITLE
Fix scrolling prop used in FixedDataTable (beta)

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -818,11 +818,11 @@ class FixedDataTable extends React.Component {
 
   _renderRows = (/*number*/ offsetTop, fixedCellTemplates, fixedRightCellTemplates, scrollableCellTemplates,
     bodyHeight) /*object*/ => {
-    const { scrollEnabledY, scrolling } = scrollbarsVisible(this.props);
+    const { scrollEnabledY } = scrollbarsVisible(this.props);
     const props = this.props;
     return (
       <FixedDataTableBufferedRows
-        isScrolling={scrolling}
+        isScrolling={props.scrolling}
         fixedColumns={fixedCellTemplates}
         fixedRightColumns={fixedRightCellTemplates}
         height={bodyHeight}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `scrolling` prop was wrongly taken from a selector, instead of from the `this.props`.
Tracing back the change, the bug was [added](https://github.com/schrodinger/fixed-data-table-2/pull/385/files#diff-293ddd101833c33e0069803f5068f2f7R828) as part of #385  by me :(

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #399 partially.

## How Has This Been Tested?
Checked that the scrolling prop is correctly passed to the cell. 
Earlier (without this change), it was always false.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
