### PR TITLE
Viewport row buffering while scrolling (second iteration)

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -825,8 +825,8 @@ class FixedDataTable extends React.Component {
         isScrolling={props.scrolling}
         fixedColumns={fixedCellTemplates}
         fixedRightColumns={fixedRightCellTemplates}
-        firstRowIndex={props.firstRowIndex}
-        endRowIndex={props.endRowIndex}
+        firstViewportRowIndex={props.firstRowIndex}
+        endViewportRowIndex={props.endRowIndex}
         height={bodyHeight}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -825,6 +825,8 @@ class FixedDataTable extends React.Component {
         isScrolling={props.scrolling}
         fixedColumns={fixedCellTemplates}
         fixedRightColumns={fixedRightCellTemplates}
+        firstRowIndex={props.firstRowIndex}
+        endRowIndex={props.endRowIndex}
         height={bodyHeight}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -21,6 +21,8 @@ import inRange from 'lodash/inRange';
 class FixedDataTableBufferedRows extends React.Component {
   static propTypes = {
     isScrolling: PropTypes.bool,
+    firstViewportRowIndex: PropTypes.number.isRequired,
+    endViewportRowIndex: PropTypes.number.isRequired,
     fixedColumns: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
     height: PropTypes.number.isRequired,
@@ -84,7 +86,7 @@ class FixedDataTableBufferedRows extends React.Component {
     } else {
       // we are scrolling, so don't display any rows which lie outside the viewport
       this._staticRowArray.forEach((row, i) => {
-        const rowOutsideViewport = !inRange(row.props.index, this.props.firstRowIndex, this.props.endRowIndex);
+        const rowOutsideViewport = !inRange(row.props.index, this.props.firstViewportRowIndex, this.props.endViewportRowIndex);
         if (rowOutsideViewport) {
           this._staticRowArray[i] = React.cloneElement(this._staticRowArray[i], {
             visible: false,
@@ -102,7 +104,7 @@ class FixedDataTableBufferedRows extends React.Component {
       const rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) &&
         props.showLastRowBorder;
-      const visible = inRange(rowIndex, this.props.firstRowIndex, this.props.endRowIndex);
+      const visible = inRange(rowIndex, this.props.firstViewportRowIndex, this.props.endViewportRowIndex);
 
       this._staticRowArray[i] =
         <FixedDataTableRow

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -87,6 +87,7 @@ class FixedDataTableContainer extends React.Component {
       'elementHeights',
       'elementTemplates',
       'firstRowIndex',
+      'endRowIndex',
       'isColumnReordering',
       'isColumnResizing',
       'maxScrollX',

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -90,11 +90,6 @@ class FixedDataTableRowImpl extends React.Component {
     scrollLeft: PropTypes.number.isRequired,
 
     /**
-     * Pass false to hide the row.  This is used internally for buffering rows
-     */
-    visible: PropTypes.bool.isRequired,
-
-    /**
      * Width of the row.
      */
     width: PropTypes.number.isRequired,
@@ -154,10 +149,6 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   render() /*object*/ {
-    if (!this.props.visible) {
-      return null;
-    }
-
     var subRowHeight = this.props.subRowHeight || 0;
     var style = {
       width: this.props.width,
@@ -452,6 +443,7 @@ class FixedDataTableRow extends React.Component {
       width: this.props.width,
       height: this.props.height,
       zIndex: (this.props.zIndex ? this.props.zIndex : 0),
+      display: this.props.visible ? 'block' : 'none',
     };
     FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
 
@@ -463,6 +455,7 @@ class FixedDataTableRow extends React.Component {
           {...this.props}
           offsetTop={undefined}
           zIndex={undefined}
+          visible={undefined}
         />
       </div>
     );

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -90,6 +90,11 @@ class FixedDataTableRowImpl extends React.Component {
     scrollLeft: PropTypes.number.isRequired,
 
     /**
+     * Pass true to not render the row. This is used internally for buffering rows.
+     */
+    fake: PropTypes.bool,
+
+    /**
      * Width of the row.
      */
     width: PropTypes.number.isRequired,
@@ -149,6 +154,10 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   render() /*object*/ {
+    if (this.props.fake) {
+      return null;
+    }
+
     var subRowHeight = this.props.subRowHeight || 0;
     var style = {
       width: this.props.width,
@@ -425,6 +434,11 @@ class FixedDataTableRow extends React.Component {
     offsetTop: PropTypes.number.isRequired,
 
     /**
+     * Pass false to hide the row via CSS
+     */
+    visible: PropTypes.bool.isRequired,
+
+    /**
      * Width of the row.
      */
     width: PropTypes.number.isRequired,
@@ -443,24 +457,21 @@ class FixedDataTableRow extends React.Component {
       width: this.props.width,
       height: this.props.height,
       zIndex: (this.props.zIndex ? this.props.zIndex : 0),
-      display: this.props.visible ? 'block' : 'none',
+      display: (this.props.visible ? 'block' : 'none'),
     };
     FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
+
+    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
 
     return (
       <div
         style={style}
-        className={cx('fixedDataTableRowLayout/rowWrapper')}>
-        <FixedDataTableRowImpl
-          {...this.props}
-          offsetTop={undefined}
-          zIndex={undefined}
-          visible={undefined}
-        />
+        className={cx('fixedDataTableRowLayout/rowWrapper')}
+      >
+        <FixedDataTableRowImpl {...rowProps} />
       </div>
     );
   }
 }
-
 
 module.exports = FixedDataTableRow;

--- a/src/FixedDataTableTranslateDOMPosition.js
+++ b/src/FixedDataTableTranslateDOMPosition.js
@@ -13,6 +13,9 @@
 import translateDOMPositionXY from 'translateDOMPositionXY';
 
 function FixedDataTableTranslateDOMPosition(/*object*/ style, /*number*/ x, /*number*/ y, /*boolean*/ initialRender = false) {
+  if (style.display === 'none') {
+    return;
+  }
   if (initialRender) {
     style.left = x + 'px';
     style.top = y + 'px';

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -16,8 +16,6 @@ import updateRowHeight from 'updateRowHeight';
 import roughHeightsSelector from 'roughHeights';
 import scrollbarsVisibleSelector from 'scrollbarsVisible';
 import tableHeightsSelector from 'tableHeights';
-import filter from 'lodash/filter';
-import inRange from 'lodash/inRange';
 
 /**
  * Returns data about the rows to render
@@ -73,6 +71,8 @@ export default function computeRenderedRows(state, scrollAnchor) {
     maxScrollY,
     scrollY,
     scrollJumpedY,
+    firstRowIndex: rowRange.firstViewportIdx,
+    endRowIndex: rowRange.endViewportIdx,
   });
 }
 
@@ -280,8 +280,8 @@ function computeRenderedRowOffsetsInViewport(state, rowRange) {
   }
 
   // output for this function
-  const rows = state.rows.slice(); // clone rows indexes
-  const rowOffsets = {}; // offsets for the rows
+  const rows = []; // state.rows
+  const rowOffsets = {}; // state.rowOffsets
 
   // incremental way for calculating rowOffset
   let runningOffset = rowOffsetIntervalTree.sumUntil(firstViewportIdx);
@@ -296,13 +296,6 @@ function computeRenderedRowOffsetsInViewport(state, rowRange) {
     const rowPosition = addRowToBuffer(rowIdx, rowBufferSet, firstViewportIdx, endViewportIdx, renderedRowsCount);
     rows[rowPosition] = rowIdx;
   }
-
-  // now recompute the row offsets for the rows lying outside the viewport
-  // but also still present in the buffer
-  const rowsInBufferOutsideViewPort = filter(rows, (rowIdx) => {
-    return rowIdx !== undefined && !inRange(rowIdx, firstViewportIdx, endViewportIdx)
-  });
-  rowsInBufferOutsideViewPort.forEach((rowIdx) => rowOffsets[rowIdx] = rowOffsetIntervalTree.sumUntil(rowIdx));
 
   // now we modify the state with the newly calculated rows and offsets
   state.rows = rows;

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -71,8 +71,6 @@ export default function computeRenderedRows(state, scrollAnchor) {
     maxScrollY,
     scrollY,
     scrollJumpedY,
-    firstRowIndex: rowRange.firstViewportIdx,
-    endRowIndex: rowRange.endViewportIdx,
   });
 }
 
@@ -172,6 +170,7 @@ function calculateRenderedRowRange(state, scrollAnchor) {
   }
 
   state.firstRowIndex = firstViewportIdx;
+  state.endRowIndex = endViewportIdx;
   state.firstRowOffset = firstOffset;
   return {
     endBufferIdx,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -144,9 +144,16 @@ function reducers(state = getInitialState(), action) {
       return newState;
     }
     case ActionTypes.SCROLL_END: {
-      return Object.assign({}, state, {
+      const newState = Object.assign({}, state, {
         scrolling: false,
       });
+      const previousScrollAnchor = {
+        firstIndex: state.firstRowIndex,
+        firstOffset: state.firstRowOffset,
+        lastIndex: state.lastIndex,
+        scrollJumpedY: state.scrollJumpedY,
+      };
+      return computeRenderedRows(newState, previousScrollAnchor);
     }
     case ActionTypes.SCROLL_JUMP_X: {
       return Object.assign({}, state, {

--- a/test/reducers/computeRenderedRows-test.js
+++ b/test/reducers/computeRenderedRows-test.js
@@ -84,6 +84,7 @@ describe('computeRenderedRows', function() {
 
       assert.deepEqual(newState, Object.assign(oldState, {
         firstRowIndex: 15,
+        endRowIndex: 20,
         firstRowOffset: -25,
         maxScrollY: 9400,
         rowOffsets: expectedRowOffsets,
@@ -120,6 +121,7 @@ describe('computeRenderedRows', function() {
 
       assert.deepEqual(newState, Object.assign(oldState, {
         firstRowIndex: 26,
+        endRowIndex: 31,
         firstRowOffset: -25,
         maxScrollY: 9400,
         rowOffsets: expectedRowOffsets,
@@ -174,6 +176,7 @@ describe('computeRenderedRows', function() {
 
       assert.deepEqual(newState, Object.assign(oldState, {
         firstRowIndex: 75,
+        endRowIndex: 80,
         firstRowOffset: -25,
         maxScrollY: 9400,
         rowOffsets: expectedRowOffsets,
@@ -213,6 +216,7 @@ describe('computeRenderedRows', function() {
 
       assert.deepEqual(newState, Object.assign(oldState, {
         firstRowIndex: 15,
+        endRowIndex: 19,
         firstRowOffset: -25,
         maxScrollY: 10000,
         rowOffsets: expectedRowOffsets,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implement viewport row buffering while scrolling.

## Description
See #402

## Motivation and Context
Fixes #402

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just manual testing done on fixed height rows.
I have used the POC in the issue for verifying that the only the rows in the viewport get updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
