### PR TITLE
Remove redundant scroll state checks in the scroll handlers.

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -947,13 +947,10 @@ class FixedDataTable extends React.Component {
       scrollFlags,
       scrollX,
       scrollY,
-      scrolling,
     } = this.props;
     const { overflowX, overflowY } = scrollFlags;
 
-    if (!scrolling) {
-      this._didScrollStart();
-    }
+    this._didScrollStart();
 
     let x = scrollX;
     let y = scrollY;
@@ -989,16 +986,13 @@ class FixedDataTable extends React.Component {
       onHorizontalScroll,
       scrollActions,
       scrollX,
-      scrolling,
     } = this.props;
 
     if (scrollPos === scrollX) {
       return;
     }
 
-    if (!scrolling) {
-      this._didScrollStart();
-    }
+    this._didScrollStart();
 
     // This is a workaround to prevent content blurring. This happens when translate3d
     // is applied with non-rounded values to elements having text.
@@ -1007,6 +1001,7 @@ class FixedDataTable extends React.Component {
     if (onHorizontalScroll ? onHorizontalScroll(roundedScrollPos) : true) {
       scrollActions.scrollToX(roundedScrollPos);
     }
+
     this._didScrollStop();
   }
 
@@ -1015,16 +1010,13 @@ class FixedDataTable extends React.Component {
       onVerticalScroll,
       scrollActions,
       scrollY,
-      scrolling,
     } = this.props;
 
     if (scrollPos === scrollY) {
       return;
     }
 
-    if (!scrolling) {
-      this._didScrollStart();
-    }
+    this._didScrollStart();
 
     if (onVerticalScroll ? onVerticalScroll(scrollPos) : true) {
       scrollActions.scrollToY(scrollPos);
@@ -1112,9 +1104,10 @@ class FixedDataTable extends React.Component {
     return true;
   }
 
-  // We need two versions of this function, one to finish up synchronously (for
-  // example, in componentWillUnmount), and a debounced version for normal
-  // scroll handling.
+  /**
+   * We need two versions of this function, one to finish up synchronously (in componentWillUnmount),
+   * and a debounced version for normal scroll handling.
+  */
   _didScrollStopSync = () => {
     const {
       firstRowIndex,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There are redundant scroll checks in the handlers. Let's remove them.
Redundant because the [function](https://github.com/schrodinger/fixed-data-table-2/blob/v1.0-beta/src/FixedDataTable.js#L1036) that ends up getting invoked has the [equivalent check](https://github.com/schrodinger/fixed-data-table-2/blob/v1.0-beta/src/FixedDataTable.js#L1046) in it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removing these makes it easier to go through the code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this on our examples.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
