### PR TITLE
Allow touch scroll to be default prevented by making the handlers passive

### DIFF
--- a/examples/TouchScrollExample.js
+++ b/examples/TouchScrollExample.js
@@ -25,7 +25,7 @@ class TouchScrollExample extends React.Component {
     // scrolling of parent containers of FDT. This style is a work around to fix this. By applying 'none' to
     // touch-action, we are disabling touch events from propagating.
     const tableParentStyle = {
-      'touch-action': 'none'
+      'touchAction': 'none'
     };
 
     return (

--- a/examples/TouchScrollExample.js
+++ b/examples/TouchScrollExample.js
@@ -20,58 +20,49 @@ class TouchScrollExample extends React.Component {
   render() {
     const { dataList } = this.state;
 
-    // Recent browser versions are making touch events passive by default. Unfortunately, React doesn't allow us
-    // to specify the event handlers as passive/active (see #6436 on facebook/react). This can lead to unneeded
-    // scrolling of parent containers of FDT. This style is a work around to fix this. By applying 'none' to
-    // touch-action, we are disabling touch events from propagating.
-    const tableParentStyle = {
-      'touchAction': 'none'
-    };
-
     return (
-      <div style={tableParentStyle}>
-        <Table
-          rowHeight={50}
-          rowsCount={dataList.getSize()}
-          headerHeight={50}
-          touchScrollEnabled={true}
-          width={1000}
-          height={500}
-          {...this.props}>
-          <Column
-            columnKey="firstName"
-            header={<Cell>First Name</Cell>}
-            cell={<TextCell data={dataList} />}
-            fixed={true}
-            width={100}
-          />
-          <Column
-            columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
-            cell={<TextCell data={dataList} />}
-            fixed={true}
-            width={100}
-          />
-          <Column
-            columnKey="city"
-            header={<Cell>City</Cell>}
-            cell={<TextCell data={dataList} />}
-            width={100}
-          />
-          <Column
-            columnKey="street"
-            header={<Cell>Street</Cell>}
-            cell={<TextCell data={dataList} />}
-            width={200}
-          />
-          <Column
-            columnKey="zipCode"
-            header={<Cell>Zip Code</Cell>}
-            cell={<TextCell data={dataList} />}
-            width={200}
-          />
-        </Table>
-      </div>
+      <Table
+        rowHeight={50}
+        rowsCount={dataList.getSize()}
+        headerHeight={50}
+        touchScrollEnabled={true}
+        width={1000}
+        height={500}
+        {...this.props}
+      >
+        <Column
+          columnKey="firstName"
+          header={<Cell>First Name</Cell>}
+          cell={<TextCell data={dataList} />}
+          fixed={true}
+          width={100}
+        />
+        <Column
+          columnKey="lastName"
+          header={<Cell>Last Name</Cell>}
+          cell={<TextCell data={dataList} />}
+          fixed={true}
+          width={100}
+        />
+        <Column
+          columnKey="city"
+          header={<Cell>City</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={100}
+        />
+        <Column
+          columnKey="street"
+          header={<Cell>Street</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+        <Column
+          columnKey="zipCode"
+          header={<Cell>Zip Code</Cell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+      </Table>
     );
   }
 }

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -463,7 +463,7 @@ class FixedDataTable extends React.Component {
       this._wheelHandler.onWheel,
       { passive: false }
     );
-    this._divRef && this._divRef.addEventListener(
+    this._divRef && this._divRef.removeEventListener(
       'touchmove',
       this._touchHandler.onTouchMove,
       { passive: false }

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -313,8 +313,8 @@ class FixedDataTable extends React.Component {
     stopReactWheelPropagation: PropTypes.bool,
 
     /**
-     * If enabled scroll events will never be default handled.
-     * If disabled/unspecified, scroll events will be default handled if the scroll
+     * If enabled scroll events will never be bubbled to the browser default handler.
+     * If disabled (default when unspecified), scroll events will be bubbled up if the scroll
      * doesn't lead to a change in scroll offsets, which is preferable if you like
      * the page/container to scroll up when the table is already scrolled up max.
      */

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -313,6 +313,14 @@ class FixedDataTable extends React.Component {
     stopReactWheelPropagation: PropTypes.bool,
 
     /**
+     * If enabled scroll events will never be default handled.
+     * If disabled/unspecified, scroll events will be default handled if the scroll
+     * doesn't lead to a change in scroll offsets, which is preferable if you like
+     * the page/container to scroll up when the table is already scrolled up max.
+     */
+    stopScrollDefaultHandling: PropTypes.bool,
+
+    /**
      * If enabled scroll events will not be propagated outside of the table.
      */
     stopScrollPropagation: PropTypes.bool,
@@ -444,6 +452,7 @@ class FixedDataTable extends React.Component {
       this._onScroll,
       this._shouldHandleWheelX,
       this._shouldHandleWheelY,
+      this.props.stopScrollDefaultHandling,
       this.props.stopScrollPropagation
     );
 
@@ -451,6 +460,7 @@ class FixedDataTable extends React.Component {
       this._onScroll,
       this._shouldHandleTouchX,
       this._shouldHandleTouchY,
+      this.props.stopScrollDefaultHandling,
       this.props.stopScrollPropagation
     );
   }

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -456,9 +456,16 @@ class FixedDataTable extends React.Component {
   }
 
   componentWillUnmount() {
+    // TODO (pradeep): Remove these and pass to our table component directly after
+    // React provides an API where event handlers can be specified to be non-passive
     this._divRef && this._divRef.removeEventListener(
       'wheel',
       this._wheelHandler.onWheel,
+      { passive: false }
+    );
+    this._divRef && this._divRef.addEventListener(
+      'touchmove',
+      this._touchHandler.onTouchMove,
       { passive: false }
     );
     this._wheelHandler = null;
@@ -574,6 +581,11 @@ class FixedDataTable extends React.Component {
     this._divRef && this._divRef.addEventListener(
       'wheel',
       this._wheelHandler.onWheel,
+      { passive: false }
+    );
+    this._divRef && this._divRef.addEventListener(
+      'touchmove',
+      this._touchHandler.onTouchMove,
       { passive: false }
     );
     this._reportContentHeight();
@@ -798,7 +810,6 @@ class FixedDataTable extends React.Component {
         onKeyDown={this._onKeyDown}
         onTouchStart={this._touchHandler.onTouchStart}
         onTouchEnd={this._touchHandler.onTouchEnd}
-        onTouchMove={this._touchHandler.onTouchMove}
         onTouchCancel={this._touchHandler.onTouchCancel}
         ref={this._onRef}
         style={{

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -467,7 +467,7 @@ class FixedDataTable extends React.Component {
 
   componentWillUnmount() {
     // TODO (pradeep): Remove these and pass to our table component directly after
-    // React provides an API where event handlers can be specified to be non-passive
+    // React provides an API where event handlers can be specified to be non-passive (facebook/react#6436)
     this._divRef && this._divRef.removeEventListener(
       'wheel',
       this._wheelHandler.onWheel,

--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -35,8 +35,8 @@ class ReactTouchHandler {
     /*function*/ onTouchScroll,
     /*boolean|function*/ handleScrollX,
     /*boolean|function*/ handleScrollY,
-    /*?boolean|?function*/ preventDefault,
-    /*?boolean|?function*/ stopPropagation
+    /*?boolean*/ preventDefault,
+    /*?boolean*/ stopPropagation
   ) {
 
     // The animation frame id for the drag scroll
@@ -79,21 +79,6 @@ class ReactTouchHandler {
         emptyFunction.thatReturnsFalse;
     }
 
-    // Can we just make this a boolean flag instead?
-    if (typeof preventDefault !== 'function') {
-      preventDefault = preventDefault ?
-        emptyFunction.thatReturnsTrue :
-        emptyFunction.thatReturnsFalse;
-    }
-
-    // TODO (jordan) Is configuring this necessary
-    // I don't think so. We are only just passing a boolean anyway.
-    if (typeof stopPropagation !== 'function') {
-      stopPropagation = stopPropagation ?
-        emptyFunction.thatReturnsTrue :
-        emptyFunction.thatReturnsFalse;
-    }
-
     this._handleScrollX = handleScrollX;
     this._handleScrollY = handleScrollY;
     this._preventDefault = preventDefault;
@@ -111,7 +96,7 @@ class ReactTouchHandler {
   }
 
   onTouchStart(/*object*/ event) {
-    if (this._preventDefault()) {
+    if (this._preventDefault) {
       event.preventDefault();
     }
 
@@ -130,13 +115,13 @@ class ReactTouchHandler {
     clearInterval(this._trackerId);
     this._trackerId = setInterval(this._track, TRACKER_TIMEOUT);
 
-    if (this._stopPropagation()) {
+    if (this._stopPropagation) {
       event.stopPropagation();
     }
   }
 
   onTouchEnd(/*object*/ event) {
-    if (this._preventDefault()) {
+    if (this._preventDefault) {
       event.preventDefault();
     }
 
@@ -147,7 +132,7 @@ class ReactTouchHandler {
     // Initialize decelerating autoscroll on drag stop
     requestAnimationFramePolyfill(this._startAutoScroll);
 
-    if (this._stopPropagation()) {
+    if (this._stopPropagation) {
       event.stopPropagation();
     }
   }
@@ -158,13 +143,13 @@ class ReactTouchHandler {
     clearInterval(this._trackerId);
     this._trackerId = null;
 
-    if (this._stopPropagation()) {
+    if (this._stopPropagation) {
       event.stopPropagation();
     }
   }
 
   onTouchMove(/*object*/ event) {
-    if (this._preventDefault()) {
+    if (this._preventDefault) {
       event.preventDefault();
     }
 
@@ -202,7 +187,7 @@ class ReactTouchHandler {
     // Ensure minimum delta magnitude is met to avoid jitter
     var changed = false;
     if (Math.abs(this._deltaX) > 2 || Math.abs(this._deltaY) > 2) {
-      if (this._stopPropagation()) {
+      if (this._stopPropagation) {
         event.stopPropagation();
       }
       changed = true;

--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -176,13 +176,11 @@ class ReactTouchHandler {
       this._deltaY = 0;
     }
 
-    //event.preventDefault();
-
     // Ensure minimum delta magnitude is met to avoid jitter
     var changed = false;
     if (Math.abs(this._deltaX) > 2 || Math.abs(this._deltaY) > 2) {
       if (this._stopPropagation()) {
-        //event.stopPropagation();
+        event.stopPropagation();
       }
       changed = true;
     }

--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -111,6 +111,9 @@ class ReactTouchHandler {
   }
 
   onTouchStart(/*object*/ event) {
+    if (this._preventDefault()) {
+      event.preventDefault();
+    }
 
     // Start tracking drag delta for scrolling
     this._lastTouchX = event.touches[0].pageX;
@@ -133,6 +136,9 @@ class ReactTouchHandler {
   }
 
   onTouchEnd(/*object*/ event) {
+    if (this._preventDefault()) {
+      event.preventDefault();
+    }
 
     // Stop tracking velocity
     clearInterval(this._trackerId);

--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -148,6 +148,7 @@ class ReactTouchHandler {
   }
 
   onTouchMove(/*object*/ event) {
+    event.preventDefault();
 
     var moveX = event.touches[0].pageX;
     var moveY = event.touches[0].pageY;
@@ -175,13 +176,13 @@ class ReactTouchHandler {
       this._deltaY = 0;
     }
 
-    event.preventDefault();
+    //event.preventDefault();
 
     // Ensure minimum delta magnitude is met to avoid jitter
     var changed = false;
     if (Math.abs(this._deltaX) > 2 || Math.abs(this._deltaY) > 2) {
       if (this._stopPropagation()) {
-        event.stopPropagation();
+        //event.stopPropagation();
       }
       changed = true;
     }

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -30,8 +30,8 @@ class ReactWheelHandler {
     /*function*/ onWheel,
     /*boolean|function*/ handleScrollX,
     /*boolean|function*/ handleScrollY,
-    /*?boolean|?function*/ preventDefault,
-    /*?boolean|?function*/ stopPropagation
+    /*?boolean*/ preventDefault,
+    /*?boolean*/ stopPropagation
   ) {
     this._animationFrameID = null;
     this._deltaX = 0;
@@ -51,21 +51,6 @@ class ReactWheelHandler {
         emptyFunction.thatReturnsFalse;
     }
 
-    // Can we just make this a boolean flag instead?
-    if (typeof preventDefault !== 'function') {
-      preventDefault = preventDefault ?
-        emptyFunction.thatReturnsTrue :
-        emptyFunction.thatReturnsFalse;
-    }
-
-    // TODO (jordan) Is configuring this necessary
-    // I don't think so. We are only just passing a boolean anyway.
-    if (typeof stopPropagation !== 'function') {
-      stopPropagation = stopPropagation ?
-        emptyFunction.thatReturnsTrue :
-        emptyFunction.thatReturnsFalse;
-    }
-
     this._handleScrollX = handleScrollX;
     this._handleScrollY = handleScrollY;
     this._preventDefault = preventDefault;
@@ -75,7 +60,7 @@ class ReactWheelHandler {
   }
 
   onWheel(/*object*/ event) {
-    if (this._preventDefault()) {
+    if (this._preventDefault) {
       event.preventDefault();
     }
 
@@ -108,7 +93,7 @@ class ReactWheelHandler {
 
     var changed;
     if (this._deltaX !== 0 || this._deltaY !== 0) {
-      if (this._stopPropagation()) {
+      if (this._stopPropagation) {
         event.stopPropagation();
       }
       changed = true;

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -64,6 +64,8 @@ class ReactWheelHandler {
   }
 
   onWheel(/*object*/ event) {
+    event.preventDefault();
+
     var normalizedEvent = normalizeWheel(event);
 
     // if shift is held, swap the axis of scrolling.
@@ -85,7 +87,6 @@ class ReactWheelHandler {
 
     this._deltaX += handleScrollX ? normalizedEvent.pixelX : 0;
     this._deltaY += handleScrollY ? normalizedEvent.pixelY : 0;
-    event.preventDefault();
 
     var changed;
     if (this._deltaX !== 0 || this._deltaY !== 0) {

--- a/test/ReactTouchHandler-test.js
+++ b/test/ReactTouchHandler-test.js
@@ -53,27 +53,9 @@ describe('ReactTouchHandler', function() {
       assert.isTrue(fakeEvent.stopPropagation.calledOnce);
     });
 
-    it('should stop event propagation if function returns true', function() {
-      // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => true);
-      reactTouchHandler.onTouchStart(fakeEvent);
-
-      // --- Verify Expectations ---
-      assert.isTrue(fakeEvent.stopPropagation.calledOnce);
-    });
-
     it('should not stop event propagation if flag is false', function() {
       // --- Run Test ---
       var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
-      reactTouchHandler.onTouchStart(fakeEvent);
-
-      // --- Verify Expectations ---
-      assert.isFalse(fakeEvent.stopPropagation.called);
-    });
-
-    it('should not stop event propagation if function returns false', function() {
-      // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
@@ -91,7 +73,7 @@ describe('ReactTouchHandler', function() {
 
     it('should start new interval', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
       reactTouchHandler.onTouchStart(fakeEvent);
       clock.tick(100);
 
@@ -128,14 +110,6 @@ describe('ReactTouchHandler', function() {
       assert.isTrue(fakeEvent.stopPropagation.calledOnce);
     });
 
-    it('should stop event propagation if function returns true', function() {
-      // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => true);
-      reactTouchHandler.onTouchEnd(fakeEvent);
-
-      // --- Verify Expectations ---
-      assert.isTrue(fakeEvent.stopPropagation.calledOnce);
-    });
 
     it('should not stop event propagation if flag is false', function() {
       // --- Run Test ---
@@ -146,18 +120,9 @@ describe('ReactTouchHandler', function() {
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
-    it('should not stop event propagation if function returns false', function() {
-      // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
-      reactTouchHandler.onTouchEnd(fakeEvent);
-
-      // --- Verify Expectations ---
-      assert.isFalse(fakeEvent.stopPropagation.called);
-    });
-
     it('should prevent default if flag is true', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
@@ -166,7 +131,7 @@ describe('ReactTouchHandler', function() {
 
     it('should clear last interval', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
@@ -175,7 +140,7 @@ describe('ReactTouchHandler', function() {
 
     it('Should start deceleration', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---

--- a/test/ReactTouchHandler-test.js
+++ b/test/ReactTouchHandler-test.js
@@ -80,22 +80,13 @@ describe('ReactTouchHandler', function() {
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
-    it('should prevent default if flag is false', function() {
+    it('should prevent default if flag is true', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, false);
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
-      assert.isFalse(fakeEvent.preventDefault.called);
-    });
-
-    it('should not prevent default if flag is false', function() {
-      // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, () => false);
-      reactTouchHandler.onTouchStart(fakeEvent);
-
-      // --- Verify Expectations ---
-      assert.isFalse(fakeEvent.preventDefault.called);
+      assert.isTrue(fakeEvent.preventDefault.calledOnce);
     });
 
     it('should start new interval', function() {
@@ -164,22 +155,13 @@ describe('ReactTouchHandler', function() {
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
-    it('should prevent default if flag is false', function() {
-      // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
-      reactTouchHandler.onTouchEnd(fakeEvent);
-
-      // --- Verify Expectations ---
-      assert.isFalse(fakeEvent.preventDefault.called);
-    });
-
-    it('should not prevent default if flag is false', function() {
+    it('should prevent default if flag is true', function() {
       // --- Run Test ---
       var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, () => false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
-      assert.isFalse(fakeEvent.preventDefault.called);
+      assert.isTrue(fakeEvent.preventDefault.calledOnce);
     });
 
     it('should clear last interval', function() {

--- a/test/ReactTouchHandler-test.js
+++ b/test/ReactTouchHandler-test.js
@@ -39,13 +39,14 @@ describe('ReactTouchHandler', function() {
           pageX: 121,
           pageY: 312
         }],
+        preventDefault: sandbox.spy(),
         stopPropagation: sandbox.spy()
       };
     });
 
     it('should stop event propagation if flag is true', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, true);
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
@@ -54,7 +55,7 @@ describe('ReactTouchHandler', function() {
 
     it('should stop event propagation if function returns true', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => true);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => true);
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
@@ -63,7 +64,7 @@ describe('ReactTouchHandler', function() {
 
     it('should not stop event propagation if flag is false', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
@@ -72,16 +73,34 @@ describe('ReactTouchHandler', function() {
 
     it('should not stop event propagation if function returns false', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
+    it('should prevent default if flag is false', function() {
+      // --- Run Test ---
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
+      reactTouchHandler.onTouchStart(fakeEvent);
+
+      // --- Verify Expectations ---
+      assert.isFalse(fakeEvent.preventDefault.called);
+    });
+
+    it('should not prevent default if flag is false', function() {
+      // --- Run Test ---
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, () => false);
+      reactTouchHandler.onTouchStart(fakeEvent);
+
+      // --- Verify Expectations ---
+      assert.isFalse(fakeEvent.preventDefault.called);
+    });
+
     it('should start new interval', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
       reactTouchHandler.onTouchStart(fakeEvent);
       clock.tick(100);
 
@@ -100,6 +119,7 @@ describe('ReactTouchHandler', function() {
           pageX: 121,
           pageY: 312
         }],
+        preventDefault: sandbox.spy(),
         stopPropagation: sandbox.spy()
       };
     });
@@ -110,7 +130,7 @@ describe('ReactTouchHandler', function() {
 
     it('should stop event propagation if flag is true', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, true);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
@@ -119,7 +139,7 @@ describe('ReactTouchHandler', function() {
 
     it('should stop event propagation if function returns true', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => true);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => true);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
@@ -128,7 +148,7 @@ describe('ReactTouchHandler', function() {
 
     it('should not stop event propagation if flag is false', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
@@ -137,16 +157,34 @@ describe('ReactTouchHandler', function() {
 
     it('should not stop event propagation if function returns false', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
+    it('should prevent default if flag is false', function() {
+      // --- Run Test ---
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, false);
+      reactTouchHandler.onTouchEnd(fakeEvent);
+
+      // --- Verify Expectations ---
+      assert.isFalse(fakeEvent.preventDefault.called);
+    });
+
+    it('should not prevent default if flag is false', function() {
+      // --- Run Test ---
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, true, () => false);
+      reactTouchHandler.onTouchEnd(fakeEvent);
+
+      // --- Verify Expectations ---
+      assert.isFalse(fakeEvent.preventDefault.called);
+    });
+
     it('should clear last interval', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
@@ -155,7 +193,7 @@ describe('ReactTouchHandler', function() {
 
     it('Should start deceleration', function() {
       // --- Run Test ---
-      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, () => false);
+      var reactTouchHandler = new ReactTouchHandler(() => {}, () => {}, () => {}, false, () => false);
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made the touch handler passive through `addEventListener` (similar to #422)
Moved `event.preventDefault` calls to the top so that they are always executed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows event to be default prevented, and thus (hopefully) fixes
* #419 - what is best way to prevent whole page scrolling when table is scrolling up?
* #154 - Scrolling horizontally using gestures causes browser to navigate through history instead of scrolling the table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our touch scroll example using chrome device tools. With the fix the page doesn't get scrolled, even when the table is already scrolled to the start/end

<!--- ## Screenshots (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
