### PR TITLE
Move cell group logic to reducer (First iteration)

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -737,7 +737,6 @@ class FixedDataTable extends React.Component {
       footer =
         <FixedDataTableRow
           key="footer"
-          key2="footer"
           isScrolling={scrolling}
           className={joinClasses(
             cx('fixedDataTableLayout/footer'),

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -630,9 +630,16 @@ class FixedDataTable extends React.Component {
 
     const {
       className,
+      columnOffsets,
+      columnGroupOffsets,
       columnReorderingData,
       columnResizingData,
+      columnsToRender,
       elementHeights,
+      fixedColumnOffsets,
+      fixedColumnGroupOffsets,
+      fixedRightColumnOffsets,
+      fixedRightColumnGroupOffsets,
       isColumnReordering,
       isColumnResizing,
       maxScrollX,
@@ -672,6 +679,9 @@ class FixedDataTable extends React.Component {
           fixedColumns={fixedColumnGroups}
           fixedRightColumns={fixedRightColumnGroups}
           scrollableColumns={scrollableColumnGroups}
+          columnOffsets={columnGroupOffsets}
+          fixedColumnOffsets={fixedColumnGroupOffsets}
+          fixedRightColumnOffsets={fixedRightColumnGroupOffsets}
           visible={true}
           onColumnResize={this._onColumnResize}
           onColumnReorder={onColumnReorder}
@@ -727,6 +737,7 @@ class FixedDataTable extends React.Component {
       footer =
         <FixedDataTableRow
           key="footer"
+          key2="footer"
           isScrolling={scrolling}
           className={joinClasses(
             cx('fixedDataTableLayout/footer'),
@@ -741,6 +752,9 @@ class FixedDataTable extends React.Component {
           fixedColumns={fixedColumns.footer}
           fixedRightColumns={fixedRightColumns.footer}
           scrollableColumns={scrollableColumns.footer}
+          columnOffsets={columnOffsets}
+          fixedColumnOffsets={fixedColumnOffsets}
+          fixedRightColumnOffsets={fixedRightColumnOffsets}
           scrollLeft={scrollX}
           showScrollbarY={scrollEnabledY}
         />;
@@ -765,6 +779,10 @@ class FixedDataTable extends React.Component {
         offsetTop={groupHeaderHeight}
         scrollLeft={scrollX}
         visible={true}
+        columnOffsets={columnOffsets}
+        columnsToRender={columnsToRender}
+        fixedColumnOffsets={fixedColumnOffsets}
+        fixedRightColumnOffsets={fixedRightColumnOffsets}
         fixedColumns={fixedColumns.header}
         fixedRightColumns={fixedRightColumns.header}
         scrollableColumns={scrollableColumns.header}
@@ -858,6 +876,10 @@ class FixedDataTable extends React.Component {
         firstViewportRowIndex={props.firstRowIndex}
         endViewportRowIndex={props.endRowIndex}
         height={bodyHeight}
+        columnsToRender={props.columnsToRender}
+        columnOffsets={props.columnOffsets}
+        fixedColumnOffsets={props.fixedColumnOffsets}
+        fixedRightColumnOffsets={props.fixedRightColumnOffsets}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}
         onRowContextMenu={props.onRowContextMenu}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -23,7 +23,10 @@ class FixedDataTableBufferedRows extends React.Component {
     isScrolling: PropTypes.bool,
     firstViewportRowIndex: PropTypes.number.isRequired,
     endViewportRowIndex: PropTypes.number.isRequired,
-    fixedColumns: PropTypes.array.isRequired,
+    columnOffsets: PropTypes.object.isRequired,
+    columnsToRender: PropTypes.array.isRequired,
+    fixedColumnOffsets: PropTypes.array.isRequired,
+    fixedRightColumnOffsets: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
@@ -131,6 +134,10 @@ class FixedDataTableBufferedRows extends React.Component {
           scrollLeft={Math.round(props.scrollLeft)}
           offsetTop={Math.round(rowOffsetTop)}
           visible={visible}
+          columnsToRender={props.columnsToRender}
+          columnOffsets={props.columnOffsets}
+          fixedColumnOffsets={props.fixedColumnOffsets}
+          fixedRightColumnOffsets={props.fixedRightColumnOffsets}
           fixedColumns={props.fixedColumns}
           fixedRightColumns={props.fixedRightColumns}
           scrollableColumns={props.scrollableColumns}
@@ -172,6 +179,8 @@ class FixedDataTableBufferedRows extends React.Component {
         scrollLeft={Math.round(props.scrollLeft)}
         visible={false}
         fake={true}
+        columnOffsets={props.columnOffsets}
+        columnsToRender={props.columnsToRender}
         fixedColumns={props.fixedColumns}
         fixedRightColumns={props.fixedRightColumns}
         scrollableColumns={props.scrollableColumns}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -99,15 +99,17 @@ class FixedDataTableCell extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
+    // if visibility changed then render
     if (nextProps.visible !== this.props.visible) {
       return true;
     }
 
     // no need to render if it's still not visible
-    if (!this.props.visible && !nextProps.visible) {
+    if (!nextProps.visible) {
       return false;
     }
 
+    // no need to render if scrolling changed neither row index nor column index
     if (nextProps.isScrolling &&
         this.props.rowIndex === nextProps.rowIndex && 
         this.props.columnKey === nextProps.columnKey

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -102,10 +102,9 @@ class FixedDataTableCell extends React.Component {
     if (nextProps.visible !== this.props.visible) {
       return true;
     }
-    return true;
 
-    // no need to render if it's not going to be visible again
-    if (this.props.visible && nextProps.visible) {
+    // no need to render if it's still not visible
+    if (!this.props.visible && !nextProps.visible) {
       return false;
     }
 

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -13,6 +13,7 @@
 import FixedDataTableCellDefault from 'FixedDataTableCellDefault';
 import FixedDataTableColumnReorderHandle from './FixedDataTableColumnReorderHandle';
 import FixedDataTableHelper from 'FixedDataTableHelper';
+import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
 import React from 'React';
 import PropTypes from 'prop-types';
 import cx from 'cx';
@@ -81,8 +82,15 @@ class FixedDataTableCell extends React.Component {
     /**
      * Whether touch is enabled or not.
      */
-    touchEnabled: PropTypes.bool
-  }
+    touchEnabled: PropTypes.bool,
+
+    /**
+     * Whether the cell is present in the viewport.
+     * We use this to skip render and also don't
+     * render the cell if it's not visible.
+     */
+    visible: PropTypes.bool,
+  };
 
   state = {
     isReorderingThisColumn: false,
@@ -91,7 +99,20 @@ class FixedDataTableCell extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (nextProps.isScrolling && this.props.rowIndex === nextProps.rowIndex) {
+    if (nextProps.visible !== this.props.visible) {
+      return true;
+    }
+    return true;
+
+    // no need to render if it's not going to be visible again
+    if (this.props.visible && nextProps.visible) {
+      return false;
+    }
+
+    if (nextProps.isScrolling &&
+        this.props.rowIndex === nextProps.rowIndex && 
+        this.props.columnKey === nextProps.columnKey
+    ) {
       return false;
     }
 
@@ -198,18 +219,15 @@ class FixedDataTableCell extends React.Component {
 
   render() /*object*/ {
 
-    var { height, width, columnKey, ...props } = this.props;
+    var { height, width, visible, columnKey, ...props } = this.props;
 
     var style = {
+      display: visible ? 'block' : 'none',
       height,
       width,
     };
 
-    if (DIR_SIGN === 1) {
-      style.left = props.left;
-    } else {
-      style.right = props.left;
-    }
+    FixedDataTableTranslateDOMPosition(style, DIR_SIGN * props.left, 0, false);
 
     if (this.state.isReorderingThisColumn) {
       style.transform = `translateX(${this.state.displacement}px) translateZ(0)`;

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -84,7 +84,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
 
     if (this.props.isScrolling) {
       // We are scrolling, so there's no need to display any cells which lie outside the viewport.
-      // We still need to render them though, so as to not cause any mounts/unmounts.
+      // We still need to render them though, so as to not cause any unmounts.
       this._staticCellArray.forEach((cell, i) => {
         this._staticCellArray[i] = React.cloneElement(this._staticCellArray[i], { visible: false });
       });

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -90,7 +90,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
       });
     } else {
       // reset the static cell array if scrolling is stopped
-      // this is done so that only cells inside the viewport are considered for vertical scrolling
+      // this is done so that only cells inside the buffer are considered for vertical scrolling
       this._staticCellArray = [];
     }
 

--- a/src/FixedDataTableColumn.js
+++ b/src/FixedDataTableColumn.js
@@ -165,18 +165,6 @@ class FixedDataTableColumn extends React.Component {
    isReorderable: PropTypes.bool,
 
    /**
-    * Whether cells in this column can be removed from document when outside
-    * of viewport as a result of horizontal scrolling.
-    * Setting this property to true allows the table to not render cells in
-    * particular column that are outside of viewport for visible rows. This
-    * allows to create table with many columns and not have vertical scrolling
-    * performance drop.
-    * Setting the property to false will keep previous behaviour and keep
-    * cell rendered if the row it belongs to is visible.
-    */
-   allowCellsRecycling: PropTypes.bool,
-
-   /**
     * Flag to enable performance check when rendering. Stops the component from
     * rendering if none of it's passed in props have changed
     */
@@ -184,7 +172,6 @@ class FixedDataTableColumn extends React.Component {
  };
 
  static defaultProps = {
-   allowCellsRecycling: false,
    fixed: false,
    fixedRight: false,
  };

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -80,14 +80,21 @@ class FixedDataTableContainer extends React.Component {
   update() {
     const state = this.reduxStore.getState();
     const boundState = pick(state, [
+      'columnGroupOffsets',
       'columnGroupProps',
+      'columnOffsets',
       'columnProps',
       'columnReorderingData',
       'columnResizingData',
+      'columnsToRender',
       'elementHeights',
       'elementTemplates',
-      'firstRowIndex',
       'endRowIndex',
+      'firstRowIndex',
+      'fixedColumnGroupOffsets',
+      'fixedColumnOffsets',
+      'fixedRightColumnGroupOffsets',
+      'fixedRightColumnOffsets',
       'isColumnReordering',
       'isColumnResizing',
       'maxScrollX',

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -84,6 +84,26 @@ class FixedDataTableRowImpl extends React.Component {
     scrollableColumns: PropTypes.array.isRequired,
 
     /**
+     * The list of columns to render.
+     */
+    columnsToRender: PropTypes.array,
+
+    /**
+     * The offsets of the fixed columns
+     */
+    columnOffsets: PropTypes.oneOfType([PropTypes.object.isRequired, PropTypes.array.isRequired]),
+
+    /**
+     * The offsets of the fixed columns
+     */
+    fixedColumnOffsets: PropTypes.array.isRequired,
+
+    /**
+     * The offsets of the fixed right columns
+     */
+    fixedRightColumnOffsets: PropTypes.array.isRequired,
+
+    /**
      * The distance between the left edge of the table and the leftmost portion
      * of the row currently visible in the table.
      */
@@ -181,6 +201,7 @@ class FixedDataTableRowImpl extends React.Component {
         width={fixedColumnsWidth}
         zIndex={2}
         columns={this.props.fixedColumns}
+        columnOffsets={this.props.fixedColumnOffsets}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
         onColumnReorder={this.props.onColumnReorder}
@@ -204,6 +225,7 @@ class FixedDataTableRowImpl extends React.Component {
         width={fixedRightColumnsWidth}
         zIndex={2}
         columns={this.props.fixedRightColumns}
+        columnOffsets={this.props.fixedRightColumnOffsets}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
         onColumnReorder={this.props.onColumnReorder}
@@ -228,6 +250,8 @@ class FixedDataTableRowImpl extends React.Component {
         width={this.props.width - fixedColumnsWidth - fixedRightColumnsWidth - scrollbarOffset}
         zIndex={0}
         columns={this.props.scrollableColumns}
+        columnsToRender={this.props.columnsToRender}
+        columnOffsets={this.props.columnOffsets}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
         onColumnReorder={this.props.onColumnReorder}

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -89,7 +89,7 @@ class FixedDataTableRowImpl extends React.Component {
     columnsToRender: PropTypes.array,
 
     /**
-     * The offsets of the fixed columns
+     * The offsets of the scrollable columns
      */
     columnOffsets: PropTypes.oneOfType([PropTypes.object.isRequired, PropTypes.array.isRequired]),
 

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -20,7 +20,6 @@ import pick from 'lodash/pick';
 function _extractProps(column) {
   return pick(column.props, [
     'align',
-    'allowCellsRecycling',
     'cellClassName',
     'columnKey',
     'flexGrow',

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -30,7 +30,6 @@ const DRAG_SCROLL_BUFFER = 100;
  * @return {!Object}
  */
 function initialize(state, props, oldProps) {
-  const { scrollLeft } = props;
   let { columnResizingData, isColumnResizing, scrollX } = state;
 
   const columnAnchor = getColumnAnchor(state, props, oldProps);
@@ -53,7 +52,7 @@ function initialize(state, props, oldProps) {
 
 /**
  * Get the anchor for scrolling.
- * This will either be the first row's index and an offset, or the last row's index.
+ * This will either be the first columns's index and an offset, or the last columns's index.
  * We also pass a flag indicating if the anchor has changed from the state
  *
  * @param {!Object} state
@@ -67,11 +66,15 @@ function initialize(state, props, oldProps) {
  * }}
  */
 function getColumnAnchor(state, props, oldProps) {
-if (props.scrollToColumn !== undefined &&
+  // if scrollToColumn changed
+  if (props.scrollToColumn !== undefined &&
     props.scrollToColumn !== null &&
-    (!oldProps || props.scrollToColumn !== oldProps.scrollToColumn)) {
+    (!oldProps || props.scrollToColumn !== oldProps.scrollToColumn)
+  ) {
     return scrollToColumn(state, props.scrollToColumn);
   }
+
+  // if scrollLeft changed
   if (
     props.scrollLeft !== undefined &&
     props.scrollLeft !== null &&
@@ -102,7 +105,6 @@ if (props.scrollToColumn !== undefined &&
 function scrollToColumn(state, scrollToColumn) {
   const {
     availableScrollWidth,
-    columnOffsets,
     fixedColumns,
     scrollableColumns,
   } = columnWidths(state);

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -15,6 +15,7 @@ import clamp from 'lodash/clamp';
 import columnWidths from 'columnWidths';
 import emptyFunction from 'emptyFunction';
 import isNil from 'lodash/isNil';
+import updateColumnWidth from 'updateColumnWidth';
 
 const DRAG_SCROLL_SPEED = 15;
 const DRAG_SCROLL_BUFFER = 100;
@@ -32,24 +33,15 @@ function initialize(state, props, oldProps) {
   const { scrollLeft } = props;
   let { columnResizingData, isColumnResizing, scrollX } = state;
 
-  if (scrollLeft !== undefined &&
-      (!oldProps || scrollLeft !== oldProps.scrollLeft)) {
-    scrollX = scrollLeft;
-  }
-
-  scrollX = scrollToColumn(state, props, oldProps.scrollToColumn, scrollX);
+  const columnAnchor = getColumnAnchor(state, props, oldProps);
 
   const { maxScrollX } = columnWidths(state);
   scrollX = clamp(scrollX, 0, maxScrollX);
-
-  const columnAnchor = getScrollAnchor(state, scrollX);
 
   // isColumnResizing should be overwritten by value from props if available
   isColumnResizing = props.isColumnResizing !== undefined ? props.isColumnResizing : isColumnResizing;
   columnResizingData = isColumnResizing ? columnResizingData : {};
 
-  // TODO (pradeep): pass 'changed' to indicate if scrollX was changed resulting in a need
-  // to calculate rendered rows and offsets (similar logic in scroll anchor)
   return Object.assign({}, state, {
     columnAnchor,
     columnResizingData,
@@ -60,71 +52,106 @@ function initialize(state, props, oldProps) {
 }
 
 /**
+ * Get the anchor for scrolling.
+ * This will either be the first row's index and an offset, or the last row's index.
+ * We also pass a flag indicating if the anchor has changed from the state
+ *
  * @param {!Object} state
- * @param {{
- *   scrollToColumn: number,
- *   width: number,
- * }} props
- * @param {number} oldScrollToColumn
- * @param {number} scrollX
- * @return {number} The new scrollX
+ * @param {!Object} props
+ * @param {!Object} oldProps
+ * @return {{
+ *   firstIndex: number,
+ *   firstOffset: number,
+ *   lastIndex: number,
+ *   changed: boolean,
+ * }}
  */
-function scrollToColumn(state, props, oldScrollToColumn, scrollX) {
-  const { scrollToColumn } = props;
-  if (isNil(scrollToColumn)) {
-    return scrollX;
+function getColumnAnchor(state, props, oldProps) {
+if (props.scrollToColumn !== undefined &&
+    props.scrollToColumn !== null &&
+    (!oldProps || props.scrollToColumn !== oldProps.scrollToColumn)) {
+    return scrollToColumn(state, props.scrollToColumn);
+  }
+  if (
+    props.scrollLeft !== undefined &&
+    props.scrollLeft !== null &&
+    (!oldProps || props.scrollLeft !== oldProps.scrollLeft)
+  ) {
+    return scrollToPos(state, props.scrollLeft);
   }
 
+  // no change in column anchor
+  return {
+    firstIndex: state.firstRowIndex,
+    firstOffset: state.firstRowOffset,
+    lastIndex: undefined,
+    changed: false,
+  };
+}
+
+/**
+ * @param {!Object} state
+ * @param {number} scrollToColumn
+ * @return {{
+ *   firstIndex: number,
+ *   firstOffset: number,
+ *   lastIndex: number,
+ *   changed: boolean,
+ * }}
+ */
+function scrollToColumn(state, scrollToColumn) {
   const {
     availableScrollWidth,
+    columnOffsets,
     fixedColumns,
     scrollableColumns,
   } = columnWidths(state);
-  const fixedColumnsCount = fixedColumns.length;
-  const scrollableColumnsCount = scrollableColumns.length;
 
-  const noScrollableColumns = scrollableColumnsCount === 0;
-  const scrollToUnchanged = scrollToColumn === oldScrollToColumn;
-  const selectedColumnFixed = scrollToColumn < fixedColumnsCount;
-  const selectedColumnFixedRight = scrollToColumn >= fixedColumnsCount + scrollableColumnsCount;
-  if (scrollToUnchanged || selectedColumnFixed || selectedColumnFixedRight || noScrollableColumns) {
-    return scrollX;
+  const { scrollX, columnOffsetIntervalTree } = state;
+
+  const selectedColumnFixed = scrollToColumn < fixedColumns.length;
+  const selectedColumnFixedRight = scrollToColumn >= fixedColumns.length + scrollableColumns.length;
+
+  // if target column is fixed, then don't do anything
+  if (selectedColumnFixed || selectedColumnFixedRight) {
+    return {
+      firstIndex: state.firstColumnIndex,
+      firstOffset: state.firstColumnOffset,
+      lastIndex: undefined,
+      changed: false,
+    }
   }
 
-  // Convert column index (0 indexed) to scrollable index (0 indexed)
-  // and clamp to max scrollable index
-  const clampedColumnIndex = Math.min(scrollToColumn - fixedColumnsCount,
-    scrollableColumns.length - 1);
+  // convert to scrollable column index where 0 denotes first scrollable column
+  const clampedColumnIndex = Math.min(scrollToColumn - fixedColumns.length, scrollableColumns.length - 1);
+  const columnBeginX = columnOffsetIntervalTree.sumUntil(clampedColumnIndex);
+  const columnEndX = columnBeginX + updateColumnWidth(state, clampedColumnIndex);
 
-  // Compute the width of all columns to the left of the column
-  let previousWidth = 0;
-  for (let columnIdx = 0; columnIdx < clampedColumnIndex; ++columnIdx) {
-    previousWidth += scrollableColumns[columnIdx].width;
+  let firstIndex = clampedColumnIndex;
+  let lastIndex = undefined;
+  if (columnBeginX < scrollX) {
+    // If column starts before the viewport, set as the first column in the viewport
+    // Uses defaults (from above)
+  } else if (scrollX < columnEndX - availableScrollWidth) {
+    // If after the viewport, set as the last column in the viewport
+    firstIndex = undefined;
+    lastIndex = clampedColumnIndex;
+  } else {
+    // If already in the viewport, do nothing.
+    return {
+      firstIndex: state.firstColumnIndex,
+      firstOffset: state.firstColumnOffset,
+      lastIndex: undefined,
+      changed: false,
+    };
   }
 
-  // Get width of specified column
-  const selectedColumnWidth = scrollableColumns[clampedColumnIndex].width;
-
-  // Compute the scroll position which sets the column on the right of the viewport
-  // Must scroll at least far enough for end of column (previousWidth + selectedColumnWidth)
-  // to be in viewport.
-  const minScrollPosition = previousWidth + selectedColumnWidth - availableScrollWidth;
-
-  // Handle offscreen to the left
-  // If scrolled less than minimum amount, scroll to minimum amount
-  // so column on right of viewport
-  if (scrollX < minScrollPosition) {
-    return minScrollPosition;
-  }
-
-  // Handle offscreen to the right
-  // If scrolled more than previous columns, at least part of column will be offscreen to left
-  // Scroll so column is flush with left edge of viewport
-  if (scrollX > previousWidth) {
-    return previousWidth;
-  }
-
-  return scrollX;
+  return {
+    firstIndex,
+    firstOffset: 0,
+    lastIndex,
+    changed: true,
+  };
 }
 
 /**
@@ -136,9 +163,10 @@ function scrollToColumn(state, props, oldScrollToColumn, scrollX) {
  *   firstIndex: number,
  *   firstOffset: number,
  *   lastIndex: number,
+ *   changed: number
  * }}
  */
-function getScrollAnchor(state, scrollX) {
+function scrollToPos(state, scrollX) {
   const {
     maxScrollX,
     scrollableColumns,
@@ -149,32 +177,42 @@ function getScrollAnchor(state, scrollX) {
   } = state;
 
   const columnsCount = scrollableColumns.length;
-  let firstIndex = 0; // first column that's visible (partially or fully)
-  let firstOffset = 0; // offset needed to see the first column fully
-  let lastIndex = undefined; // if we scroll value is above the available width, we calculate from the last index
 
+  // scroll to the last column
   if (scrollX >= maxScrollX) {
-    // Scroll to the last column
-    firstIndex = undefined;
-    lastIndex = columnsCount - 1;
+    return {
+      firstIndex: undefined,
+      firstOffset: 0,
+      lastIndex: columnsCount - 1,
+      changed: true,
+    }
   } else if (scrollX > 0) {
     // Mark the column which will appear first in the viewport
-    // We use this as our "marker" when scrolling even if updating rowOffsets
-    // leads to it not being different from the scrollX specified
+    // We use this as our "marker" when scrolling even if updating columnOffsets
+    // leads to it being different from the scrollX specified
     const newColumnIdx = columnOffsetIntervalTree.greatestLowerBound(scrollX);
-    firstIndex = clamp(newColumnIdx, 0, Math.max(columnsCount - 1, 0));
+    const firstIndex = clamp(newColumnIdx, 0, Math.max(columnsCount - 1, 0));
 
     // Record how far into the first column we should scroll
-    // firstOffset is a negative value representing how much larger scrollY is
-    // than the scroll position of the first col in the viewport
+    // firstOffset is a negative value representing how much larger scrollX is
+    // than the scroll position of the first column in the viewport
     const firstColumnPosition = columnOffsetIntervalTree.sumUntil(firstIndex);
-    firstOffset = firstColumnPosition - scrollX;
+    const firstOffset = firstColumnPosition - scrollX;
+
+    return {
+      firstIndex,
+      firstOffset,
+      lastIndex: undefined,
+      changed: true,
+    }
   }
 
+  // scroll to the first column
   return {
-    firstIndex,
-    firstOffset,
-    lastIndex,
+    firstIndex: 0,
+    firstOffset: 0,
+    lastIndex: undefined,
+    changed: true,
   };
 }
 
@@ -269,5 +307,5 @@ module.exports = {
   reorderColumn,
   reorderColumnMove,
   resizeColumn,
-  getScrollAnchor,
-}
+  scrollToPos,
+};

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -82,8 +82,8 @@ if (props.scrollToColumn !== undefined &&
 
   // no change in column anchor
   return {
-    firstIndex: state.firstRowIndex,
-    firstOffset: state.firstRowOffset,
+    firstIndex: state.firstColumnIndex,
+    firstOffset: state.firstColumnOffset,
     lastIndex: undefined,
     changed: false,
   };

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -1,0 +1,230 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule computeRenderedColumns
+ */
+
+'use strict';
+
+import clamp from 'lodash/clamp';
+import columnWidths from 'columnWidths';
+import scrollbarsVisibleSelector from 'scrollbarsVisible';
+import updateColumnWidth from 'updateColumnWidth';
+
+export default function computeRenderedColumns(state, columnAnchor) {
+  // clone state
+  const newState = Object.assign({}, state);
+  
+  // get buffer and viewport range
+  const columnRange = calculateRenderedColumnRange(newState, columnAnchor);
+  
+  // update the offsets and buffer mapping
+  computeRenderedColumnOffsets(newState, columnRange, newState.scrolling);
+  
+  return newState;
+}
+
+/**
+ * Determine the range of columns to render (buffer and viewport)
+ * The leading and trailing buffer is based on a fixed count,
+ * while the viewport columns are based on their height and the viewport height
+ * We use the columnAnchor to determine what either the first or last column
+ * will be, as well as the offset.
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {{
+ *   firstIndex: number,
+ *   firstOffset: number,
+ *   lastIndex: number,
+ * }} columnAnchor
+ * @return {{
+ *   endBufferIdy: number,
+ *   endViewportIdy: number,
+ *   firstBufferIdy: number,
+ *   firstViewportIdy: number,
+ * }}
+ * @private
+ */
+function calculateRenderedColumnRange(state, columnAnchor) {
+  const bufferColumnCount = 3; // TODO (pradeep): should we calculate this similar to bufferColumnCount ?
+  const { availableScrollWidth, scrollableColumns } = columnWidths(state);
+  const columnCount = scrollableColumns.length;
+
+  if (columnCount === 0) {
+    return {
+      endBufferIdy: 0,
+      endViewportIdy: 0,
+      firstBufferIdy: 0,
+      firstViewportIdy: 0,
+    };
+  }
+
+  // If our first or last index is greater than our columnCount,
+  // treat it as if the last column is at the end of the viewport
+  let { firstIndex, firstOffset, lastIndex } = columnAnchor;
+  if (firstIndex >= columnCount || lastIndex >= columnCount) {
+    lastIndex = columnCount - 1;
+  }
+
+  // Walk the viewport until filled with columns
+  // If lastIndex is set, walk backward so that column is the last in the viewport
+  let step = 1;
+  let startIdy = firstIndex;
+  let totalWidth = firstOffset;
+  if (lastIndex !== undefined) {
+    step = -1;
+    startIdy = lastIndex;
+    totalWidth = 0;
+  }
+
+  // Loop to walk the viewport until we've touched enough columns to fill its width
+  let columnIdy = startIdy;
+  let endIdy = columnIdy;
+  while (columnIdy < columnCount && columnIdy >= 0 &&
+      totalWidth < availableScrollWidth) {
+    totalWidth += updateColumnWidth(state, columnIdy);
+    endIdy = columnIdy;
+    columnIdy += step;
+  }
+
+  // Loop to walk the leading buffer
+  let firstViewportIdy = Math.min(startIdy, endIdy);
+  const firstBufferIdy = Math.max(firstViewportIdy - bufferColumnCount, 0);
+  for (columnIdy = firstBufferIdy; columnIdy < firstViewportIdy; columnIdy++) {
+    updateColumnWidth(state, columnIdy);
+  }
+
+  // Loop to walk the trailing buffer
+  const endViewportIdy = Math.max(startIdy, endIdy) + 1;
+  const endBufferIdy = Math.min(endViewportIdy + bufferColumnCount, columnCount);
+  for (columnIdy = endViewportIdy; columnIdy < endBufferIdy; columnIdy++) {
+    updateColumnWidth(state, columnIdy);
+  }
+
+  state.firstColumnIndex = firstViewportIdy;
+  state.endColumnIndex = endViewportIdy;
+  state.firstColumnOffset = firstOffset;
+
+  return {
+    endBufferIdy,
+    endViewportIdy,
+    firstBufferIdy,
+    firstViewportIdy,
+  };
+}
+
+/**
+ * Walk the columns to render and compute the width offsets and
+ * positions in the column buffer.
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {{
+ *   endBufferIdy: number,
+ *   endViewportIdy: number,
+ *   firstBufferIdy: number,
+ *   firstViewportIdy: number,
+ * }} columnRange
+ * @param {boolean} viewportOnly
+ * @private
+ */
+function computeRenderedColumnOffsets(state, columnRange, viewportOnly) {
+  const { columnBufferSet, columnOffsetIntervalTree } = state;
+  const {
+    endBufferIdy,
+    endViewportIdy,
+    firstBufferIdy,
+    firstViewportIdy,
+  } = columnRange;
+
+  const {
+    fixedColumnOffsets,
+    fixedRightColumnOffsets,
+    columnGroupOffsets,
+    fixedColumnGroupOffsets,
+    fixedRightColumnGroupOffsets,
+  } = columnWidths(state);
+
+  // we aren't doing calculations for fixed columns
+  state.columnGroupOffsets = columnGroupOffsets;
+  state.fixedColumnOffsets = fixedColumnOffsets;
+  state.fixedRightColumnOffsets = fixedRightColumnOffsets;
+  state.fixedColumnGroupOffsets = fixedColumnGroupOffsets;
+  state.fixedRightColumnGroupOffsets = fixedRightColumnGroupOffsets;
+
+  const renderedColumnsCount = endBufferIdy - firstBufferIdy;
+  if (renderedColumnsCount === 0) {
+    state.columnOffsets = {};
+    state.columnsToRender = [];
+    return;
+  }
+
+  const startIdx = viewportOnly ? firstViewportIdy : firstBufferIdy;
+  const endIdx = viewportOnly ? endViewportIdy : endBufferIdy;
+
+  // output for this function
+  const columns = []; // state.columnsToRender
+  const columnOffsets = {}; // state.columnOffsets
+
+  // incremental way for calculating columnOffset
+  let runningOffset = columnOffsetIntervalTree.sumUntil(startIdx);
+
+  // compute column index and offsets for every columns inside the buffer
+  for (let columnIdy = startIdx; columnIdy < endIdx; columnIdy++) {
+
+    // Update the offset for rendering the column
+    columnOffsets[columnIdy] = runningOffset;
+    runningOffset += columnOffsetIntervalTree.get(columnIdy);
+
+    // Get position for the viewport column
+    const columnPosition = addColumnToBuffer(columnIdy, columnBufferSet, startIdx, endIdx, renderedColumnsCount);
+    columns[columnPosition] = columnIdy;
+  }
+
+  // now we modify the state with the newly calculated columns and offsets
+  state.columnsToRender = columns;
+  state.columnOffsets = columnOffsets;
+}
+
+/**
+ * Add the column to the buffer set if it doesn't exist.
+ * If addition isn't possible due to max buffer size, it'll replace an existing element outside the given range.
+ *
+ * @param {!number} columnIdy
+ * @param {!number} columnBufferSet
+ * @param {!number} startRange
+ * @param {!number} endRange
+ * @param {!number} maxBufferSize
+ *
+ * @return {?number} the position of the column after being added to the buffer set
+ * @private
+ */
+function addColumnToBuffer(columnIdy, columnBufferSet, startRange, endRange, maxBufferSize) {
+  // Check if column already has a position in the buffer
+  let columnPosition = columnBufferSet.getValuePosition(columnIdy);
+
+  // Request a position in the buffer through eviction of another column
+  if (columnPosition === null && columnBufferSet.getSize() >= maxBufferSize)  {
+    columnPosition = columnBufferSet.replaceFurthestValuePosition(
+      startRange,
+      endRange - 1, // replaceFurthestValuePosition uses closed interval from startRange to endRange
+      columnIdy
+    );
+  }
+
+  if (columnPosition === null) {
+    columnPosition = columnBufferSet.getNewPositionForValue(columnIdy);
+  }
+
+  return columnPosition;
+}

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -40,7 +40,7 @@ export default function computeRenderedColumns(state, columnAnchor) {
 /**
  * Determine the range of columns to render (buffer and viewport)
  * The leading and trailing buffer is based on a fixed count,
- * while the viewport columns are based on their height and the viewport height
+ * while the viewport columns are based on their width and the viewport width.
  * We use the columnAnchor to determine what either the first or last column
  * will be, as well as the offset.
  *
@@ -117,7 +117,7 @@ function calculateRenderedColumnRange(state, columnAnchor) {
     updateColumnWidth(state, columnIdy);
   }
 
-  // Calculate offset needed to position column row at the end of viewport
+  // Calculate offset needed to position column at the end of viewport
   // This should be negative and represent how far the first column needs to be offscreen
   if (lastIndex !== undefined) {
     firstOffset = Math.min(availableScrollWidth - totalWidth, 0);

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -25,7 +25,15 @@ export default function computeRenderedColumns(state, columnAnchor) {
   
   // update the offsets and buffer mapping
   computeRenderedColumnOffsets(newState, columnRange, newState.scrolling);
-  
+
+  // scrollX might have changed due to change in columns and offsets
+  const { scrollableColumns, maxScrollX } = columnWidths(state);
+  let scrollX = 0;
+  if (scrollableColumns.length > 0) {
+    scrollX = newState.columnOffsets[columnRange.firstViewportIdy] - newState.firstColumnOffset;
+  }
+  newState.scrollX = clamp(scrollX, 0, maxScrollX);
+
   return newState;
 }
 
@@ -109,6 +117,12 @@ function calculateRenderedColumnRange(state, columnAnchor) {
     updateColumnWidth(state, columnIdy);
   }
 
+  // Calculate offset needed to position column row at the end of viewport
+  // This should be negative and represent how far the first column needs to be offscreen
+  if (lastIndex !== undefined) {
+    firstOffset = Math.min(availableScrollWidth - totalWidth, 0);
+  }
+
   state.firstColumnIndex = firstViewportIdy;
   state.endColumnIndex = endViewportIdy;
   state.firstColumnOffset = firstOffset;
@@ -155,7 +169,7 @@ function computeRenderedColumnOffsets(state, columnRange, viewportOnly) {
     fixedRightColumnGroupOffsets,
   } = columnWidths(state);
 
-  // we aren't doing calculations for fixed columns
+  // we are only doing calculations for scrollable columns
   state.columnGroupOffsets = columnGroupOffsets;
   state.fixedColumnOffsets = fixedColumnOffsets;
   state.fixedRightColumnOffsets = fixedRightColumnOffsets;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -75,6 +75,8 @@ function getInitialState() {
      * NOTE (jordan) rows may contain undefineds if we don't need all the buffer positions
      */
     columnOffsets: {},
+    fixedColumnOffsets: {},
+    fixedRightOffsets: {},
     columnsToRender: [],
     columnReorderingData: {},
     columnResizingData: {},
@@ -103,6 +105,7 @@ function getInitialState() {
     columnBufferSet: new IntegerBufferSet(),
     storedHeights: [],
     rowOffsetIntervalTree: null, // PrefixIntervalTree
+    columnOffsetIntervalTree: null, // PrefixIntervalTree
   };
 }
 

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule updateColumnWidth
+ */
+
+'use strict';
+
+import columnWidths from 'columnWidths';
+
+/**
+ * Update our cached col width for a specific index
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {number} columnIdy
+ * @return {number} The new col width
+ */
+export default function updateColumnWidth(state, columnIdy) {
+  const { scrollableColumns } = columnWidths(state);
+  const { columnOffsetIntervalTree } = state;
+  const newWidth = scrollableColumns[columnIdy].width;
+  const oldWidth = columnOffsetIntervalTree.get(columnIdy);
+  if (newWidth !== oldWidth) {
+    columnOffsetIntervalTree.set(columnIdy, newWidth);
+  }
+
+  return newWidth;
+}

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -48,21 +48,35 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     newColumnGroupProps,
     newColumnProps,
   } = flexWidths(columnGroupProps, columnProps, viewportWidth);
+
   const {
     fixedColumns,
     fixedRightColumns,
     scrollableColumns,
   } = groupColumns(newColumnProps);
 
+  const {
+    fixedColumnOffsets,
+    fixedRightColumnOffsets,
+    columnGroupOffsets,
+    fixedColumnGroupOffsets,
+    fixedRightColumnGroupOffsets,
+  } = columnOffsets(newColumnProps, newColumnGroupProps);
+
   const availableScrollWidth = viewportWidth - getTotalWidth(fixedColumns) - getTotalWidth(fixedRightColumns);
   const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
   return {
     columnGroupProps: newColumnGroupProps,
+    columnGroupOffsets,
     columnProps: newColumnProps,
     availableScrollWidth,
     fixedColumns,
+    fixedColumnGroupOffsets,
     fixedRightColumns,
+    fixedRightColumnGroupOffsets,
     scrollableColumns,
+    fixedColumnOffsets,
+    fixedRightColumnOffsets,
     maxScrollX,
   };
 }
@@ -155,9 +169,67 @@ function groupColumns(columnProps) {
   };
 }
 
+/**
+ * @param {!Array.<columnDefinition>} columnProps
+ * @param {!Array.<columnDefinition>} columnGroupProps
+ * @return {{
+ *   fixedColumnOffsets: !Array.<number>,
+ *   fixedRightColumnOffsets: !Array.<number>.
+ *   columnGroupOffsets: !Array.<number>.
+ *   fixedColumnGroupOffsets: !Array.<number>.
+ *   fixedRightColumnGroupOffsets: !Array.<number>
+ * }}
+ */
+function columnOffsets(columnProps, columnGroupProps) {
+  const fixedColumnOffsets = [];
+  const fixedRightColumnOffsets = [];
+  const columnGroupOffsets = [];
+  const fixedColumnGroupOffsets = [];
+  const fixedRightColumnGroupOffsets = [];
+
+  let offsetFixed = 0;
+  let offsetFixedRight = 0;
+  let offset = 0;
+
+  forEach(columnProps, columnProp => {
+    if (columnProp.fixed) {
+      fixedColumnOffsets.push(offsetFixed);
+      offsetFixed += columnProp.width;
+    } else if (columnProp.fixedRight) {
+      fixedRightColumnOffsets.push(offsetFixedRight);
+      offsetFixedRight += columnProp.width;
+    }
+  });
+
+  offset = 0;
+  offsetFixed = 0;
+  offsetFixedRight = 0;
+
+  forEach(columnGroupProps, columnGroupProp => {
+    if (columnGroupProp.fixed) {
+      fixedColumnGroupOffsets.push(offset);
+      offsetFixed += columnGroupProp.width;
+    } else if (columnGroupProp.fixedRight) {
+      fixedRightColumnGroupOffsets.push(offset);
+      offsetFixedRight += columnGroupProp.width;
+    } else {
+      columnGroupOffsets.push(offset);
+      offset += columnGroupProp.width;
+    }
+  });
+
+  return {
+    fixedColumnOffsets,
+    fixedRightColumnOffsets,
+    fixedColumnGroupOffsets,
+    fixedRightColumnGroupOffsets,
+    columnGroupOffsets,
+  };
+}
+
 export default shallowEqualSelector([
-  state => state.columnGroupProps,
-  state => state.columnProps,
-  state => scrollbarsVisible(state).scrollEnabledY,
-  state => state.tableSize.width,
+    state => state.columnGroupProps,
+    state => state.columnProps,
+    state => scrollbarsVisible(state).scrollEnabledY,
+    state => state.tableSize.width,
 ], columnWidths);

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -181,7 +181,6 @@ function groupColumns(columnProps) {
  * }}
  */
 function columnOffsets(columnProps, columnGroupProps) {
-  const columnOffsets = [];
   const fixedColumnOffsets = [];
   const fixedRightColumnOffsets = [];
   const columnGroupOffsets = [];
@@ -191,7 +190,6 @@ function columnOffsets(columnProps, columnGroupProps) {
   // calculate offsets for columns
   let offsetFixed = 0;
   let offsetFixedRight = 0;
-  let offset = 0;
 
   forEach(columnProps, columnProp => {
     if (columnProp.fixed) {
@@ -200,14 +198,11 @@ function columnOffsets(columnProps, columnGroupProps) {
     } else if (columnProp.fixedRight) {
       fixedRightColumnOffsets.push(offsetFixedRight);
       offsetFixedRight += columnProp.width;
-    } else {
-      columnOffsets.push(offset);
-      offset += columnProp.width;
     }
   });
 
   // calculate offsets for column groups
-  offset = 0;
+  let offset = 0;
   offsetFixed = 0;
   offsetFixedRight = 0;
 
@@ -234,8 +229,8 @@ function columnOffsets(columnProps, columnGroupProps) {
 }
 
 export default shallowEqualSelector([
-    state => state.columnGroupProps,
-    state => state.columnProps,
-    state => scrollbarsVisible(state).scrollEnabledY,
-    state => state.tableSize.width,
+  state => state.columnGroupProps,
+  state => state.columnProps,
+  state => scrollbarsVisible(state).scrollEnabledY,
+  state => state.tableSize.width,
 ], columnWidths);

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -181,12 +181,14 @@ function groupColumns(columnProps) {
  * }}
  */
 function columnOffsets(columnProps, columnGroupProps) {
+  const columnOffsets = [];
   const fixedColumnOffsets = [];
   const fixedRightColumnOffsets = [];
   const columnGroupOffsets = [];
   const fixedColumnGroupOffsets = [];
   const fixedRightColumnGroupOffsets = [];
 
+  // calculate offsets for columns
   let offsetFixed = 0;
   let offsetFixedRight = 0;
   let offset = 0;
@@ -198,9 +200,13 @@ function columnOffsets(columnProps, columnGroupProps) {
     } else if (columnProp.fixedRight) {
       fixedRightColumnOffsets.push(offsetFixedRight);
       offsetFixedRight += columnProp.width;
+    } else {
+      columnOffsets.push(offset);
+      offset += columnProp.width;
     }
   });
 
+  // calculate offsets for column groups
   offset = 0;
   offsetFixed = 0;
   offsetFixedRight = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Changes
Moved cell recycling logic to reducer.

To minimize position changes across columns, IntegerBufferSet is used. This is the same logic that our rows have been using.

The same changes in #421 are also used here -- only columns inside the viewport are considering while scrolling.

**Note:** Cell recycling is always on by default (hence the prop has been removed from FixedDataTableColumn)
This means: only columns in the buffer are rendered.

## Future scope
This will be another step to column virtualization? We just need maintain to `storedWidths` for columns, provide an API for the user to specify column settings given the column index, and then only demand these based on the existing logic. Basically something like `rowSettings` used internally.

## Missing changes (will add to future iterations)
Column buffer count is strictly 3 + no: of colums in the viewport. This should be made customizable through a prop.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Used around 20000 columns, with `pureRendering` and `allowCellsRecycling` turned on.

With PR (only for beta):
![FDT-Cell-group-reducer-PR-changes](https://user-images.githubusercontent.com/41563608/56074893-53652480-5dd7-11e9-96b8-51c401eada46.gif)

Current (beta):
![FDT-Cell-group-reducer-existing-behavior](https://user-images.githubusercontent.com/41563608/56074895-552ee800-5dd7-11e9-97d6-52eef7b1c0ac.gif)

Current (master):
![FDT-Cell-group-reducer-existing-behavior-_master_ (1)](https://user-images.githubusercontent.com/41563608/56074924-a939cc80-5dd7-11e9-916d-518f4fdeef95.gif)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
