### PR TITLE
Beta performance checks (Second iteration)

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -97,6 +97,12 @@ class FixedDataTableBufferedRows extends React.Component {
       this._staticRowArray.length = rowsToRender.length;
     }
 
+    const height  = props.height;
+    // we translate all the rows together using a parent DIV
+    // the problem with this approach is that for HUGE numbers, multiple translates aren't accurate, so
+    // we limit the offset to our table height and position the rows relative to this offset.
+    const bufferIndex = Math.floor(props.scrollTop / height);
+
     for (let i = 0; i < rowsToRender.length; i++) {
       const rowIndex = rowsToRender[i];
 
@@ -112,7 +118,8 @@ class FixedDataTableBufferedRows extends React.Component {
 
       const currentRowHeight = this.props.rowSettings.rowHeightGetter(rowIndex);
       const currentSubRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
-      const rowOffsetTop = props.rowOffsets[rowIndex];
+      const rowBufferIndex = Math.floor(props.rowOffsets[rowIndex] / height);
+      const rowOffsetTop = (props.rowOffsets[rowIndex] % height) + (rowBufferIndex - bufferIndex) * height;
       const rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) &&
         props.showLastRowBorder;
@@ -155,9 +162,10 @@ class FixedDataTableBufferedRows extends React.Component {
         />;
     }
 
+    // We translate all the rows together with a parent div. This saves a lot of renders.
     const style = {};
-    FixedDataTableTranslateDOMPosition(style, 0, props.offsetTop - props.scrollTop, false);
-    return <div style={style}>{this._staticRowArray}</div>;
+    FixedDataTableTranslateDOMPosition(style, 0, props.offsetTop - (props.scrollTop % height), false);
+    return <div style={style}> {this._staticRowArray} </div>;
   }
 
   getFakeRow(/*number*/key) /*object*/ {

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -97,11 +97,11 @@ class FixedDataTableBufferedRows extends React.Component {
       this._staticRowArray.length = rowsToRender.length;
     }
 
-    const height  = props.height;
     // we translate all the rows together using a parent DIV
-    // the problem with this approach is that for HUGE numbers, multiple translates aren't accurate, so
-    // we limit the offset to our table height and position the rows relative to this offset.
-    const bufferIndex = Math.floor(props.scrollTop / height);
+    // the problem with this approach is that for HUGE numbers, multiple translates aren't accurate
+    // so we limit the offset to a safe number and position the rows relative to this offset
+    const bufferHeight = 10000000;
+    const bufferIndex = Math.floor(props.scrollTop / bufferHeight);
 
     for (let i = 0; i < rowsToRender.length; i++) {
       const rowIndex = rowsToRender[i];
@@ -116,10 +116,11 @@ class FixedDataTableBufferedRows extends React.Component {
         continue;
       }
 
+      const rowBufferIndex = Math.floor(props.rowOffsets[rowIndex] / bufferHeight);
+      const rowOffsetTop = (props.rowOffsets[rowIndex] % bufferHeight) + (rowBufferIndex - bufferIndex) * bufferHeight;
+
       const currentRowHeight = this.props.rowSettings.rowHeightGetter(rowIndex);
       const currentSubRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
-      const rowBufferIndex = Math.floor(props.rowOffsets[rowIndex] / height);
-      const rowOffsetTop = (props.rowOffsets[rowIndex] % height) + (rowBufferIndex - bufferIndex) * height;
       const rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) &&
         props.showLastRowBorder;
@@ -164,7 +165,7 @@ class FixedDataTableBufferedRows extends React.Component {
 
     // We translate all the rows together with a parent div. This saves a lot of renders.
     const style = {};
-    FixedDataTableTranslateDOMPosition(style, 0, props.offsetTop - (props.scrollTop % height), false);
+    FixedDataTableTranslateDOMPosition(style, 0, props.offsetTop - (props.scrollTop % bufferHeight), false);
     return <div style={style}> {this._staticRowArray} </div>;
   }
 

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -11,6 +11,7 @@
  */
 
 import FixedDataTableRow from 'FixedDataTableRow';
+import FixedDataTableTranslateDOMPosition from 'FixedDataTableTranslateDOMPosition';
 import PropTypes from 'prop-types';
 import React from 'React';
 import cx from 'cx';
@@ -96,8 +97,6 @@ class FixedDataTableBufferedRows extends React.Component {
       this._staticRowArray.length = rowsToRender.length;
     }
 
-    var baseOffsetTop = props.offsetTop - props.scrollTop;
-
     for (let i = 0; i < rowsToRender.length; i++) {
       const rowIndex = rowsToRender[i];
 
@@ -113,7 +112,7 @@ class FixedDataTableBufferedRows extends React.Component {
 
       const currentRowHeight = this.props.rowSettings.rowHeightGetter(rowIndex);
       const currentSubRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
-      const rowOffsetTop = baseOffsetTop + props.rowOffsets[rowIndex];
+      const rowOffsetTop = props.rowOffsets[rowIndex];
       const rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) &&
         props.showLastRowBorder;
@@ -156,7 +155,9 @@ class FixedDataTableBufferedRows extends React.Component {
         />;
     }
 
-    return <div>{this._staticRowArray}</div>;
+    const style = {};
+    FixedDataTableTranslateDOMPosition(style, 0, props.offsetTop - props.scrollTop, false);
+    return <div style={style}>{this._staticRowArray}</div>;
   }
 
   getFakeRow(/*number*/key) /*object*/ {

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -128,7 +128,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
     /*number*/ left,
     /*string*/ key,
     /*number*/ columnGroupWidth,
-    /*boolean*/ isColumnReordering,
+    /*boolean*/ isColumnReordering
   ) /*object*/ => {
 
     var cellIsResizable = columnProps.isResizable &&
@@ -193,11 +193,17 @@ class FixedDataTableCellGroup extends React.Component {
   }
 
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {
-    return (
-      !nextProps.isScrolling ||
-      this.props.rowIndex !== nextProps.rowIndex ||
-      this.props.left !== nextProps.left
-    );
+    /// if offsets haven't changed for the same row while scrolliong, then skip update
+    if (nextProps.isScrolling) {
+      if (
+        this.props.rowIndex === nextProps.rowIndex &&
+        this.props.left === nextProps.left &&
+        this.props.offsetLeft === nextProps.offsetLeft
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 
   static defaultProps = /*object*/ {

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -193,7 +193,7 @@ class FixedDataTableCellGroup extends React.Component {
   }
 
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {
-    /// if offsets haven't changed for the same row while scrolliong, then skip update
+    /// if offsets haven't changed for the same row while scrolling, then skip update
     if (nextProps.isScrolling) {
       if (
         this.props.rowIndex === nextProps.rowIndex &&

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -193,17 +193,13 @@ class FixedDataTableCellGroup extends React.Component {
   }
 
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {
-    /// if offsets haven't changed for the same row while scrolling, then skip update
-    if (nextProps.isScrolling) {
-      if (
-        this.props.rowIndex === nextProps.rowIndex &&
-        this.props.left === nextProps.left &&
-        this.props.offsetLeft === nextProps.offsetLeft
-      ) {
-        return false;
-      }
-    }
-    return true;
+    /// if offsets haven't changed for the same cell group while scrolling, then skip update
+    return !(
+      nextProps.isScrolling &&
+      this.props.rowIndex === nextProps.rowIndex &&
+      this.props.left === nextProps.left &&
+      this.props.offsetLeft === nextProps.offsetLeft
+    );
   }
 
   static defaultProps = /*object*/ {

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -155,6 +155,7 @@ class FixedDataTableRowImpl extends React.Component {
 
   shouldComponentUpdate(nextProps) {
     // if row is not visible then no need to render it
+    // change in visibility is handled by the parent
     if (!nextProps.visible) {
       return false;
     }
@@ -166,15 +167,11 @@ class FixedDataTableRowImpl extends React.Component {
 
     // only update the row if scrolling leads to change in horizontal offsets
     // the vertical offset is taken care of by the wrapper
-    if (nextProps.isScrolling) {
-      if (
-        this.props.index === nextProps.index &&
-        this.props.scrollLeft === nextProps.scrollLeft
-      ) {
-        return false;
-      }
-    }
-    return true;
+    return !(
+      nextProps.isScrolling &&
+      this.props.index === nextProps.index &&
+      this.props.scrollLeft === nextProps.scrollLeft
+    );
   }
 
   render() /*object*/ {
@@ -493,18 +490,13 @@ class FixedDataTableRow extends React.Component {
       return true;
     }
 
-    // while scrolling if offsets haven't changed for the same row then skip update
-    if (nextProps.isScrolling) {
-      if (
-        this.props.index === nextProps.index &&
-        this.props.offsetTop === nextProps.offsetTop &&
-        this.props.scrollLeft === nextProps.scrollLeft
-      ) {
-        return false;
-      }
-    }
-
-    return true;
+    // if offsets haven't changed for the same row while scrolling, then skip update
+    return !(
+      nextProps.isScrolling &&
+      this.props.index === nextProps.index &&
+      this.props.offsetTop === nextProps.offsetTop &&
+      this.props.scrollLeft === nextProps.scrollLeft
+    );
   }
 
   render() /*object*/ {

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -153,6 +153,20 @@ class FixedDataTableRowImpl extends React.Component {
     touchEnabled: PropTypes.bool,
   };
 
+  shouldComponentUpdate(nextProps) {
+    // only update the row if scrolling leads to change in horizontal offsets
+    // the vertical offset is taken care of by the wrapper
+    if (nextProps.isScrolling) {
+      if (
+        this.props.index === nextProps.index &&
+        this.props.scrollLeft === nextProps.scrollLeft
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   render() /*object*/ {
     if (this.props.fake) {
       return null;
@@ -452,16 +466,47 @@ class FixedDataTableRow extends React.Component {
     this._initialRender = false;
   }
 
+  shouldComponentUpdate(nextProps) {
+    // if row is still fake or still not visible then no need to update
+    if (
+      !this.props.visible && !nextProps.visible ||
+      this.props.fake && nextProps.fake
+    ) {
+      return false;
+    }
+
+    // if row's visibility or fakeness has changed, then update it
+    if (
+      this.props.visible !== nextProps.visible ||
+      this.props.fake !== nextProps.fake
+    ) {
+      return true;
+    }
+
+    // if offsets haven't changed for the same row index while scrolling then no need to update
+    if (nextProps.isScrolling) {
+      if (
+        this.props.index === nextProps.index &&
+        this.props.offsetTop === nextProps.offsetTop &&
+        this.props.scrollLeft === nextProps.scrollLeft
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   render() /*object*/ {
+    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
+
     var style = {
       width: this.props.width,
       height: this.props.height,
-      zIndex: (this.props.zIndex ? this.props.zIndex : 0),
-      display: (this.props.visible ? 'block' : 'none'),
+      zIndex: (zIndex ? zIndex : 0),
+      display: (visible ? 'block' : 'none'),
     };
-    FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
-
-    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
+    FixedDataTableTranslateDOMPosition(style, 0, offsetTop, this._initialRender);
 
     return (
       <div

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -474,20 +474,17 @@ class FixedDataTableRow extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    // if row is still fake or still not visible then no need to update
-    if (
-      !this.props.visible && !nextProps.visible ||
-      this.props.fake && nextProps.fake
-    ) {
-      return false;
-    }
-
     // if row's visibility or fakeness has changed, then update it
     if (
       this.props.visible !== nextProps.visible ||
       this.props.fake !== nextProps.fake
     ) {
       return true;
+    }
+
+    // if row is still fake or still not visible then no need to update
+    if (nextProps.fake || !nextProps.visible) {
+      return false;
     }
 
     // if offsets haven't changed for the same row while scrolling, then skip update

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -154,6 +154,11 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   shouldComponentUpdate(nextProps) {
+    // always render if fakeness has changed
+    if (this.props.fake !== nextProps.fake) {
+      return true;
+    }
+
     // only update the row if scrolling leads to change in horizontal offsets
     // the vertical offset is taken care of by the wrapper
     if (nextProps.isScrolling) {
@@ -483,7 +488,7 @@ class FixedDataTableRow extends React.Component {
       return true;
     }
 
-    // if offsets haven't changed for the same row index while scrolling then no need to update
+    // while scrolling if offsets haven't changed for the same row then skip update
     if (nextProps.isScrolling) {
       if (
         this.props.index === nextProps.index &&

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -154,6 +154,11 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   shouldComponentUpdate(nextProps) {
+    // if row is not visible then no need to render it
+    if (!nextProps.visible) {
+      return false;
+    }
+
     // always render if fakeness has changed
     if (this.props.fake !== nextProps.fake) {
       return true;
@@ -503,13 +508,13 @@ class FixedDataTableRow extends React.Component {
   }
 
   render() /*object*/ {
-    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
+    const { offsetTop, zIndex, ...rowProps } = this.props;
 
     var style = {
       width: this.props.width,
       height: this.props.height,
       zIndex: (zIndex ? zIndex : 0),
-      display: (visible ? 'block' : 'none'),
+      display: (rowProps.visible ? 'block' : 'none'),
     };
     FixedDataTableTranslateDOMPosition(style, 0, offsetTop, this._initialRender);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Only change from #432 is a change for https://github.com/schrodinger/fixed-data-table-2/pull/432#discussion_r279091451, in shouldComponentUpdate of FixedDataTableRow.

## Description
<!--- Describe your changes in detail -->
* Add shouldComponentUpdate checks to prevent renders
* Use parent div to translate rows vertically : This means that rows with the same index won't ever have to be rendered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase scrolling performance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our examples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
