### PR TITLE
Fix prop type warning when rows are empty - beta

### DIFF
--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -40,6 +40,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
   const { rowsCount } = rowSettings;
   const { bodyHeight } = tableHeightsSelector(newState);
   const maxScrollY = scrollContentHeight - bodyHeight;
+  let firstRowOffset;
 
   // NOTE (jordan) This handles #115 where resizing the viewport may
   // leave only a subset of rows shown, but no scrollbar to scroll up to the first rows.
@@ -51,18 +52,26 @@ export default function computeRenderedRows(state, scrollAnchor) {
       });
     }
 
-    newState.firstRowOffset = 0;
+    firstRowOffset = 0;
+  } else {
+    firstRowOffset = rowRange.firstOffset;
   }
+
+  const firstRowIndex = rowRange.firstViewportIdx;
+  const endRowIndex = rowRange.endViewportIdx;
 
   computeRenderedRowOffsets(newState, rowRange, state.scrolling);
 
   let scrollY = 0;
   if (rowsCount > 0) {
-    scrollY = newState.rowOffsets[rowRange.firstViewportIdx] - newState.firstRowOffset;
+    scrollY = newState.rowOffsets[rowRange.firstViewportIdx] - firstRowOffset;
   }
   scrollY = clamp(scrollY, 0, maxScrollY);
 
   return Object.assign(newState, {
+    firstRowIndex,
+    firstRowOffset,
+    endRowIndex,
     maxScrollY,
     scrollY,
   });
@@ -88,6 +97,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
  *   endBufferIdx: number,
  *   endViewportIdx: number,
  *   firstBufferIdx: number,
+ *   firstOffset: number,
  *   firstViewportIdx: number,
  * }}
  * @private
@@ -101,6 +111,7 @@ function calculateRenderedRowRange(state, scrollAnchor) {
       endBufferIdx: 0,
       endViewportIdx: 0,
       firstBufferIdx: 0,
+      firstOffset: 0,
       firstViewportIdx: 0,
     };
   }
@@ -163,13 +174,11 @@ function calculateRenderedRowRange(state, scrollAnchor) {
     }
   }
 
-  state.firstRowIndex = firstViewportIdx;
-  state.endRowIndex = endViewportIdx;
-  state.firstRowOffset = firstOffset;
   return {
     endBufferIdx,
     endViewportIdx,
     firstBufferIdx,
+    firstOffset,
     firstViewportIdx,
   };
 }

--- a/test/reducers/computeRenderedRows-test.js
+++ b/test/reducers/computeRenderedRows-test.js
@@ -140,6 +140,9 @@ describe('computeRenderedRows', function() {
       const newState = computeRenderedRows(oldState, scrollAnchor);
 
       assert.deepEqual(newState, Object.assign(oldState, {
+        endRowIndex: 0,
+        firstRowIndex: 0,
+        firstRowOffset: 0,
         maxScrollY: 9400,
         rowOffsets: {},
         rows: [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Edge case when FDT was rendered with empty rows.
endViewPortRowIndex wasn't assigned in computeRenderedRows. 
Introduced through #421.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #433 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing examples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
