### PR TITLE
Beta columngroup reducer (second iteration)

### DIFF
--- a/examples/helpers/cells.js
+++ b/examples/helpers/cells.js
@@ -120,10 +120,10 @@ module.exports.RemovableHeaderCell = RemovableHeaderCell;
 
 class TextCell extends React.PureComponent {
   render() {
-    const {data, rowIndex, columnKey, ...props} = this.props;
+    const {data, rowIndex, columnKey, actualKey, ...props} = this.props;
     return (
       <Cell {...props}>
-        {data.getObjectAt(rowIndex)[columnKey]}
+        {data.getObjectAt(rowIndex)[actualKey || columnKey]}
       </Cell>
     );
   }

--- a/examples/helpers/cells.js
+++ b/examples/helpers/cells.js
@@ -120,10 +120,10 @@ module.exports.RemovableHeaderCell = RemovableHeaderCell;
 
 class TextCell extends React.PureComponent {
   render() {
-    const {data, rowIndex, columnKey, actualKey, ...props} = this.props;
+    const {data, rowIndex, columnKey, ...props} = this.props;
     return (
       <Cell {...props}>
-        {data.getObjectAt(rowIndex)[actualKey || columnKey]}
+        {data.getObjectAt(rowIndex)[columnKey]}
       </Cell>
     );
   }

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -642,6 +642,7 @@ class FixedDataTable extends React.Component {
       columnGroupOffsets,
       columnReorderingData,
       columnResizingData,
+      columnGroupsToRender,
       columnsToRender,
       elementHeights,
       fixedColumnOffsets,
@@ -689,6 +690,7 @@ class FixedDataTable extends React.Component {
           fixedRightColumns={fixedRightColumnGroups}
           scrollableColumns={scrollableColumnGroups}
           columnOffsets={columnGroupOffsets}
+          columnsToRender={columnGroupsToRender}
           fixedColumnOffsets={fixedColumnGroupOffsets}
           fixedRightColumnOffsets={fixedRightColumnGroupOffsets}
           visible={true}
@@ -761,6 +763,7 @@ class FixedDataTable extends React.Component {
           fixedColumns={fixedColumns.footer}
           fixedRightColumns={fixedRightColumns.footer}
           scrollableColumns={scrollableColumns.footer}
+          columnsToRender={columnsToRender}
           columnOffsets={columnOffsets}
           fixedColumnOffsets={fixedColumnOffsets}
           fixedRightColumnOffsets={fixedRightColumnOffsets}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -429,6 +429,13 @@ class FixedDataTable extends React.Component {
      * half of the number of visible rows.
      */
     bufferRowCount: PropTypes.number,
+
+    /**
+     * If this is turned on, Fixed Data Table will only request columns inside the viewport
+     * TODO (pradeep): Provide API for this. For now this will only act as
+     * performance check in FixedDataTableCellGroup
+     */
+    allowColumnVirtualization: PropTypes.bool,
   }
 
   static defaultProps = /*object*/ {
@@ -629,6 +636,7 @@ class FixedDataTable extends React.Component {
     } = tableHeightsSelector(this.props);
 
     const {
+      allowColumnVirtualization,
       className,
       columnOffsets,
       columnGroupOffsets,
@@ -663,6 +671,7 @@ class FixedDataTable extends React.Component {
     if (groupHeaderHeight > 0) {
       groupHeader = (
         <FixedDataTableRow
+          allowColumnVirtualization={allowColumnVirtualization}
           key="group_header"
           isScrolling={scrolling}
           className={joinClasses(
@@ -736,8 +745,8 @@ class FixedDataTable extends React.Component {
     if (footerHeight) {
       footer =
         <FixedDataTableRow
+          allowColumnVirtualization={allowColumnVirtualization}
           key="footer"
-          key2="footer"
           isScrolling={scrolling}
           className={joinClasses(
             cx('fixedDataTableLayout/footer'),
@@ -765,6 +774,7 @@ class FixedDataTable extends React.Component {
 
     const header =
       <FixedDataTableRow
+        allowColumnVirtualization={allowColumnVirtualization}
         key="header"
         isScrolling={scrolling}
         className={joinClasses(
@@ -870,6 +880,7 @@ class FixedDataTable extends React.Component {
     const props = this.props;
     return (
       <FixedDataTableBufferedRows
+        allowColumnVirtualization={props.allowColumnVirtualization}
         isScrolling={props.scrolling}
         fixedColumns={fixedCellTemplates}
         fixedRightColumns={fixedRightCellTemplates}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -20,6 +20,7 @@ import inRange from 'lodash/inRange';
 
 class FixedDataTableBufferedRows extends React.Component {
   static propTypes = {
+    allowColumnVirtualization: PropTypes.bool,
     isScrolling: PropTypes.bool,
     firstViewportRowIndex: PropTypes.number.isRequired,
     endViewportRowIndex: PropTypes.number.isRequired,
@@ -124,6 +125,7 @@ class FixedDataTableBufferedRows extends React.Component {
 
       this._staticRowArray[i] =
         <FixedDataTableRow
+          allowColumnVirtualization={props.allowColumnVirtualization}
           key={rowKey}
           isScrolling={props.isScrolling}
           index={rowIndex}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -98,16 +98,23 @@ class FixedDataTableCell extends React.Component {
     reorderingDisplacement: 0
   }
 
+  // TODO (pradeep): Remove this when merging to Beta (acts as a quick check to see if cells are mounted)
+  componentDidMount() {
+    console.log("cell mounted");
+  }
+
   shouldComponentUpdate(nextProps) {
+    // if visibility changed then always render
     if (nextProps.visible !== this.props.visible) {
       return true;
     }
 
     // no need to render if it's still not visible
-    if (!this.props.visible && !nextProps.visible) {
+    if (!nextProps.visible) {
       return false;
     }
 
+    // no need to render if scrolling changed neither row index nor column index
     if (nextProps.isScrolling &&
         this.props.rowIndex === nextProps.rowIndex && 
         this.props.columnKey === nextProps.columnKey

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -219,7 +219,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
         isColumnReordering={isColumnReordering}
         columnReorderingData={this.props.columnReorderingData}
         rowIndex={rowIndex}
-        columnKey={columnProps.columnKey}
+        columnKey={columnProps.columnKey || columnIndex}
         width={columnProps.width}
         left={currentPosition}
         cell={cellTemplate}

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -70,7 +70,6 @@ class FixedDataTableCellGroupImpl extends React.Component {
   componentWillMount() {
     this._initialRender = true;
     this._staticCellArray = [];
-    this._staticNonRecyclableCellArray = [];
   }
 
   componentDidMount() {
@@ -153,7 +152,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
     /*boolean*/isColumnReordering,
     /*number*/columnGroupWidth,
   }) => {
-    const { allowColumnVirtualization, columns, columnOffsets, left } = this.props;
+    const { allowColumnVirtualization, columns } = this.props;
 
     // no need to compute non virtualized cells if column virtualization turned on
     if (allowColumnVirtualization) {
@@ -163,15 +162,10 @@ class FixedDataTableCellGroupImpl extends React.Component {
     const nonVirtualizedCells = [];
 
     for (let i = 0; i < columns.length; i++) {
-      const { allowCellsRecycling, width } = columns[i].props;
-
       // if allowCellsRecycling was true, then it would have be included by this._staticCellArray
-      if (allowCellsRecycling) {
+      if (columns[i].props.allowCellsRecycling) {
         continue;
       }
-
-      const currentPosition = columnOffsets[i];
-      const visible = currentPosition - left <= width && currentPosition - left + width >= 0;
 
       nonVirtualizedCells[i] = this._renderCell({
         columnIndex: i,

--- a/src/FixedDataTableColumn.js
+++ b/src/FixedDataTableColumn.js
@@ -165,6 +165,18 @@ class FixedDataTableColumn extends React.Component {
    isReorderable: PropTypes.bool,
 
    /**
+    * Whether cells in this column can be removed from document when outside
+    * of viewport as a result of horizontal scrolling.
+    * Setting this property to true allows the table to not render cells in
+    * particular column that are outside of viewport for visible rows. This
+    * allows to create table with many columns and not have vertical scrolling
+    * performance drop.
+    * Setting the property to false will keep previous behaviour and keep
+    * cell rendered if the row it belongs to is visible.
+    */
+   allowCellsRecycling: PropTypes.bool,
+
+   /**
     * Flag to enable performance check when rendering. Stops the component from
     * rendering if none of it's passed in props have changed
     */

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -86,6 +86,7 @@ class FixedDataTableContainer extends React.Component {
       'columnProps',
       'columnReorderingData',
       'columnResizingData',
+      'columnGroupsToRender',
       'columnsToRender',
       'elementHeights',
       'elementTemplates',

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -38,6 +38,11 @@ class FixedDataTableRowImpl extends React.Component {
 
   static propTypes = {
 
+    /**
+     * Only columns within the viewport will be considered for rendering.
+     */
+    allowColumnVirtualization: PropTypes.bool,
+
     isScrolling: PropTypes.bool,
 
     /**
@@ -89,7 +94,7 @@ class FixedDataTableRowImpl extends React.Component {
     columnsToRender: PropTypes.array,
 
     /**
-     * The offsets of the fixed columns
+     * The offsets of the scrollable columns
      */
     columnOffsets: PropTypes.oneOfType([PropTypes.object.isRequired, PropTypes.array.isRequired]),
 

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -20,6 +20,7 @@ import pick from 'lodash/pick';
 function _extractProps(column) {
   return pick(column.props, [
     'align',
+    'allowCellsRecycling',
     'cellClassName',
     'columnKey',
     'flexGrow',

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -30,7 +30,6 @@ const DRAG_SCROLL_BUFFER = 100;
  * @return {!Object}
  */
 function initialize(state, props, oldProps) {
-  const { scrollLeft } = props;
   let { columnResizingData, isColumnResizing, scrollX } = state;
 
   const columnAnchor = getColumnAnchor(state, props, oldProps);
@@ -53,7 +52,7 @@ function initialize(state, props, oldProps) {
 
 /**
  * Get the anchor for scrolling.
- * This will either be the first row's index and an offset, or the last row's index.
+ * This will either be the first columns's index and an offset, or the last columns's index.
  * We also pass a flag indicating if the anchor has changed from the state
  *
  * @param {!Object} state
@@ -67,11 +66,15 @@ function initialize(state, props, oldProps) {
  * }}
  */
 function getColumnAnchor(state, props, oldProps) {
-if (props.scrollToColumn !== undefined &&
+  // if scrollToColumn changed
+  if (props.scrollToColumn !== undefined &&
     props.scrollToColumn !== null &&
-    (!oldProps || props.scrollToColumn !== oldProps.scrollToColumn)) {
+    (!oldProps || props.scrollToColumn !== oldProps.scrollToColumn)
+  ) {
     return scrollToColumn(state, props.scrollToColumn);
   }
+
+  // if scrollLeft changed
   if (
     props.scrollLeft !== undefined &&
     props.scrollLeft !== null &&
@@ -102,7 +105,6 @@ if (props.scrollToColumn !== undefined &&
 function scrollToColumn(state, scrollToColumn) {
   const {
     availableScrollWidth,
-    columnOffsets,
     fixedColumns,
     scrollableColumns,
   } = columnWidths(state);

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -15,7 +15,7 @@ import clamp from 'lodash/clamp';
 import columnWidths from 'columnWidths';
 import emptyFunction from 'emptyFunction';
 import isNil from 'lodash/isNil';
-import updateColumnWidth from 'updateColumnWidth';
+import { updateColumnWidth } from 'updateColumnWidth';
 
 const DRAG_SCROLL_SPEED = 15;
 const DRAG_SCROLL_BUFFER = 100;

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -40,7 +40,7 @@ export default function computeRenderedColumns(state, columnAnchor) {
 /**
  * Determine the range of columns to render (buffer and viewport)
  * The leading and trailing buffer is based on a fixed count,
- * while the viewport columns are based on their height and the viewport height
+ * while the viewport columns are based on their width and the viewport width.
  * We use the columnAnchor to determine what either the first or last column
  * will be, as well as the offset.
  *
@@ -62,7 +62,7 @@ export default function computeRenderedColumns(state, columnAnchor) {
  * @private
  */
 function calculateRenderedColumnRange(state, columnAnchor) {
-  const bufferColumnCount = 3; // TODO (pradeep): should we calculate this similar to bufferColumnCount ?
+  const bufferColumnCount = 0; // TODO (pradeep): calculate this similar to bufferRowCount
   const { availableScrollWidth, scrollableColumns } = columnWidths(state);
   const columnCount = scrollableColumns.length;
 
@@ -117,7 +117,7 @@ function calculateRenderedColumnRange(state, columnAnchor) {
     updateColumnWidth(state, columnIdy);
   }
 
-  // Calculate offset needed to position column row at the end of viewport
+  // Calculate offset needed to position column at the end of viewport
   // This should be negative and represent how far the first column needs to be offscreen
   if (lastIndex !== undefined) {
     firstOffset = Math.min(availableScrollWidth - totalWidth, 0);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -75,6 +75,8 @@ function getInitialState() {
      * NOTE (jordan) rows may contain undefineds if we don't need all the buffer positions
      */
     columnOffsets: {},
+    fixedColumnOffsets: {},
+    fixedRightOffsets: {},
     columnsToRender: [],
     columnReorderingData: {},
     columnResizingData: {},
@@ -103,6 +105,7 @@ function getInitialState() {
     columnBufferSet: new IntegerBufferSet(),
     storedHeights: [],
     rowOffsetIntervalTree: null, // PrefixIntervalTree
+    columnOffsetIntervalTree: null, // PrefixIntervalTree
   };
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -103,9 +103,11 @@ function getInitialState() {
      */
     rowBufferSet: new IntegerBufferSet(),
     columnBufferSet: new IntegerBufferSet(),
+    columnGroupBufferSet: new IntegerBufferSet(),
     storedHeights: [],
     rowOffsetIntervalTree: null, // PrefixIntervalTree
     columnOffsetIntervalTree: null, // PrefixIntervalTree
+    columnGroupOffsetIntervalTree: null, // PrefixIntervalTree
   };
 }
 
@@ -246,10 +248,12 @@ function initializeRowHeightsAndOffsets(state) {
  * @private
  */
 function initializeColumnOffsets(state) {
-  const { scrollableColumns } = columnWidths(state);
+  const { scrollableColumns, scrollableColumnGroups } = columnWidths(state);
   const columnOffsetIntervalTree = new PrefixIntervalTree(scrollableColumns.map(column => column.width));
+  const columnGroupOffsetIntervalTree = new PrefixIntervalTree(scrollableColumnGroups.map(column => column.width));
 
   return Object.assign({}, state, {
+    columnGroupOffsetIntervalTree,
     columnOffsetIntervalTree,
   });
 }

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -46,10 +46,12 @@ function updateColumnWidth(state, columnIdx) {
  * @return {number} The new col width
  */
 function updateColumnGroupWidth(state, columnIdx) {
-  const { columnGroupProps } = columnWidths(state);
+  const { columnGroupProps, scrollableColumnGroupIndex } = columnWidths(state);
   const { columnGroupOffsetIntervalTree } = state;
-  const newWidth = columnGroupProps[columnIdx].width;
+
+  const newWidth = columnGroupProps[scrollableColumnGroupIndex[columnIdx]].width;
   const oldWidth = columnGroupOffsetIntervalTree.get(columnIdx);
+
   if (newWidth !== oldWidth) {
     columnGroupOffsetIntervalTree.set(columnIdx, newWidth);
   }

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule updateColumnWidth
+ * @providesModule { updateColumnWidth, updateColumnGroupWidth }
  */
 
 'use strict';
@@ -20,17 +20,41 @@ import columnWidths from 'columnWidths';
  * without state having been cloned first.
  *
  * @param {!Object} state
- * @param {number} columnIdy
+ * @param {number} columnIdx
  * @return {number} The new col width
  */
-export default function updateColumnWidth(state, columnIdy) {
+function updateColumnWidth(state, columnIdx) {
   const { scrollableColumns } = columnWidths(state);
   const { columnOffsetIntervalTree } = state;
-  const newWidth = scrollableColumns[columnIdy].width;
-  const oldWidth = columnOffsetIntervalTree.get(columnIdy);
+  const newWidth = scrollableColumns[columnIdx].width;
+  const oldWidth = columnOffsetIntervalTree.get(columnIdx);
   if (newWidth !== oldWidth) {
-    columnOffsetIntervalTree.set(columnIdy, newWidth);
+    columnOffsetIntervalTree.set(columnIdx, newWidth);
   }
 
   return newWidth;
 }
+
+/**
+ * Update our cached col group width for a specific index
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {number} columnIdx
+ * @return {number} The new col width
+ */
+function updateColumnGroupWidth(state, columnIdx) {
+  const { columnGroupProps } = columnWidths(state);
+  const { columnGroupOffsetIntervalTree } = state;
+  const newWidth = columnGroupProps[columnIdx].width;
+  const oldWidth = columnGroupOffsetIntervalTree.get(columnIdx);
+  if (newWidth !== oldWidth) {
+    columnGroupOffsetIntervalTree.set(columnIdx, newWidth);
+  }
+
+  return newWidth;
+}
+
+export { updateColumnGroupWidth, updateColumnWidth };

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -55,6 +55,7 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     scrollableColumns,
     fixedColumnGroups,
     scrollableColumnGroups,
+    scrollableColumnGroupIndex,
     columnGroupIndex,
   } = groupColumns(newColumnProps, newColumnGroupProps);
 
@@ -79,6 +80,7 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     fixedRightColumnGroupOffsets,
     scrollableColumns,
     scrollableColumnGroups,
+    scrollableColumnGroupIndex,
     fixedColumnOffsets,
     fixedRightColumnOffsets,
     maxScrollX,
@@ -160,6 +162,7 @@ function groupColumns(columnProps, columnGroupProps) {
   const scrollableColumns = [];
   const scrollableColumnGroups = [];
   const columnGroupIndex = [];
+  const scrollableColumnGroupIndex = [];
 
   forEach(columnProps, columnProp => {
     let container = scrollableColumns;
@@ -177,6 +180,8 @@ function groupColumns(columnProps, columnGroupProps) {
       container = fixedColumnGroups;
     } else if (columnProp.fixedRight) {
       container = fixedRightColumnGroups;
+    } else {
+      scrollableColumnGroupIndex.push(index);
     }
     columnGroupIndex[index] = container.length;
     container.push(columnProp);
@@ -190,6 +195,7 @@ function groupColumns(columnProps, columnGroupProps) {
     scrollableColumns,
     scrollableColumnGroups,
     columnGroupIndex,
+    scrollableColumnGroupIndex,
   };
 }
 

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -181,7 +181,6 @@ function groupColumns(columnProps) {
  * }}
  */
 function columnOffsets(columnProps, columnGroupProps) {
-  const columnOffsets = [];
   const fixedColumnOffsets = [];
   const fixedRightColumnOffsets = [];
   const columnGroupOffsets = [];
@@ -191,7 +190,6 @@ function columnOffsets(columnProps, columnGroupProps) {
   // calculate offsets for columns
   let offsetFixed = 0;
   let offsetFixedRight = 0;
-  let offset = 0;
 
   forEach(columnProps, columnProp => {
     if (columnProp.fixed) {
@@ -200,14 +198,11 @@ function columnOffsets(columnProps, columnGroupProps) {
     } else if (columnProp.fixedRight) {
       fixedRightColumnOffsets.push(offsetFixedRight);
       offsetFixedRight += columnProp.width;
-    } else {
-      columnOffsets.push(offset);
-      offset += columnProp.width;
     }
   });
 
   // calculate offsets for column groups
-  offset = 0;
+  let offset = 0;
   offsetFixed = 0;
   offsetFixedRight = 0;
 
@@ -234,8 +229,8 @@ function columnOffsets(columnProps, columnGroupProps) {
 }
 
 export default shallowEqualSelector([
-    state => state.columnGroupProps,
-    state => state.columnProps,
-    state => scrollbarsVisible(state).scrollEnabledY,
-    state => state.tableSize.width,
+  state => state.columnGroupProps,
+  state => state.columnProps,
+  state => scrollbarsVisible(state).scrollEnabledY,
+  state => state.tableSize.width,
 ], columnWidths);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes from last PR (#430)
* column prop `allowCellsRecycling` added back
* lots of nits - typos, comments, indentation, and destructuring
* table prop  `allowColumnVirtualization` added
* refactored FixedDataTableCellGroup
* renamed endViewportIdy to endViewportCol
* also virtualied column groups and footer, that make's it all

### Things to be done in this iteration: (live list, will ~cross out~ once each task is done)
* ~remove unnecessary changes (left a comment)~
* ~rename Idy in `endViewportIdy` into `endViewportCol` (also at similar names)~
* ~virtualize column groups and footer~

### Things to be done in subsequent iterations
* API for specifying columns
* Refactor column widths (won't be needed any more since we have PrefixIntervalTree instead)
* Calculate and work with buffered columns

### Final touch:
* JSDocs and comments if missed
* Fix tests