### PR TITLE
Beta columngroup reducer (Third Iteration)

### DIFF
--- a/examples/ColumnVirtualizationExample.js
+++ b/examples/ColumnVirtualizationExample.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+"use strict";
+
+const { Table } = require('fixed-data-table-2');
+const React = require('react');
+
+const cellRenderer = ({rowIndex, columnKey}) => {
+  if (rowIndex !== undefined) { // column groups
+    return `(${rowIndex}, ${columnKey})`;
+  }
+  return columnKey;
+};
+
+class ObjectDataExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const columnsCount = 1000;
+    const columnInfo = [];
+    const columnGetter = ({ index }) => this.state.columnInfo[index];
+
+    for (let i = 0; i < columnsCount; i++) {
+      columnInfo.push({
+        columnKey: i,
+        header: cellRenderer,
+        cell: cellRenderer,
+        align: 'center',
+        width: 150,
+        fixed: i > 5 && i < 8,
+        fixedRight: i > 20 && i < 23,
+        allowCellsRecycling: true,
+      });
+    }
+
+    this.state = {
+      columnInfo,
+      columnGetter,
+      columnsCount,
+    };
+  }
+
+  render() {
+    const { columnGetter, columnsCount } = this.state;
+
+    return (
+      <Table
+        rowsCount={1000}
+        rowHeight={50}
+        headerHeight={50}
+        width={1000}
+        height={500}
+        keyboardScrollEnabled={true}
+        keyboardPageEnabled={true}
+        onScrollStart={(a, b, c) => console.log(a, b, c)}
+        onScrollEnd={(a, b, c) => console.log(a, b, c)}
+        groupHeaderHeight={150}
+        allowColumnVirtualization={true}
+        columnGetter={columnGetter}
+        columnsCount={columnsCount}
+        {...this.props}
+      >
+        /* note that Columns aren't passed here */
+      </Table>
+    );
+  }
+}
+
+module.exports = ObjectDataExample;

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -163,6 +163,13 @@ exports.ExamplePages = {
     description: 'A table example using a data context to pass data to the cells.' +
     ' The table is paginated and filterable by first and last name.',
   },
+  COLUMN_VIRTUALIZATION_EXAMPLE: {
+    location: 'example-column-virtualization.html',
+    fileName: 'ColumnVirtualizationExample.js',
+    title: 'Column Virtualization',
+    description: 'A table example that can render thousands of columns without performance drops.' +
+    ' We use the new API for specifying columns.',
+  },
 };
 
 Object.keys(exports.ExamplePages).forEach(

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -49,6 +49,7 @@ var EXAMPLE_COMPONENTS = {
   [ExamplePages.LONG_CLICK_EXAMPLE.location]: require('../../examples/LongClickExample'),
   [ExamplePages.CONTEXT_EXAMPLE.location]: require('../../examples/ContextExample'),
   [ExamplePages.FIXED_RIGHT_COLUMNS_EXAMPLE.location]: require('../../examples/FixedRightColumnsExample'),
+  [ExamplePages.COLUMN_VIRTUALIZATION_EXAMPLE.location]: require('../../examples/ColumnVirtualizationExample'),
 };
 
 class ExamplesPage extends React.Component {

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -162,7 +162,7 @@ function calculateRenderedColumnGroups(state, columnAnchor, columnRange) {
   const bufferColumnCount = 0; // TODO (pradeep): calculate this similar to bufferRowCount
   const { columnGroupBufferSet, columnGroupOffsetIntervalTree } = state;
 
-  const { availableScrollWidth, scrollableColumns, scrollableColumnGroups, columnGroupProps, columnGroupIndex } = columnWidths(state);
+  const { availableScrollWidth, scrollableColumns, scrollableColumnGroups, columnGroupIndex } = columnWidths(state);
   const columnCount = scrollableColumns.length;
   const columnGroupCount = scrollableColumnGroups.length;
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -19,7 +19,7 @@ import columnStateHelper from 'columnStateHelper'
 import columnWidths from 'columnWidths';
 import computeRenderedColumns from 'computeRenderedColumns';
 import computeRenderedRows from 'computeRenderedRows';
-import convertColumnElementsToData from 'convertColumnElementsToData';
+import getColumnData from 'convertColumnElementsToData';
 import pick from 'lodash/pick';
 import shallowEqual from 'shallowEqual';
 
@@ -265,22 +265,28 @@ function initializeColumnOffsets(state) {
  * @private
  */
 function setStateFromProps(state, props) {
+  // clone state
+  const newState = Object.assign({}, state);
+
+  // get column info from props
   const {
     columnGroupProps,
     columnProps,
     elementTemplates,
     useGroupHeader,
-  } = convertColumnElementsToData(props.children);
+  } = getColumnData(props);
 
-  const newState = Object.assign({}, state,
+  Object.assign(newState,
     { columnGroupProps, columnProps, elementTemplates });
 
+  // element heights
   newState.elementHeights = Object.assign({}, newState.elementHeights,
     pick(props, ['cellGroupWrapperHeight', 'footerHeight', 'groupHeaderHeight', 'headerHeight']));
   if (!useGroupHeader) {
     newState.elementHeights.groupHeaderHeight = 0;
   }
 
+  // row settings
   newState.rowSettings = Object.assign({}, newState.rowSettings,
     pick(props, ['bufferRowCount', 'rowHeight', 'rowsCount', 'subRowHeight']));
   const { rowHeight, subRowHeight } = newState.rowSettings;
@@ -289,9 +295,11 @@ function setStateFromProps(state, props) {
   newState.rowSettings.subRowHeightGetter =
     props.subRowHeightGetter || (() => subRowHeight || 0);
 
+  // scroll flags
   newState.scrollFlags = Object.assign({}, newState.scrollFlags,
     pick(props, ['overflowX', 'overflowY', 'showScrollbarX', 'showScrollbarY']));
 
+  // table size
   newState.tableSize = Object.assign({}, newState.tableSize,
     pick(props, ['height', 'maxHeight', 'ownerHeight', 'width']));
   newState.tableSize.useMaxHeight =

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule { updateColumnWidth, updateColumnGroupWidth }
+ * @providesModule updateColumnWidth
  */
 
 'use strict';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes from last PR (#441)
* table prop `columnGetter` added, which can be used to specify columns (new API)
* column prop `groupIdx` added (which is necessary to specify column groups)
* added example to showcase new column virtualization API. It has fixed and fixed right columns (1000 columns in total), and runs prettty fast

### Screenshots
![FDT-Beta-Column-Virtualization](https://user-images.githubusercontent.com/41563608/57695660-77cd4e80-766c-11e9-9953-c43a69ac83ee.gif)


### Things to be done in subsequent iterations
* ~API for specifying columns~
* Example for specifying grouped columns in the new API
* Refactor column widths ~(won't be needed any more since we have PrefixIntervalTree instead)~ we still need to calculate widths for EVERY column due to how flex widths work
* Calculate and work with buffered columns

### Final touch:
* JSDocs and comments if missed
* Fix tests