### PR TITLE
Add roles and aria-attributes for initial screen reader support

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -751,7 +751,7 @@ var FixedDataTable = createReactClass({
         />;
     }
 
-    var rows = this._renderRows(bodyOffsetTop);
+    var rows = this._renderRows(bodyOffsetTop, ariaAttributes.ariaRowIndexOffset);
 
     var header =
       <FixedDataTableRow
@@ -815,10 +815,6 @@ var FixedDataTable = createReactClass({
     if (this.props.keyboardPageEnabled || this.props.keyboardScrollEnabled) {
       tabIndex = 0
     }
-    var ariaRowCount = this.props.rowsCount + 1;
-    if (footer) {
-	    ariaRowCount++;
-    }
     return (
       <div
         className={joinClasses(
@@ -853,19 +849,19 @@ var FixedDataTable = createReactClass({
     );
   },
 
-  _renderRows(/*number*/ offsetTop) /*object*/ {
+  _renderRows(/*number*/ offsetTop, /*number*/ ariaIndexOffset) /*object*/ {
     var state = this.state;
     var showScrollbarY = this._showScrollbarY(state);
 
     return (
       <FixedDataTableBufferedRows
+        ariaIndexOffset={ariaIndexOffset}
         isScrolling={this._isScrolling}
         defaultRowHeight={state.rowHeight}
         firstRowIndex={state.firstRowIndex}
         firstRowOffset={state.firstRowOffset}
         fixedColumns={state.bodyFixedColumns}
         fixedRightColumns={state.bodyFixedRightColumns}
-        hasGroupHeader={state.useGroupHeader}
         height={state.bodyHeight}
         offsetTop={offsetTop}
         onRowClick={state.onRowClick}
@@ -901,7 +897,7 @@ var FixedDataTable = createReactClass({
    * This is needed to calculate the aria attributes for the rows and grid. Specifically
    * the aria-rowindex and aria-rowcount. Note that aria-rowindex is 1-indexed based.
    */
-  _calculateAriaAttributes(state) {
+  _calculateAriaAttributes(/*object*/ state) /*object*/ {
     // Default index values
     var groupHeaderAriaIndex = 1;
 
@@ -914,10 +910,15 @@ var FixedDataTable = createReactClass({
     // assuming no group header or footer
     var ariaRowCount = state.rowsCount + 1; 
 
+    // offset to add to rowIndex (0-indexed) to calculate aria-rowindex
+    // Need to add 1 for the header
+    var ariaRowIndexOffset = 2;
+
     if (state.useGroupHeader) {
       headerAriaIndex++;
       ariaRowCount++;
       footerAriaIndex++;
+      ariaRowIndexOffset++;
     }
     if (state.footerHeight) {
       ariaRowCount++;
@@ -927,7 +928,8 @@ var FixedDataTable = createReactClass({
       groupHeaderAriaIndex,
       headerAriaIndex,
       footerAriaIndex,
-      ariaRowCount
+      ariaRowCount,
+      ariaRowIndexOffset,
     };
   },
 

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -742,6 +742,8 @@ var FixedDataTable = createReactClass({
           scrollableColumns={state.footScrollableColumns}
           scrollLeft={state.scrollX}
           showScrollbarY={showScrollbarY}
+          isHeaderOrFooter={true}
+          ariaIndex={this.props.rowsCount+2}
         />;
     }
 
@@ -773,6 +775,8 @@ var FixedDataTable = createReactClass({
         isColumnReordering={!!state.isColumnReordering}
         columnReorderingData={state.columnReorderingData}
         showScrollbarY={showScrollbarY}
+        isHeaderOrFooter={true}
+        ariaIndex={1}
       />;
 
     var topShadow;
@@ -807,6 +811,10 @@ var FixedDataTable = createReactClass({
     if (this.props.keyboardPageEnabled || this.props.keyboardScrollEnabled) {
       tabIndex = 0
     }
+    var ariaRowCount = this.props.rowsCount + 1;
+    if (footer) {
+	    ariaRowCount++;
+    }
     return (
       <div
         className={joinClasses(
@@ -814,6 +822,8 @@ var FixedDataTable = createReactClass({
           cx('fixedDataTableLayout/main'),
           cx('public/fixedDataTable/main'),
         )}
+        role="grid"
+        aria-rowcount={ariaRowCount}
         tabIndex={tabIndex}
         onKeyDown={this._onKeyDown}
         onTouchStart={this._touchHandler.onTouchStart}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -627,6 +627,8 @@ var FixedDataTable = createReactClass({
     var showScrollbarX = state.maxScrollX > 0 && state.overflowX !== 'hidden' && state.showScrollbarX !== false;
     var showScrollbarY = this._showScrollbarY(state);
 
+    var ariaAttributes = this._calculateAriaAttributes(state);
+
     var groupHeader;
     if (state.useGroupHeader) {
       groupHeader = (
@@ -651,6 +653,8 @@ var FixedDataTable = createReactClass({
           onColumnReorder={onColumnReorder}
           onColumnReorderMove={this._onColumnReorderMove}
           showScrollbarY={showScrollbarY}
+          isHeaderOrFooter={true}
+          ariaIndex={ariaAttributes.groupHeaderAriaIndex}
         />
       );
     }
@@ -743,7 +747,7 @@ var FixedDataTable = createReactClass({
           scrollLeft={state.scrollX}
           showScrollbarY={showScrollbarY}
           isHeaderOrFooter={true}
-          ariaIndex={this.props.rowsCount+2}
+          ariaIndex={ariaAttributes.footerAriaIndex}
         />;
     }
 
@@ -776,7 +780,7 @@ var FixedDataTable = createReactClass({
         columnReorderingData={state.columnReorderingData}
         showScrollbarY={showScrollbarY}
         isHeaderOrFooter={true}
-        ariaIndex={1}
+        ariaIndex={ariaAttributes.headerAriaIndex}
       />;
 
     var topShadow;
@@ -823,7 +827,7 @@ var FixedDataTable = createReactClass({
           cx('public/fixedDataTable/main'),
         )}
         role="grid"
-        aria-rowcount={ariaRowCount}
+        aria-rowcount={ariaAttributes.ariaRowCount}
         tabIndex={tabIndex}
         onKeyDown={this._onKeyDown}
         onTouchStart={this._touchHandler.onTouchStart}
@@ -861,6 +865,7 @@ var FixedDataTable = createReactClass({
         firstRowOffset={state.firstRowOffset}
         fixedColumns={state.bodyFixedColumns}
         fixedRightColumns={state.bodyFixedRightColumns}
+        hasGroupHeader={state.useGroupHeader}
         height={state.bodyHeight}
         offsetTop={offsetTop}
         onRowClick={state.onRowClick}
@@ -890,6 +895,40 @@ var FixedDataTable = createReactClass({
         showScrollbarY={showScrollbarY}
       />
     );
+  },
+
+  /**
+   * This is needed to calculate the aria attributes for the rows and grid. Specifically
+   * the aria-rowindex and aria-rowcount. Note that aria-rowindex is 1-indexed based.
+   */
+  _calculateAriaAttributes(state) {
+    // Default index values
+    var groupHeaderAriaIndex = 1;
+
+    // assuming no group header
+    var headerAriaIndex = 1;
+
+    // assuming no group header
+    var footerAriaIndex = state.rowsCount + 2; 
+
+    // assuming no group header or footer
+    var ariaRowCount = state.rowsCount + 1; 
+
+    if (state.useGroupHeader) {
+      headerAriaIndex++;
+      ariaRowCount++;
+      footerAriaIndex++;
+    }
+    if (state.footerHeight) {
+      ariaRowCount++;
+    }
+
+    return {
+      groupHeaderAriaIndex,
+      headerAriaIndex,
+      footerAriaIndex,
+      ariaRowCount
+    };
   },
 
   /**

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -24,6 +24,7 @@ var FixedDataTableBufferedRows = createReactClass({
   displayName: 'FixedDataTableBufferedRows',
 
   propTypes: {
+    ariaIndexOffset: PropTypes.number,
     bufferRowCount: PropTypes.number,
     isScrolling: PropTypes.bool,
     defaultRowHeight: PropTypes.number.isRequired,
@@ -31,7 +32,6 @@ var FixedDataTableBufferedRows = createReactClass({
     firstRowOffset: PropTypes.number.isRequired,
     fixedColumns: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
-    hasGroupHeader: PropTypes.bool,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
@@ -151,10 +151,6 @@ var FixedDataTableBufferedRows = createReactClass({
 
     var baseOffsetTop = props.firstRowOffset - props.rowPositionGetter(props.firstRowIndex) + props.offsetTop;
 
-    // offset to add to rowIndex to calculate aria-rowindex
-    // aria-rowindex is 1-indexed based, but also need to add 1 for header and group header
-    var ariaIndexOffset = props.hasGroupHeader ? 3 : 2;
-
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
@@ -170,7 +166,7 @@ var FixedDataTableBufferedRows = createReactClass({
           key={rowKey}
           isScrolling={props.isScrolling}
           index={rowIndex}
-          ariaIndex={rowIndex+ariaIndexOffset}
+          ariaIndex={rowIndex+props.ariaIndexOffset}
           width={props.width}
           height={currentRowHeight}
           subRowHeight={currentSubRowHeight}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -31,6 +31,7 @@ var FixedDataTableBufferedRows = createReactClass({
     firstRowOffset: PropTypes.number.isRequired,
     fixedColumns: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
+    hasGroupHeader: PropTypes.bool,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
@@ -150,6 +151,10 @@ var FixedDataTableBufferedRows = createReactClass({
 
     var baseOffsetTop = props.firstRowOffset - props.rowPositionGetter(props.firstRowIndex) + props.offsetTop;
 
+    // offset to add to rowIndex to calculate aria-rowindex
+    // aria-rowindex is 1-indexed based, but also need to add 1 for header and group header
+    var ariaIndexOffset = props.hasGroupHeader ? 3 : 2;
+
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
@@ -165,7 +170,7 @@ var FixedDataTableBufferedRows = createReactClass({
           key={rowKey}
           isScrolling={props.isScrolling}
           index={rowIndex}
-          ariaIndex={rowIndex+2}
+          ariaIndex={rowIndex+ariaIndexOffset}
           width={props.width}
           height={currentRowHeight}
           subRowHeight={currentSubRowHeight}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -165,6 +165,7 @@ var FixedDataTableBufferedRows = createReactClass({
           key={rowKey}
           isScrolling={props.isScrolling}
           index={rowIndex}
+          ariaIndex={rowIndex+2}
           width={props.width}
           height={currentRowHeight}
           subRowHeight={currentSubRowHeight}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -91,6 +91,9 @@ var FixedDataTableCell = createReactClass({
      */
     touchEnabled: PropTypes.bool,
 
+    /**
+     * Whether cell is in a header or footer row or not
+     */
     isHeaderOrFooter: PropTypes.bool,
   },
 

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -89,7 +89,9 @@ var FixedDataTableCell = createReactClass({
     /**
      * Whether touch is enabled or not.
      */
-    touchEnabled: PropTypes.bool
+    touchEnabled: PropTypes.bool,
+
+    isHeaderOrFooter: PropTypes.bool,
   },
 
   getInitialState() {
@@ -206,8 +208,7 @@ var FixedDataTableCell = createReactClass({
   },
 
   render() /*object*/ {
-
-    var {height, width, columnKey, ...props} = this.props;
+    var { height, width, columnKey, isHeaderOrFooter, ...props } = this.props;
 
     var style = {
       height,
@@ -306,8 +307,10 @@ var FixedDataTableCell = createReactClass({
       );
     }
 
+    var role = isHeaderOrFooter ? "columnheader" : "gridcell";
+
     return (
-      <div className={className} style={style}>
+      <div className={className} style={style} role={role}>
         {columnResizerComponent}
         {columnReorderComponent}
         {content}

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -63,7 +63,9 @@ var FixedDataTableCellGroupImpl = createReactClass({
 
     zIndex: PropTypes.number.isRequired,
 
-    touchEnabled: PropTypes.bool
+    touchEnabled: PropTypes.bool,
+
+    isHeaderOrFooter: PropTypes.bool,
   },
 
   componentWillMount() {
@@ -145,6 +147,7 @@ var FixedDataTableCellGroupImpl = createReactClass({
     return (
       <FixedDataTableCell
         isScrolling={this.props.isScrolling}
+        isHeaderOrFooter={this.props.isHeaderOrFooter}
         align={columnProps.align}
         className={className}
         height={height}
@@ -201,6 +204,8 @@ var FixedDataTableCellGroup = createReactClass({
      * header and footer in front of other rows.
      */
     zIndex: PropTypes.number.isRequired,
+
+    isHeaderOrFooter: PropTypes.bool,
   },
 
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -146,6 +146,13 @@ class FixedDataTableRowImpl extends React.Component {
     onColumnReorderEnd: PropTypes.func,
 
     touchEnabled: PropTypes.bool,
+
+    isHeaderOrFooter: PropTypes.bool,
+
+    /**
+    * The value of the aria-rowindex.
+    */
+    ariaIndex: PropTypes.number,
   };
 
   render() /*object*/ {
@@ -181,6 +188,7 @@ class FixedDataTableRowImpl extends React.Component {
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}
         rowIndex={this.props.index}
+        isHeaderOrFooter={this.props.isHeaderOrFooter}
       />;
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
     var fixedRightColumnsWidth = this._getColumnsWidth(this.props.fixedRightColumns);
@@ -204,6 +212,7 @@ class FixedDataTableRowImpl extends React.Component {
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}
         rowIndex={this.props.index}
+        isHeaderOrFooter={this.props.isHeaderOrFooter}
       />;
     var fixedRightColumnsShadow = fixedRightColumnsWidth ?
       this._renderFixedRightColumnsShadow(this.props.width - fixedRightColumnsWidth - scrollbarOffset - 5) : null;
@@ -228,6 +237,7 @@ class FixedDataTableRowImpl extends React.Component {
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}
         rowIndex={this.props.index}
+        isHeaderOrFooter={this.props.isHeaderOrFooter}
       />;
     var scrollableColumnsWidth = this._getColumnsWidth(this.props.scrollableColumns);
     var columnsRightShadow = this._renderColumnsRightShadow(fixedColumnsWidth + scrollableColumnsWidth);
@@ -255,6 +265,8 @@ class FixedDataTableRowImpl extends React.Component {
     return (
       <div
         className={joinClasses(className, this.props.className)}
+        role="row"
+        aria-rowindex={this.props.ariaIndex}
         onClick={this.props.onClick ? this._onClick : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}
         onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -150,7 +150,7 @@ class FixedDataTableRowImpl extends React.Component {
     isHeaderOrFooter: PropTypes.bool,
 
     /**
-    * The value of the aria-rowindex.
+    * The value of the aria-rowindex attribute.
     */
     ariaIndex: PropTypes.number,
   };


### PR DESCRIPTION
## Description
Add role of grid to the container of the table, role of row to the div of each row, and the role of either columnheader or gridcell to the cells. Then add aria-rowcount and aria-rowindex to the rows since not all the rows are in the DOM.

## Motivation and Context
This seems to have helped the screen reader identify where it is when focus is within the table.
https://github.com/schrodinger/fixed-data-table-2/issues/440

## How Has This Been Tested?
Ran my changes with narrator/Edge as well as using the Accessibility tools with Firefox. The screen reader does say the roles correctly, reads the column with the cell, can tell which column it is in, and which row it is in.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
