### PR TITLE
Fix horizontal scrolling through shift key on Mac (Fixes #444)

### DIFF
--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -77,7 +77,7 @@ class ReactWheelHandler {
     var normalizedEvent = normalizeWheel(event);
 
     // if shift is held, swap the axis of scrolling.
-    if (event.shiftKey) {
+    if (event.shiftKey && this._allowInternalAxesSwap()) {
       normalizedEvent = this._swapNormalizedWheelAxis(normalizedEvent);
     }
 
@@ -128,6 +128,10 @@ class ReactWheelHandler {
       pixelX: normalizedEvent.pixelY,
       pixelY: normalizedEvent.pixelX,
     };
+  }
+
+  static _allowInternalAxesSwap() /*boolean*/{
+    return navigator.platform !=="MacIntel";
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 MacOS seems to detect shift key while scrolling, and internally swaps the spin.
The changes in #390 explicitly check for the shift key, and swaps the axis again, leading to #444.
Hence we check "navigator.platform" to disable our check for Mac.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #444

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
