### PR TITLE
Beta update dependencies babel - Fix internal build (step 4)

### DIFF
--- a/build_helpers/buildNPMInternals.sh
+++ b/build_helpers/buildNPMInternals.sh
@@ -5,7 +5,7 @@
 var glob = require('glob');
 var path = require('path');
 var fs = require('fs');
-var babel = require('babel-core');
+var babel = require('@babel/core');
 
 var internalPath = path.join(__dirname, '../internal');
 if (!fs.existsSync(internalPath)) {
@@ -13,7 +13,7 @@ if (!fs.existsSync(internalPath)) {
 }
 
 var providesModuleRegex = /@providesModule ([^\s*]+)/;
-var moduleRequireRegex = /=\s+require\((?:'|")([\w\.\/]+)(?:'|")\);/gm;
+var moduleRequireRegex = /require\((?:'|")([\w\.\/]+)(?:'|")\)/gm;
 var excludePathRegex = /^(react|lodash|redux|reselect)($|\/)/;
 var findDEVRegex = /__DEV__/g;
 
@@ -24,7 +24,7 @@ function replaceRequirePath(match, modulePath) {
     path = './' + path;
   }
 
-  return '= require(\'' + path + '\');';
+  return 'require(\'' + path + '\')';
 }
 
 var babelConf = JSON.parse(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Probably the final step

> In the entire codebase, FDT uses imports without ./
> so imports are written like require("FixedDataTable")
> 
> now I'm not sure why but during internal files build, we need them in the form require("./FixedDataTable")
> (notice the ./)
> 
> so the build script (this file) reads through the file contents after it's transpiled by babel, and then searches for the regex matching strings like "= require("FixedDataTable")" (notice the "= ")
> Then it replaces the match by prepending a "./" before the path, so that it becomes = require("./FixedDataTable")
> 
> Now the problem was that, after the babel upgrade, this transformation wasn't seen. After digging through a lot, and blaming Babel, flow plugins, webpack, etc, I found out that it was simply because the requires were transpiled a bit differently:
> 
> var _FixedDataTableRow = _interopRequireDefault(require('FixedDataTableRow'));
> instead of the earlier
> 
> var _FixedDataTableRow = require('./FixedDataTableRow');
> notice that "= require" isn't present, and hence the regex didn't match...
> 
> After changing the regex, and the replace string down below, everything seems to work 🙂

We'll clean this up later (tracked with #449)

## Navigate
#450 - Initial babel upgrade 
#451 - Calypso codemods 
#452 - Fix site and tests
#453 - Fix internal build  (*)