### PR TITLE
Fix rows having stale props during scrolling (beta)

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -104,7 +104,7 @@ class FixedDataTableBufferedRows extends React.Component {
       if (rowIndex === undefined) {
         // if a previous row existed, let's just make use of that
         if (this._staticRowArray[i] === undefined) {
-          this._staticRowArray[i] = this.getStubRow(i, true);
+          this._staticRowArray[i] = this.getStubRow(i, true, -1);
         }
         continue;
       }
@@ -164,7 +164,7 @@ class FixedDataTableBufferedRows extends React.Component {
    *
    * @param {number} key
    * @param {boolean} fake
-   * @param {number=} index
+   * @param {number} index
    * @return {!Object}
    */
   getStubRow(key, fake, index) /*object*/ {
@@ -173,7 +173,7 @@ class FixedDataTableBufferedRows extends React.Component {
       <FixedDataTableRow
         key={key}
         isScrolling={props.isScrolling}
-        index={index || -1}
+        index={index}
         width={props.width}
         height={0}
         offsetTop={0}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -87,9 +87,7 @@ class FixedDataTableBufferedRows extends React.Component {
       this._staticRowArray.forEach((row, i) => {
         const rowOutsideViewport = !this.isRowInsideViewport(row.props.index);
         if (rowOutsideViewport) {
-          this._staticRowArray[i] = React.cloneElement(this._staticRowArray[i], {
-            visible: false,
-          });
+          this._staticRowArray[i] = this.getStubRow(i, false, row.props.index);
         }
       });
     } else {
@@ -106,7 +104,7 @@ class FixedDataTableBufferedRows extends React.Component {
       if (rowIndex === undefined) {
         // if a previous row existed, let's just make use of that
         if (this._staticRowArray[i] === undefined) {
-          this._staticRowArray[i] = this.getFakeRow(i);
+          this._staticRowArray[i] = this.getStubRow(i, true);
         }
         continue;
       }
@@ -159,19 +157,29 @@ class FixedDataTableBufferedRows extends React.Component {
     return <div>{this._staticRowArray}</div>;
   }
 
-  getFakeRow(/*number*/key) /*object*/ {
+
+  /**
+   * Returns a stub row which won't be visible to the user.
+   * This allows us to still render a row and React won't unmount it.
+   *
+   * @param {number} key
+   * @param {boolean} fake
+   * @param {number=} index
+   * @return {!Object}
+   */
+  getStubRow(key, fake, index) /*object*/ {
     const props = this.props;
     return (
       <FixedDataTableRow
         key={key}
         isScrolling={props.isScrolling}
-        index={key}
+        index={index || -1}
         width={props.width}
         height={0}
         offsetTop={0}
         scrollLeft={Math.round(props.scrollLeft)}
         visible={false}
-        fake={true}
+        fake={fake}
         fixedColumns={props.fixedColumns}
         fixedRightColumns={props.fixedRightColumns}
         scrollableColumns={props.scrollableColumns}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In #403, I had introduced a performance improvement in beta which makes sure that only rows within the viewport are fetched while scrolling. 
We use React.cloneElement on the rows outside the view-port so that React won't unmount them.

But now, even if props change, these rows don't get updated in the component (since the clone uses the stale one). This means that rows outside the view-port can have very different props (such as columns) than the ones inside the view-port.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
LD uses the same table component across different LRs (to prevent unmounts). So changing LRs can change the columns, hence the rows outside the view-port won't be updated with the new columns. This leads to a hard type error where the cell renderer uses old column data which is not present.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in our examples and LD. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.