### PR TITLE
Fix table scrolling while touch scroll is disabled (master)

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -826,10 +826,10 @@ var FixedDataTable = createReactClass({
         aria-rowcount={ariaAttributes.ariaRowCount}
         tabIndex={tabIndex}
         onKeyDown={this._onKeyDown}
-        onTouchStart={this._touchHandler.onTouchStart}
-        onTouchEnd={this._touchHandler.onTouchEnd}
-        onTouchMove={this._touchHandler.onTouchMove}
-        onTouchCancel={this._touchHandler.onTouchCancel}
+        onTouchStart={state.touchScrollEnabled ? this._touchHandler.onTouchStart : null}
+        onTouchEnd={state.touchScrollEnabled ? this._touchHandler.onTouchEnd : null}
+        onTouchMove={state.touchScrollEnabled ? this._touchHandler.onTouchMove : null}
+        onTouchCancel={state.touchScrollEnabled ? this._touchHandler.onTouchCancel : null}
         ref={this._onRef}
         style={{height: state.height, width: state.width}}>
         <div

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -37,11 +37,11 @@ var KEYBOARD_SCROLL_AMOUNT = 40;
 var _lastScrolledScrollbar = null;
 
 var getTouchX = function(e) {
-  return Math.round(e.targetTouches[0].pageX - e.target.getBoundingClientRect().x);
+  return Math.round(e.targetTouches[0].clientX - e.target.getBoundingClientRect().x);
 };
 
 var getTouchY = function(e) {
-  return Math.round(e.targetTouches[0].pageY - e.target.getBoundingClientRect().y);
+  return Math.round(e.targetTouches[0].clientY - e.target.getBoundingClientRect().y);
 };
 
 var Scrollbar = createReactClass({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Touch handlers are registered even when 'touchScrollEnabled' is not true. This allows users to scroll the table (incorrectly) by touch, leading to #456 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #456 
Also fixes scroll bar not being in the correct position

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing examples (both emulator and normal mode).
Object Data Example and Touch Scroll Example

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
