### PR TITLE
Fix cells having stale props during scrolling (beta)

### DIFF
--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -153,6 +153,11 @@ class FixedDataTableRowImpl extends React.Component {
     touchEnabled: PropTypes.bool,
   };
 
+  shouldComponentUpdate(nextProps) {
+    // only render if row is visible
+    return nextProps.visible;
+  }
+
   render() /*object*/ {
     if (this.props.fake) {
       return null;
@@ -461,7 +466,7 @@ class FixedDataTableRow extends React.Component {
     };
     FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
 
-    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
+    const { offsetTop, zIndex, ...rowProps } = this.props;
 
     return (
       <div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a more complicated case of #454.

Stub rows provide stub props, and the cell will get rendered with it.
Now since the existing `shouldComponentUpdate` of our cells optimize scrolling by not *rerendering*, the cell can remain in the view with stub props. This means it can have a height of 0 (since our stub props are specified in that way.)
One way to fix this will be to specify all the correct props every time a scroll happens, but this can't be done since offsets for the rows outside the viewport aren't calculated.

The correct thing here is to not rerender them at all, since stub rows are just rows not visible to the user, but in React's DOM it is present so as to not cause unmounts. This means the cell won't be updated with stale props, and the moment the cell is visible, it's not a stub anymore and gets updated with the correct values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Scrolling in specific ways can render `stub` cells which are visible to the users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing examples with horizontal AND vertical scrolling.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
