### PR TITLE
Column Virtualization - Add reducer to virtualize columns (Step 1)

### DIFF
--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+"use strict";
+
+const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
+const { ImageCell, LinkCell } = require('./helpers/cells');
+const { Table, Column, Cell } = require('fixed-data-table-2');
+const React = require('react');
+
+class AutoScrollExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dataList: new FakeObjectDataListStore(1000000),
+      scrollTop: 0,
+      scrollLeft: 0,
+      autoScrollEnabled: true,
+      horizontalScrollDelta: 0,
+      verticalScrollDelta: 0,
+    };
+
+    this.columns = [];
+    const cellRenderer = ({ columnKey, rowIndex }) => (`${rowIndex}, ${columnKey}`);
+
+    for (let i = 0; i < 100; i++) {
+      this.columns[i] = (
+        <Column
+          key={i}
+          columnKey={i}
+          header={<div> {i} </div>}
+          cell={cellRenderer}
+          width={100}
+          allowCellsRecycling={true}
+        />
+      )
+    }
+
+    this.onVerticalScroll = this.onVerticalScroll.bind(this);
+    this.onHorizontalScroll = this.onHorizontalScroll.bind(this);
+    this.toggleAutoScroll = this.toggleAutoScroll.bind(this);
+    this.setHorizontalScrollDelta = this.setHorizontalScrollDelta.bind(this);
+    this.setVerticalScrollDelta = this.setVerticalScrollDelta.bind(this);
+  }
+
+  componentDidMount() {
+    setInterval(() => {
+      if (!this.state.autoScrollEnabled) {
+        return;
+      }
+      this.setState((prevState) => ({
+        scrollTop: prevState.scrollTop + (prevState.verticalScrollDelta || 0),
+        scrollLeft: prevState.scrollLeft + (prevState.horizontalScrollDelta || 0),
+      }));
+    }, 16);
+  }
+
+  render() {
+    return (
+      <div>
+        {this.renderControls()}
+        {this.renderTable()}
+      </div>
+    );
+  }
+
+  renderControls() {
+    return (
+      <div className='autoScrollControlContainer'>
+        <label>
+          Auto Scroll Enabled
+          <input type='checkbox' checked={this.state.autoScrollEnabled} onChange={this.toggleAutoScroll} />
+        </label>
+        <label>
+          Horizontal Scroll Delta
+          <input type='number' value={this.state.horizontalScrollDelta} onChange={this.setHorizontalScrollDelta} />
+        </label>
+        <label>
+          Vertical Scroll Delta
+          <input type='number' value={this.state.verticalScrollDelta} onChange={this.setVerticalScrollDelta} />
+        </label>
+      </div>
+    )
+  }
+
+  renderTable() {
+    var { dataList, scrollLeft, scrollTop } = this.state;
+    return (
+      <Table
+        rowHeight={50}
+        headerHeight={50}
+        rowsCount={dataList.getSize()}
+        width={1000}
+        height={500}
+        scrollLeft={scrollLeft}
+        scrollTop={scrollTop}
+        onVerticalScroll={this.onVerticalScroll}
+        onHorizontalScroll={this.onHorizontalScroll}
+        {...this.props}
+      >
+        <Column
+          columnKey="avatar"
+          cell={<ImageCell data={dataList} />}
+          fixed={true}
+          width={50}
+        />
+        <Column
+          columnKey="firstName"
+          header={<Cell>First Name</Cell>}
+          cell={<LinkCell data={dataList} />}
+          fixed={true}
+          width={100}
+        />
+        {this.columns}
+      </Table>
+    );
+  }
+
+  onVerticalScroll(scrollTop) {
+    this.setState({ scrollTop });
+  }
+
+  onHorizontalScroll(scrollLeft) {
+    this.setState({ scrollLeft });
+  }
+
+  toggleAutoScroll() {
+    this.setState((prevState) => ({
+      autoScrollEnabled: !prevState.autoScrollEnabled,
+    }));
+  }
+
+  setHorizontalScrollDelta(event) {
+    const { value } = event.target;
+    if (isNaN(value)) {
+      return;
+    }
+    this.setState({
+      horizontalScrollDelta: parseInt(value),
+    });
+  }
+
+  setVerticalScrollDelta(event) {
+    const { value } = event.target;
+    if (isNaN(value)) {
+      return;
+    }
+    this.setState({
+      verticalScrollDelta: parseInt(value),
+    });
+  }
+}
+
+module.exports = AutoScrollExample;

--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -23,7 +23,8 @@ class AutoScrollExample extends React.Component {
     };
 
     this.columns = [];
-    const cellRenderer = ({ columnKey, rowIndex }) => (`${rowIndex}, ${columnKey}`);
+    const cellRenderer = ({ columnKey, rowIndex }) =>
+      (<div className='autoScrollCell'> `${rowIndex}, ${columnKey}` </div>);
 
     for (let i = 0; i < 100; i++) {
       this.columns[i] = (
@@ -59,7 +60,7 @@ class AutoScrollExample extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className='autoScrollContainer'>
         {this.renderControls()}
         {this.renderTable()}
       </div>
@@ -68,7 +69,7 @@ class AutoScrollExample extends React.Component {
 
   renderControls() {
     return (
-      <div className='autoScrollControlContainer'>
+      <div className='autoScrollControls'>
         <label>
           Auto Scroll Enabled
           <input type='checkbox' checked={this.state.autoScrollEnabled} onChange={this.toggleAutoScroll} />

--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -24,7 +24,7 @@ class AutoScrollExample extends React.Component {
 
     this.columns = [];
     const cellRenderer = ({ columnKey, rowIndex }) =>
-      (<div className='autoScrollCell'> `${rowIndex}, ${columnKey}` </div>);
+      (<div className='autoScrollCell'> {rowIndex}, {columnKey} </div>);
 
     for (let i = 0; i < 100; i++) {
       this.columns[i] = (

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -169,6 +169,12 @@ exports.ExamplePages = {
     title: 'Fixed Rows',
     description: 'An example using multiple tables to mimic fixed rows.',
   },
+  AUTO_SCROLL_EXAMPLE: {
+    location: 'example-auto-scroll.html',
+    fileName: 'AutoScrollExample.js',
+    title: 'Auto Scroll',
+    description: 'An example using Controlled Scrolling to mimic auto scrolling',
+  },
 };
 
 Object.keys(exports.ExamplePages).forEach(

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -50,6 +50,7 @@ var EXAMPLE_COMPONENTS = {
   [ExamplePages.CONTEXT_EXAMPLE.location]: require('../../examples/ContextExample'),
   [ExamplePages.FIXED_RIGHT_COLUMNS_EXAMPLE.location]: require('../../examples/FixedRightColumnsExample'),
   [ExamplePages.FIXED_ROWS_EXAMPLE.location]: require('../../examples/FixedRowsExample'),
+  [ExamplePages.AUTO_SCROLL_EXAMPLE.location]: require('../../examples/AutoScrollExample'),
 };
 
 class ExamplesPage extends React.Component {

--- a/site/examples/examplesPageStyle.less
+++ b/site/examples/examplesPageStyle.less
@@ -326,3 +326,9 @@
   height: 50px;
   width: 50px;
 }
+
+.autoScrollControlContainer {
+  display: flex;
+  justify-content: space-around;
+  align-items: baseline;
+}

--- a/site/examples/examplesPageStyle.less
+++ b/site/examples/examplesPageStyle.less
@@ -327,8 +327,16 @@
   width: 50px;
 }
 
-.autoScrollControlContainer {
-  display: flex;
-  justify-content: space-around;
-  align-items: baseline;
+.autoScrollContainer {
+  .autoScrollControls {
+    display: flex;
+    justify-content: space-around;
+    align-items: baseline;
+  }
+  .autoScrollCell {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+  }
 }

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -429,6 +429,13 @@ class FixedDataTable extends React.Component {
      * half of the number of visible rows.
      */
     bufferRowCount: PropTypes.number,
+
+    /**
+     * Turn on column virtualization so that columns inside the viewport are rendered,
+     * regardless of allowCellsRecycling. This also avoids cell mounts by reusing the
+     * component.
+     */
+    allowColumnVirtualization: PropTypes.bool,
   }
 
   static defaultProps = /*object*/ {
@@ -629,9 +636,12 @@ class FixedDataTable extends React.Component {
     } = tableHeightsSelector(this.props);
 
     const {
+      allowColumnVirtualization,
       className,
+      columnOffsets,
       columnReorderingData,
       columnResizingData,
+      columnsToRender,
       elementHeights,
       isColumnReordering,
       isColumnResizing,
@@ -726,6 +736,7 @@ class FixedDataTable extends React.Component {
     if (footerHeight) {
       footer =
         <FixedDataTableRow
+          allowColumnVirtualization={allowColumnVirtualization}
           key="footer"
           isScrolling={scrolling}
           className={joinClasses(
@@ -741,6 +752,8 @@ class FixedDataTable extends React.Component {
           fixedColumns={fixedColumns.footer}
           fixedRightColumns={fixedRightColumns.footer}
           scrollableColumns={scrollableColumns.footer}
+          columnsToRender={columnsToRender}
+          columnOffsets={columnOffsets}
           scrollLeft={scrollX}
           showScrollbarY={scrollEnabledY}
         />;
@@ -751,6 +764,7 @@ class FixedDataTable extends React.Component {
 
     const header =
       <FixedDataTableRow
+        allowColumnVirtualization={allowColumnVirtualization}
         key="header"
         isScrolling={scrolling}
         className={joinClasses(
@@ -765,6 +779,8 @@ class FixedDataTable extends React.Component {
         offsetTop={groupHeaderHeight}
         scrollLeft={scrollX}
         visible={true}
+        columnOffsets={columnOffsets}
+        columnsToRender={columnsToRender}
         fixedColumns={fixedColumns.header}
         fixedRightColumns={fixedRightColumns.header}
         scrollableColumns={scrollableColumns.header}
@@ -852,12 +868,15 @@ class FixedDataTable extends React.Component {
     const props = this.props;
     return (
       <FixedDataTableBufferedRows
+        allowColumnVirtualization={props.allowColumnVirtualization}
         isScrolling={props.scrolling}
         fixedColumns={fixedCellTemplates}
         fixedRightColumns={fixedRightCellTemplates}
         firstViewportRowIndex={props.firstRowIndex}
         endViewportRowIndex={props.endRowIndex}
         height={bodyHeight}
+        columnsToRender={props.columnsToRender}
+        columnOffsets={props.columnOffsets}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}
         onRowContextMenu={props.onRowContextMenu}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -104,7 +104,7 @@ class FixedDataTableBufferedRows extends React.Component {
       });
     }
 
-    return <div>{this._staticRowArray}</div>;
+    return <div> {this._staticRowArray} </div>;
   }
 
   /**
@@ -142,8 +142,8 @@ class FixedDataTableBufferedRows extends React.Component {
     return (
       <FixedDataTableRow
         key={key}
-        isScrolling={props.isScrolling}
         index={rowIndex}
+        isScrolling={props.isScrolling}
         width={props.width}
         rowExpanded={props.rowExpanded}
         scrollLeft={Math.round(props.scrollLeft)}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -77,118 +77,95 @@ class FixedDataTableBufferedRows extends React.Component {
   }
 
   render() /*object*/ {
-    var props = this.props;
-    var rowClassNameGetter = props.rowClassNameGetter || emptyFunction;
-    var rowsToRender = this.props.rowsToRender || [];
+    let { offsetTop, scrollTop, isScrolling, rowsToRender } = this.props;
+    const baseOffsetTop = offsetTop - scrollTop;
+    rowsToRender = rowsToRender || [];
 
-    if (props.isScrolling) {
-      // We are scrolling, so there's no need to display any rows which lie outside the viewport.
-      // We still need to render them though, so as to not cause any mounts/unmounts.
-      this._staticRowArray.forEach((row, i) => {
-        const rowOutsideViewport = !this.isRowInsideViewport(row.props.index);
-        if (rowOutsideViewport) {
-          this._staticRowArray[i] = this.getStubRow(i, false, row.props.index);
-        }
-      });
+    if (isScrolling) {
+      // allow static array to grow while scrolling
+      this._staticRowArray.length = Math.max(this._staticRowArray.length, rowsToRender.length);
     } else {
+      // when scrolling is done, static array can shrink to fit the buffer
       this._staticRowArray.length = rowsToRender.length;
     }
 
-    var baseOffsetTop = props.offsetTop - props.scrollTop;
-
-    for (let i = 0; i < rowsToRender.length; i++) {
-      const rowIndex = rowsToRender[i];
-
-      // if the row doesn't exist in the buffer, assign a fake row to it.
-      // this is so that we can get rid of unnecessary row mounts/unmounts
+    // render each row from the buffer into the static row array
+    for (let i = 0; i < this._staticRowArray.length; i++) {
+      let rowIndex = rowsToRender[i];
+      // if the row doesn't exist in the buffer set, then take the previous one
       if (rowIndex === undefined) {
-        // if a previous row existed, let's just make use of that
-        if (this._staticRowArray[i] === undefined) {
-          this._staticRowArray[i] = this.getStubRow(i, true, -1);
-        }
-        continue;
+        rowIndex = this._staticRowArray[i] && this._staticRowArray[i].props.index;
       }
 
-      const currentRowHeight = this.props.rowSettings.rowHeightGetter(rowIndex);
-      const currentSubRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
-      const rowOffsetTop = baseOffsetTop + props.rowOffsets[rowIndex];
-      const rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
-      const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) &&
-        props.showLastRowBorder;
-      const visible = this.isRowInsideViewport(rowIndex);
-
-      this._staticRowArray[i] =
-        <FixedDataTableRow
-          key={rowKey}
-          isScrolling={props.isScrolling}
-          index={rowIndex}
-          width={props.width}
-          height={currentRowHeight}
-          subRowHeight={currentSubRowHeight}
-          rowExpanded={props.rowExpanded}
-          scrollLeft={Math.round(props.scrollLeft)}
-          offsetTop={Math.round(rowOffsetTop)}
-          visible={visible}
-          fixedColumns={props.fixedColumns}
-          fixedRightColumns={props.fixedRightColumns}
-          scrollableColumns={props.scrollableColumns}
-          onClick={props.onRowClick}
-          onContextMenu={props.onRowContextMenu}
-          onDoubleClick={props.onRowDoubleClick}
-          onMouseDown={props.onRowMouseDown}
-          onMouseUp={props.onRowMouseUp}
-          onMouseEnter={props.onRowMouseEnter}
-          onMouseLeave={props.onRowMouseLeave}
-          onTouchStart={props.onRowTouchStart}
-          onTouchEnd={props.onRowTouchEnd}
-          onTouchMove={props.onRowTouchMove}
-          showScrollbarY={props.showScrollbarY}
-          className={joinClasses(
-            rowClassNameGetter(rowIndex),
-            cx('public/fixedDataTable/bodyRow'),
-            cx({
-              'fixedDataTableLayout/hasBottomBorder': hasBottomBorder,
-              'public/fixedDataTable/hasBottomBorder': hasBottomBorder,
-            })
-          )}
-        />;
+      this._staticRowArray[i] = this.renderRow({
+        rowIndex,
+        key: i,
+        baseOffsetTop,
+      });
     }
 
     return <div>{this._staticRowArray}</div>;
   }
 
-
   /**
-   * Returns a stub row which won't be visible to the user.
-   * This allows us to still render a row and React won't unmount it.
-   *
+   * @param {number} rowIndex
    * @param {number} key
-   * @param {boolean} fake
-   * @param {number} index
+   * @param {number} baseOffsetTop
    * @return {!Object}
    */
-  getStubRow(key, fake, index) /*object*/ {
+  renderRow({ rowIndex, key, baseOffsetTop }) /*object*/ {
     const props = this.props;
+    const rowClassNameGetter = props.rowClassNameGetter || emptyFunction;
+    const fake = rowIndex === undefined;
+    let rowProps = {};
+
+    // if row exists, then calculate row specific props
+    if (!fake) {
+      rowProps.height = this.props.rowSettings.rowHeightGetter(rowIndex);
+      rowProps.subRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
+      rowProps.offsetTop = Math.round(baseOffsetTop + props.rowOffsets[rowIndex]);
+      rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
+
+      const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) && props.showLastRowBorder;
+      rowProps.className = joinClasses(
+        rowClassNameGetter(rowIndex),
+        cx('public/fixedDataTable/bodyRow'),
+        cx({
+          'fixedDataTableLayout/hasBottomBorder': hasBottomBorder,
+          'public/fixedDataTable/hasBottomBorder': hasBottomBorder,
+        })
+      );
+    }
+
+    const visible = inRange(rowIndex, this.props.firstViewportRowIndex, this.props.endViewportRowIndex);
+
     return (
       <FixedDataTableRow
         key={key}
         isScrolling={props.isScrolling}
-        index={index}
+        index={rowIndex}
         width={props.width}
-        height={0}
-        offsetTop={0}
+        rowExpanded={props.rowExpanded}
         scrollLeft={Math.round(props.scrollLeft)}
-        visible={false}
-        fake={fake}
         fixedColumns={props.fixedColumns}
         fixedRightColumns={props.fixedRightColumns}
         scrollableColumns={props.scrollableColumns}
+        onClick={props.onRowClick}
+        onContextMenu={props.onRowContextMenu}
+        onDoubleClick={props.onRowDoubleClick}
+        onMouseDown={props.onRowMouseDown}
+        onMouseUp={props.onRowMouseUp}
+        onMouseEnter={props.onRowMouseEnter}
+        onMouseLeave={props.onRowMouseLeave}
+        onTouchStart={props.onRowTouchStart}
+        onTouchEnd={props.onRowTouchEnd}
+        onTouchMove={props.onRowTouchMove}
+        showScrollbarY={props.showScrollbarY}
+        visible={visible}
+        fake={fake}
+        {...rowProps}
       />
     );
-  }
-
-  isRowInsideViewport(/*number*/rowIndex) {
-    return inRange(rowIndex, this.props.firstViewportRowIndex, this.props.endViewportRowIndex);
   }
 };
 

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -25,6 +25,7 @@ class FixedDataTableBufferedRows extends React.Component {
     firstViewportRowIndex: PropTypes.number.isRequired,
     endViewportRowIndex: PropTypes.number.isRequired,
     columnsToRender: PropTypes.array.isRequired,
+    fixedColumns: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
     columnOffsets: PropTypes.object.isRequired,
     height: PropTypes.number.isRequired,

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -20,11 +20,13 @@ import inRange from 'lodash/inRange';
 
 class FixedDataTableBufferedRows extends React.Component {
   static propTypes = {
+    allowColumnVirtualization: PropTypes.bool,
     isScrolling: PropTypes.bool,
     firstViewportRowIndex: PropTypes.number.isRequired,
     endViewportRowIndex: PropTypes.number.isRequired,
-    fixedColumns: PropTypes.array.isRequired,
+    columnsToRender: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
+    columnOffsets: PropTypes.object.isRequired,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
@@ -147,6 +149,8 @@ class FixedDataTableBufferedRows extends React.Component {
         width={props.width}
         rowExpanded={props.rowExpanded}
         scrollLeft={Math.round(props.scrollLeft)}
+        columnsToRender={props.columnsToRender}
+        columnOffsets={props.columnOffsets}
         fixedColumns={props.fixedColumns}
         fixedRightColumns={props.fixedRightColumns}
         scrollableColumns={props.scrollableColumns}
@@ -163,6 +167,7 @@ class FixedDataTableBufferedRows extends React.Component {
         showScrollbarY={props.showScrollbarY}
         visible={visible}
         fake={fake}
+        allowColumnVirtualization={props.allowColumnVirtualization}
         {...rowProps}
       />
     );

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -90,6 +90,15 @@ class FixedDataTableCell extends React.Component {
     reorderingDisplacement: 0
   }
 
+  componentDidMount() {
+    "use strict";
+    console.log("cell mounted");
+  }
+  componentWillUnmount() {
+    "use strict";
+    console.log("cell unmounted");
+  }
+
   shouldComponentUpdate(nextProps) {
     if (nextProps.isScrolling && this.props.rowIndex === nextProps.rowIndex) {
       return false;

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -90,15 +90,6 @@ class FixedDataTableCell extends React.Component {
     reorderingDisplacement: 0
   }
 
-  componentDidMount() {
-    "use strict";
-    console.log("cell mounted");
-  }
-  componentWillUnmount() {
-    "use strict";
-    console.log("cell unmounted");
-  }
-
   shouldComponentUpdate(nextProps) {
     if (nextProps.isScrolling && this.props.rowIndex === nextProps.rowIndex) {
       return false;

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -80,14 +80,17 @@ class FixedDataTableContainer extends React.Component {
   update() {
     const state = this.reduxStore.getState();
     const boundState = pick(state, [
+      'allowColumnVirtualization',
       'columnGroupProps',
+      'columnOffsets',
       'columnProps',
       'columnReorderingData',
       'columnResizingData',
+      'columnsToRender',
       'elementHeights',
       'elementTemplates',
-      'firstRowIndex',
       'endRowIndex',
+      'firstRowIndex',
       'isColumnReordering',
       'isColumnResizing',
       'maxScrollX',

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -153,6 +153,11 @@ class FixedDataTableRowImpl extends React.Component {
     touchEnabled: PropTypes.bool,
   };
 
+  shouldComponentUpdate(nextProps) {
+    // only render if row is visible
+    return nextProps.visible;
+  }
+
   render() /*object*/ {
     if (this.props.fake) {
       return null;
@@ -461,7 +466,7 @@ class FixedDataTableRow extends React.Component {
     };
     FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
 
-    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
+    const { offsetTop, zIndex, ...rowProps } = this.props;
 
     return (
       <div

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -461,7 +461,7 @@ class FixedDataTableRow extends React.Component {
     };
     FixedDataTableTranslateDOMPosition(style, 0, this.props.offsetTop, this._initialRender);
 
-    const { offsetTop, zIndex, ...rowProps } = this.props;
+    const { offsetTop, zIndex, visible, ...rowProps } = this.props;
 
     return (
       <div

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -38,6 +38,11 @@ class FixedDataTableRowImpl extends React.Component {
 
   static propTypes = {
 
+    /**
+     * Only columns within the viewport will be considered for rendering.
+     */
+    allowColumnVirtualization: PropTypes.bool,
+
     isScrolling: PropTypes.bool,
 
     /**
@@ -82,6 +87,16 @@ class FixedDataTableRowImpl extends React.Component {
      * Array of data for the scrollable columns.
      */
     scrollableColumns: PropTypes.array.isRequired,
+
+    /**
+     * The list of columns to render.
+     */
+    columnsToRender: PropTypes.array,
+
+    /**
+     * The offsets of the scrollable columns
+     */
+    columnOffsets: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 
     /**
      * The distance between the left edge of the table and the leftmost portion
@@ -218,6 +233,7 @@ class FixedDataTableRowImpl extends React.Component {
       this._renderFixedRightColumnsShadow(this.props.width - fixedRightColumnsWidth - scrollbarOffset - 5) : null;
     var scrollableColumns =
       <FixedDataTableCellGroup
+        allowColumnVirtualization={this.props.allowColumnVirtualization}
         key="scrollable_cells"
         isScrolling={this.props.isScrolling}
         height={this.props.height}
@@ -228,6 +244,8 @@ class FixedDataTableRowImpl extends React.Component {
         width={this.props.width - fixedColumnsWidth - fixedRightColumnsWidth - scrollbarOffset}
         zIndex={0}
         columns={this.props.scrollableColumns}
+        columnsToRender={this.props.columnsToRender}
+        columnOffsets={this.props.columnOffsets}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
         onColumnReorder={this.props.onColumnReorder}

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -153,11 +153,6 @@ class FixedDataTableRowImpl extends React.Component {
     touchEnabled: PropTypes.bool,
   };
 
-  shouldComponentUpdate(nextProps) {
-    // only render if row is visible
-    return nextProps.visible;
-  }
-
   render() /*object*/ {
     if (this.props.fake) {
       return null;

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -32,6 +32,7 @@ export default function computeRenderedColumns(state, columnAnchor) {
     scrollX = newState.columnOffsets[columnRange.firstViewportCol] - newState.firstColumnOffset;
   }
   const { maxScrollX } = columnWidths(state);
+  newState.maxScrollX = maxScrollX;
   newState.scrollX = clamp(scrollX, 0, maxScrollX);
 
   return newState;
@@ -88,33 +89,33 @@ function calculateRenderedColumnRange(state, columnAnchor) {
   // Walk the viewport until filled with columns
   // If lastIndex is set, walk backward so that column is the last in the viewport
   let step = 1;
-  let startIdy = firstIndex;
+  let startIdx = firstIndex;
   let totalWidth = firstOffset;
   if (lastIndex !== undefined) {
     step = -1;
-    startIdy = lastIndex;
+    startIdx = lastIndex;
     totalWidth = 0;
   }
 
   // Loop to walk the viewport until we've touched enough columns to fill its width
-  let columnIdx = startIdy;
-  let endIdy = columnIdx;
+  let columnIdx = startIdx;
+  let endIdx = columnIdx;
   while (columnIdx < columnCount && columnIdx >= 0 &&
       totalWidth < availableScrollWidth) {
     totalWidth += updateColumnWidth(state, columnIdx);
-    endIdy = columnIdx;
+    endIdx = columnIdx;
     columnIdx += step;
   }
 
   // Loop to walk the leading buffer
-  let firstViewportCol = Math.min(startIdy, endIdy);
+  let firstViewportCol = Math.min(startIdx, endIdx);
   const firstBufferCol = Math.max(firstViewportCol - bufferColumnCount, 0);
   for (columnIdx = firstBufferCol; columnIdx < firstViewportCol; columnIdx++) {
     updateColumnWidth(state, columnIdx);
   }
 
   // Loop to walk the trailing buffer
-  const endViewportCol = Math.max(startIdy, endIdy) + 1;
+  const endViewportCol = Math.max(startIdx, endIdx) + 1;
   const endBufferCol = Math.min(endViewportCol + bufferColumnCount, columnCount);
   for (columnIdx = endViewportCol; columnIdx < endBufferCol; columnIdx++) {
     updateColumnWidth(state, columnIdx);

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -1,0 +1,232 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule computeRenderedColumns
+ */
+
+'use strict';
+
+import clamp from 'lodash/clamp';
+import columnWidths from 'columnWidths';
+import scrollbarsVisibleSelector from 'scrollbarsVisible';
+import { updateColumnWidth, updateColumnGroupWidth } from 'updateColumnWidth';
+
+export default function computeRenderedColumns(state, columnAnchor) {
+  // clone state
+  const newState = Object.assign({}, state);
+  
+  // get buffer and viewport range
+  const columnRange = calculateRenderedColumnRange(newState, columnAnchor);
+  
+  // update the offsets and buffer mapping
+  computeRenderedColumnOffsets(newState, columnRange, newState.scrolling);
+
+  // scrollX might have changed due to change in columns and offsets
+  let scrollX = state.scrollX;
+  if (columnRange.firstViewportCol !== columnRange.endViewportCol) {
+    scrollX = newState.columnOffsets[columnRange.firstViewportCol] - newState.firstColumnOffset;
+  }
+  const { maxScrollX } = columnWidths(state);
+  newState.scrollX = clamp(scrollX, 0, maxScrollX);
+
+  return newState;
+}
+
+/**
+ * Determine the range of columns to render (buffer and viewport)
+ * The leading and trailing buffer is based on a fixed count,
+ * while the viewport columns are based on their width and the viewport width.
+ * We use the columnAnchor to determine what either the first or last column
+ * will be, as well as the offset.
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {{
+ *   firstIndex: number,
+ *   firstOffset: number,
+ *   lastIndex: number,
+ * }} columnAnchor
+ * @return {{
+ *   endBufferCol: number,
+ *   endViewportCol: number,
+ *   firstBufferCol: number,
+ *   firstViewportCol: number,
+ * }}
+ * @private
+ */
+function calculateRenderedColumnRange(state, columnAnchor) {
+  const bufferColumnCount = 0; // TODO (pradeep): calculate this similar to bufferRowCount
+  const { availableScrollWidth, scrollableColumns } = columnWidths(state);
+  const columnCount = scrollableColumns.length;
+
+  if (availableScrollWidth === 0 || columnCount === 0) {
+    state.firstColumnIndex = 0;
+    state.endColumnIndex = 0;
+    state.firstColumnOffset = 0;
+    return {
+      endBufferCol: 0,
+      endViewportCol: 0,
+      firstBufferCol: 0,
+      firstViewportCol: 0,
+    };
+  }
+
+  // If our first or last index is greater than our columnCount,
+  // treat it as if the last column is at the end of the viewport
+  let { firstIndex, firstOffset, lastIndex } = columnAnchor;
+  if (firstIndex >= columnCount || lastIndex >= columnCount) {
+    lastIndex = columnCount - 1;
+  }
+
+  // Walk the viewport until filled with columns
+  // If lastIndex is set, walk backward so that column is the last in the viewport
+  let step = 1;
+  let startIdy = firstIndex;
+  let totalWidth = firstOffset;
+  if (lastIndex !== undefined) {
+    step = -1;
+    startIdy = lastIndex;
+    totalWidth = 0;
+  }
+
+  // Loop to walk the viewport until we've touched enough columns to fill its width
+  let columnIdx = startIdy;
+  let endIdy = columnIdx;
+  while (columnIdx < columnCount && columnIdx >= 0 &&
+      totalWidth < availableScrollWidth) {
+    totalWidth += updateColumnWidth(state, columnIdx);
+    endIdy = columnIdx;
+    columnIdx += step;
+  }
+
+  // Loop to walk the leading buffer
+  let firstViewportCol = Math.min(startIdy, endIdy);
+  const firstBufferCol = Math.max(firstViewportCol - bufferColumnCount, 0);
+  for (columnIdx = firstBufferCol; columnIdx < firstViewportCol; columnIdx++) {
+    updateColumnWidth(state, columnIdx);
+  }
+
+  // Loop to walk the trailing buffer
+  const endViewportCol = Math.max(startIdy, endIdy) + 1;
+  const endBufferCol = Math.min(endViewportCol + bufferColumnCount, columnCount);
+  for (columnIdx = endViewportCol; columnIdx < endBufferCol; columnIdx++) {
+    updateColumnWidth(state, columnIdx);
+  }
+
+  // Calculate offset needed to position column at the end of viewport
+  // This should be negative and represent how far the first column needs to be offscreen
+  if (lastIndex !== undefined) {
+    firstOffset = Math.min(availableScrollWidth - totalWidth, 0);
+  }
+
+  state.firstColumnIndex = firstViewportCol;
+  state.endColumnIndex = endViewportCol;
+  state.firstColumnOffset = firstOffset;
+
+  return {
+    endBufferCol,
+    endViewportCol,
+    firstBufferCol,
+    firstViewportCol,
+  };
+}
+
+/**
+ * Walk the columns to render and compute the width offsets and
+ * positions in the column buffer.
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {{
+ *   endBufferCol: number,
+ *   endViewportCol: number,
+ *   firstBufferCol: number,
+ *   firstViewportCol: number,
+ * }} columnRange
+ * @param {boolean} viewportOnly
+ * @private
+ */
+function computeRenderedColumnOffsets(state, columnRange, viewportOnly) {
+  const { columnBufferSet, columnOffsetIntervalTree } = state;
+  const {
+    endBufferCol,
+    endViewportCol,
+    firstBufferCol,
+    firstViewportCol,
+  } = columnRange;
+
+  const renderedColumnsCount = endBufferCol - firstBufferCol;
+  if (renderedColumnsCount === 0) {
+    state.columnOffsets = {};
+    state.columnsToRender = [];
+    return;
+  }
+
+  const startIdx = viewportOnly ? firstViewportCol : firstBufferCol;
+  const endIdx = viewportOnly ? endViewportCol : endBufferCol;
+
+  // output for this function
+  const columns = []; // state.columnsToRender
+  const columnOffsets = {}; // state.columnOffsets
+
+  // incremental way for calculating columnOffset
+  let runningOffset = columnOffsetIntervalTree.sumUntil(startIdx);
+
+  // compute column index and offsets for every columns inside the buffer
+  for (let columnIdx = startIdx; columnIdx < endIdx; columnIdx++) {
+
+    // Update the offset for rendering the column
+    columnOffsets[columnIdx] = runningOffset;
+    runningOffset += columnOffsetIntervalTree.get(columnIdx);
+
+    // Get position for the viewport column
+    const columnPosition = addColumnToBuffer(columnIdx, columnBufferSet, startIdx, endIdx, renderedColumnsCount);
+    columns[columnPosition] = columnIdx;
+  }
+
+  // now we modify the state with the newly calculated columns and offsets
+  state.columnsToRender = columns;
+  state.columnOffsets = columnOffsets;
+}
+
+/**
+ * Add the column to the buffer set if it doesn't exist.
+ * If addition isn't possible due to max buffer size, it'll replace an existing element outside the given range.
+ *
+ * @param {!number} columnIdx
+ * @param {!number} columnBufferSet
+ * @param {!number} startRange
+ * @param {!number} endRange
+ * @param {!number} maxBufferSize
+ *
+ * @return {?number} the position of the column after being added to the buffer set
+ * @private
+ */
+function addColumnToBuffer(columnIdx, columnBufferSet, startRange, endRange, maxBufferSize) {
+  // Check if column already has a position in the buffer
+  let columnPosition = columnBufferSet.getValuePosition(columnIdx);
+
+  // Request a position in the buffer through eviction of another column
+  if (columnPosition === null && columnBufferSet.getSize() >= maxBufferSize)  {
+    columnPosition = columnBufferSet.replaceFurthestValuePosition(
+      startRange,
+      endRange - 1, // replaceFurthestValuePosition uses closed interval from startRange to endRange
+      columnIdx
+    );
+  }
+
+  if (columnPosition === null) {
+    columnPosition = columnBufferSet.getNewPositionForValue(columnIdx);
+  }
+
+  return columnPosition;
+}

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -21,20 +21,20 @@ import tableHeightsSelector from 'tableHeights';
  * Returns data about the rows to render
  * rows is a map of rowIndexes to render to their heights
  * firstRowIndex & firstRowOffset are calculated based on the lastIndex if
- * specified in scrollAnchor.
- * Otherwise, they are unchanged from the firstIndex & firstOffset scrollAnchor values.
+ * specified in rowAnchor.
+ * Otherwise, they are unchanged from the firstIndex & firstOffset rowAnchor values.
  *
  * @param {!Object} state
  * @param {{
  *   firstIndex: number,
  *   firstOffset: number,
  *   lastIndex: number,
- * }} scrollAnchor
+ * }} rowAnchor
  * @return {!Object} The updated state object
  */
-export default function computeRenderedRows(state, scrollAnchor) {
+export default function computeRenderedRows(state, rowAnchor) {
   const newState = Object.assign({}, state);
-  let rowRange = calculateRenderedRowRange(newState, scrollAnchor);
+  let rowRange = calculateRenderedRowRange(newState, rowAnchor);
 
   const { rowSettings, scrollContentHeight } = newState;
   const { rowsCount } = rowSettings;
@@ -81,7 +81,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
  * Determine the range of rows to render (buffer and viewport)
  * The leading and trailing buffer is based on a fixed count,
  * while the viewport rows are based on their height and the viewport height
- * We use the scrollAnchor to determine what either the first or last row
+ * We use the rowAnchor to determine what either the first or last row
  * will be, as well as the offset.
  *
  * NOTE (jordan) This alters state so it shouldn't be called
@@ -92,7 +92,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
  *   firstIndex: number,
  *   firstOffset: number,
  *   lastIndex: number,
- * }} scrollAnchor
+ * }} rowAnchor
  * @return {{
  *   endBufferIdx: number,
  *   endViewportIdx: number,
@@ -102,7 +102,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
  * }}
  * @private
  */
-function calculateRenderedRowRange(state, scrollAnchor) {
+function calculateRenderedRowRange(state, rowAnchor) {
   const { bufferRowCount, maxAvailableHeight } = roughHeightsSelector(state);
   const rowsCount = state.rowSettings.rowsCount;
 
@@ -119,7 +119,7 @@ function calculateRenderedRowRange(state, scrollAnchor) {
 
   // If our first or last index is greater than our rowsCount,
   // treat it as if the last row is at the bottom of the viewport
-  let { firstIndex, firstOffset, lastIndex } = scrollAnchor;
+  let { firstIndex, firstOffset, lastIndex } = rowAnchor;
   if (firstIndex >= rowsCount || lastIndex >= rowsCount) {
     lastIndex = rowsCount - 1;
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import { getScrollAnchor, scrollTo } from 'scrollAnchor';
+import { getRowAnchor, scrollTo } from 'rowAnchor';
 import * as ActionTypes from 'ActionTypes';
 import IntegerBufferSet from 'IntegerBufferSet';
 import PrefixIntervalTree from 'PrefixIntervalTree';
@@ -75,8 +75,6 @@ function getInitialState() {
      * NOTE (jordan) rows may contain undefineds if we don't need all the buffer positions
      */
     columnOffsets: {},
-    fixedColumnOffsets: {},
-    fixedRightOffsets: {},
     columnsToRender: [],
     columnReorderingData: {},
     columnResizingData: {},
@@ -117,8 +115,8 @@ function reducers(state = getInitialState(), action) {
       let newState = setStateFromProps(state, props);
       newState = initializeRowHeightsAndOffsets(newState);
       newState = initializeColumnOffsets(newState);
-      const scrollAnchor = getScrollAnchor(newState, props);
-      newState = computeRenderedRows(newState, scrollAnchor);
+      const rowAnchor = getRowAnchor(newState, props);
+      newState = computeRenderedRows(newState, rowAnchor);
       newState = columnStateHelper.initialize(newState, props, {});
       return computeRenderedColumns(newState, newState.columnAnchor);
     }
@@ -138,11 +136,11 @@ function reducers(state = getInitialState(), action) {
         newState.rowBufferSet = new IntegerBufferSet();
       }
 
-      const scrollAnchor = getScrollAnchor(newState, newProps, oldProps);
+      const rowAnchor = getRowAnchor(newState, newProps, oldProps);
 
       // If anything has changed in state, update our rendered rows
-      if (!shallowEqual(state, newState) || scrollAnchor.changed) {
-        newState = computeRenderedRows(newState, scrollAnchor);
+      if (!shallowEqual(state, newState) || rowAnchor.changed) {
+        newState = computeRenderedRows(newState, rowAnchor);
       }
 
       newState = columnStateHelper.initialize(newState, newProps, oldProps);
@@ -181,8 +179,8 @@ function reducers(state = getInitialState(), action) {
       const newState = Object.assign({}, state, {
         scrolling: true,
       });
-      const scrollAnchor = scrollTo(newState, scrollY);
-      return computeRenderedRows(newState, scrollAnchor);
+      const rowAnchor = scrollTo(newState, scrollY);
+      return computeRenderedRows(newState, rowAnchor);
     }
     case ActionTypes.COLUMN_RESIZE: {
       const { resizeData } = action;

--- a/src/reducers/rowAnchor.js
+++ b/src/reducers/rowAnchor.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule scrollAnchor
+ * @providesModule rowAnchor
  */
 
 'use strict';
@@ -17,7 +17,7 @@ import updateRowHeight from 'updateRowHeight';
 import scrollbarsVisibleSelector from 'scrollbarsVisible';
 
 /**
- * Get the anchor for scrolling.
+ * Get the row anchor for scrolling.
  * This will either be the first row's index and an offset, or the last row's index.
  * We also pass a flag indicating if the anchor has changed from the state
  *
@@ -31,7 +31,7 @@ import scrollbarsVisibleSelector from 'scrollbarsVisible';
  *   changed: boolean,
  * }}
  */
-export function getScrollAnchor(state, newProps, oldProps) {
+export function getRowAnchor(state, newProps, oldProps) {
   if (newProps.scrollToRow !== undefined &&
       newProps.scrollToRow !== null &&
       (!oldProps || newProps.scrollToRow !== oldProps.scrollToRow)) {

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule updateColumnWidth
+ */
+
+'use strict';
+
+import columnWidths from 'columnWidths';
+
+/**
+ * Update our cached col width for a specific index
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {number} columnIdx
+ * @return {number} The new col width
+ */
+function updateColumnWidth(state, columnIdx) {
+  const { scrollableColumns } = columnWidths(state);
+  const { columnOffsetIntervalTree } = state;
+  const newWidth = scrollableColumns[columnIdx].width;
+  const oldWidth = columnOffsetIntervalTree.get(columnIdx);
+  if (newWidth !== oldWidth) {
+    columnOffsetIntervalTree.set(columnIdx, newWidth);
+  }
+
+  return newWidth;
+}
+
+export { updateColumnWidth };

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -48,13 +48,14 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     newColumnGroupProps,
     newColumnProps,
   } = flexWidths(columnGroupProps, columnProps, viewportWidth);
+
   const {
     fixedColumns,
     fixedRightColumns,
     scrollableColumns,
   } = groupColumns(newColumnProps);
 
-  const availableScrollWidth = viewportWidth - getTotalWidth(fixedColumns) - getTotalWidth(fixedRightColumns);
+  const availableScrollWidth = Math.max(viewportWidth - getTotalWidth(fixedColumns) - getTotalWidth(fixedRightColumns), 0);
   const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
   return {
     columnGroupProps: newColumnGroupProps,

--- a/test/reducers/scrollAnchor-test.js
+++ b/test/reducers/scrollAnchor-test.js
@@ -2,9 +2,9 @@
  * Copyright Schrodinger, LLC
  */
 import { assert } from 'chai';
-import { __RewireAPI__, getScrollAnchor } from 'scrollAnchor';
+import { __RewireAPI__, getRowAnchor } from 'rowAnchor';
 
-describe('scrollAnchor', function() {
+describe('rowAnchor', function() {
   beforeEach(function() {
     __RewireAPI__.__Rewire__('scrollbarsVisibleSelector', () => ({
       availableHeight: 600,
@@ -31,8 +31,8 @@ describe('scrollAnchor', function() {
     });
 
     it('should scroll to row and offset of scrollY', function() {
-      const scrollAnchor = getScrollAnchor(oldState, { scrollTop: 2150 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollTop: 2150 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 21,
         firstOffset: -50,
         lastIndex: undefined,
@@ -41,8 +41,8 @@ describe('scrollAnchor', function() {
     });
 
     it('should scroll to first index if scrollY < 0', function() {
-      const scrollAnchor = getScrollAnchor(oldState, { scrollTop: -200 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollTop: -200 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 0,
         firstOffset: 0,
         lastIndex: undefined,
@@ -51,8 +51,8 @@ describe('scrollAnchor', function() {
     });
 
     it('should scroll to last index if scrollY is larger than max scroll', function() {
-      const scrollAnchor = getScrollAnchor(oldState, { scrollTop: 9500 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollTop: 9500 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: undefined,
         firstOffset: 0,
         lastIndex: 99,
@@ -63,8 +63,8 @@ describe('scrollAnchor', function() {
     it('should scroll to first index if rowsCount is 0', function() {
       oldState.rowSettings.rowsCount = 0;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollTop: 9500 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollTop: 9500 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 0,
         firstOffset: 0,
         lastIndex: undefined,
@@ -96,8 +96,8 @@ describe('scrollAnchor', function() {
     it('should scroll forward to row', function() {
       oldState.scrollY = 2000;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollToRow: 40 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollToRow: 40 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: undefined,
         firstOffset: 0,
         lastIndex: 40,
@@ -108,8 +108,8 @@ describe('scrollAnchor', function() {
     it('should scroll backward to row', function() {
       oldState.scrollY = 5000;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollToRow: 40 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollToRow: 40 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 40,
         firstOffset: 0,
         lastIndex: undefined,
@@ -122,8 +122,8 @@ describe('scrollAnchor', function() {
       oldState.firstRowIndex = 38;
       oldState.firstRowOffset = 50;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollToRow: 40 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollToRow: 40 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 38,
         firstOffset: 50,
         lastIndex: undefined,
@@ -136,8 +136,8 @@ describe('scrollAnchor', function() {
       oldState.firstRowOffset = 50;
       oldState.rowSettings.rowsCount = 0;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollToRow: 40 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollToRow: 40 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 0,
         firstOffset: 0,
         lastIndex: undefined,
@@ -148,8 +148,8 @@ describe('scrollAnchor', function() {
     it('should treat a negative row index as 0', function() {
       oldState.scrollY = 2000;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollToRow: -20 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollToRow: -20 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: 0,
         firstOffset: 0,
         lastIndex: undefined,
@@ -160,8 +160,8 @@ describe('scrollAnchor', function() {
     it('should clamp to the max row', function() {
       oldState.scrollY = 2000;
 
-      const scrollAnchor = getScrollAnchor(oldState, { scrollToRow: 200 }, {});
-      assert.deepEqual(scrollAnchor, {
+      const rowAnchor = getRowAnchor(oldState, { scrollToRow: 200 }, {});
+      assert.deepEqual(rowAnchor, {
         firstIndex: undefined,
         firstOffset: 0,
         lastIndex: 99,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Initial step towards column virtualization.

* Add reducers to handle virtualization for columns (similar to how we do it for rows).

* To manage columns in the viewport, we make use of `IntegerBufferSet`. This provides a mapping of columns to indices, such that removing/adding columns will only result in minimal position changes.

* To manage offsets, we use `PrefixIntervalTree`, which can be used for efficient O(1) retrieval of column offsets ( O(logN) for update though ). In the future, it'll be easy to lazy fetch column offsets with this.

* **In later PRs, we'll actually use the calculated reducer output to use in our view components.**

## Navigate
## Navigate
#461 - Add reducer to virtualize columns (*)
#462 - Use virtualized columns from reducer in views
#463 - Virtualize Column Groups 
#464 - ~Introduce Virtualization API~
#472 - Cleanup + Fix tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current implementation doesn't use IntegerBufferSet, thus causing constant cell mounts/unmounts as user scrolls horizontally.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All of our examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
