### PR TITLE
Column Virtualization - Virtualize Column Groups (Step 3) 

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -639,9 +639,11 @@ class FixedDataTable extends React.Component {
       allowColumnVirtualization,
       className,
       columnOffsets,
+      columnGroupOffsets,
       columnReorderingData,
       columnResizingData,
       columnsToRender,
+      columnGroupsToRender,
       elementHeights,
       isColumnReordering,
       isColumnResizing,
@@ -666,6 +668,7 @@ class FixedDataTable extends React.Component {
     if (groupHeaderHeight > 0) {
       groupHeader = (
         <FixedDataTableRow
+          allowColumnVirtualization={allowColumnVirtualization}
           key="group_header"
           isScrolling={scrolling}
           className={joinClasses(
@@ -682,6 +685,8 @@ class FixedDataTable extends React.Component {
           fixedColumns={fixedColumnGroups}
           fixedRightColumns={fixedRightColumnGroups}
           scrollableColumns={scrollableColumnGroups}
+          columnOffsets={columnGroupOffsets}
+          columnsToRender={columnGroupsToRender}
           visible={true}
           onColumnResize={this._onColumnResize}
           onColumnReorder={onColumnReorder}

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -86,6 +86,8 @@ class FixedDataTableContainer extends React.Component {
       'columnProps',
       'columnReorderingData',
       'columnResizingData',
+      'columnGroupOffsets',
+      'columnGroupsToRender',
       'columnsToRender',
       'elementHeights',
       'elementTemplates',

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -196,6 +196,7 @@ class FixedDataTableRowImpl extends React.Component {
         width={fixedColumnsWidth}
         zIndex={2}
         columns={this.props.fixedColumns}
+        columnOffsets={this.props.fixedColumnOffsets}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
         onColumnReorder={this.props.onColumnReorder}
@@ -219,6 +220,7 @@ class FixedDataTableRowImpl extends React.Component {
         width={fixedRightColumnsWidth}
         zIndex={2}
         columns={this.props.fixedRightColumns}
+        columnOffsets={this.props.fixedRightColumnOffsets}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
         onColumnReorder={this.props.onColumnReorder}

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -14,6 +14,7 @@
 import React from 'react';
 import forEach from 'lodash/forEach';
 import invariant from 'invariant';
+import get from 'lodash/get';
 import map from 'lodash/map';
 import pick from 'lodash/pick';
 
@@ -76,6 +77,7 @@ function convertColumnElementsToData(childComponents) {
         columnProps.push(column);
         _extractTemplates(elementTemplates, child);
       });
+      columnGroupProps[index].childrenCount = get(columnGroupElement, 'props.children.length', 0);
     });
 
     return {

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -176,7 +176,7 @@ function calculateRenderedColumnGroups(state, columnAnchor, columnRange) {
 
   // get first and last scrollable columns in the view port
   const startScrollableColumn = scrollableColumns[Math.max(0, columnRange.firstViewportCol)];
-  const endScrollableColumn = scrollableColumns[Math.max(0, columnRange.endViewportCol - 1)] + 1;
+  const endScrollableColumn = scrollableColumns[Math.max(0, columnRange.endViewportCol - 1)];
 
   // now get the first and last scrollable group column's index in the view port
   const startIdx = columnGroupIndex[startScrollableColumn.groupIdx];

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -140,7 +140,7 @@ function calculateRenderedColumnRange(state, columnAnchor) {
 }
 
 /**
- * Determine the range amd offsets of column groups to be rendered (buffer and viewport)
+ * Determine the range and offsets of column groups to be rendered (buffer and viewport)
  *
  * NOTE (jordan) This alters state so it shouldn't be called
  * without state having been cloned first.
@@ -198,7 +198,10 @@ function calculateRenderedColumnGroups(state, columnAnchor, columnRange) {
     }
   }
 
-  const renderedColumnsCount = endIdx - startIdx + 2 * bufferColumnCount;
+  // calculate total number of columns to be rendered (which are the ones in the viewport and in the buffer)
+  const columnsCountBefore = Math.max(startIdx - bufferColumnCount, 0);
+  const columnsCountAfter = Math.min(startIdx - bufferColumnCount, columnGroupCount);
+  const renderedColumnsCount = endIdx - startIdx + columnsCountBefore + columnsCountAfter;
 
   // incremental way for calculating columnOffset
   let runningOffset = columnOffsetIntervalTree.sumUntil(scrollableColumnGroups[startIdx].firstChildIdx);

--- a/src/reducers/computeRenderedColumns.js
+++ b/src/reducers/computeRenderedColumns.js
@@ -69,7 +69,7 @@ function calculateRenderedColumnRange(state, columnAnchor) {
   const { availableScrollWidth, scrollableColumns } = columnWidths(state);
   const columnCount = scrollableColumns.length;
 
-  if (columnCount === 0) {
+  if (availableScrollWidth === 0 || columnCount === 0) {
     return {
       endBufferCol: 0,
       endViewportCol: 0,
@@ -174,16 +174,20 @@ function calculateRenderedColumnGroups(state, columnAnchor, columnRange) {
     return;
   }
 
-  const { firstOffset } = columnAnchor;
-  const startIdx = columnGroupIndex[scrollableColumns[Math.max(0, columnRange.firstViewportCol)].groupIdx];
-  const endIdx = columnGroupIndex[scrollableColumns[Math.max(0, columnRange.endViewportCol - 1)].groupIdx];
+  // get first and last scrollable columns in the view port
+  const startScrollableColumn = scrollableColumns[Math.max(0, columnRange.firstViewportCol)];
+  const endScrollableColumn = scrollableColumns[Math.max(0, columnRange.endViewportCol - 1)] + 1;
+
+  // now get the first and last scrollable group column's index in the view port
+  const startIdx = columnGroupIndex[startScrollableColumn.groupIdx];
+  const endIdx = columnGroupIndex[endScrollableColumn.groupIdx] + 1;
 
   // output for this function
   const columns = []; // state.columnsToRender
   const columnOffsets = {}; // state.columnOffsets
 
   // update offsets for the columns
-  let totalWidth = firstOffset;
+  let totalWidth = columnAnchor.firstOffset;
   for (let currentIdx = startIdx; currentIdx < endIdx; currentIdx++) {
     totalWidth += updateColumnGroupWidth(state, currentIdx);
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -103,9 +103,11 @@ function getInitialState() {
      */
     rowBufferSet: new IntegerBufferSet(),
     columnBufferSet: new IntegerBufferSet(),
+    columnGroupBufferSet: new IntegerBufferSet(),
     storedHeights: [],
     rowOffsetIntervalTree: null, // PrefixIntervalTree
     columnOffsetIntervalTree: null, // PrefixIntervalTree
+    columnGroupOffsetIntervalTree: null, // PrefixIntervalTree
   };
 }
 
@@ -246,11 +248,13 @@ function initializeRowHeightsAndOffsets(state) {
  * @private
  */
 function initializeColumnOffsets(state) {
-  const { scrollableColumns } = columnWidths(state);
+  const { scrollableColumns, scrollableColumnGroups } = columnWidths(state);
   const columnOffsetIntervalTree = new PrefixIntervalTree(scrollableColumns.map(column => column.width));
+  const columnGroupOffsetIntervalTree = new PrefixIntervalTree(scrollableColumnGroups.map(column => column.width));
 
   return Object.assign({}, state, {
     columnOffsetIntervalTree,
+    columnGroupOffsetIntervalTree,
   });
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -74,6 +74,8 @@ function getInitialState() {
      * Output state passed as props to the the rendered FixedDataTable
      * NOTE (jordan) rows may contain undefineds if we don't need all the buffer positions
      */
+    columnGroupOffsets: {},
+    columnGroupsToRender: [],
     columnOffsets: {},
     columnsToRender: [],
     columnReorderingData: {},
@@ -105,7 +107,6 @@ function getInitialState() {
     storedHeights: [],
     rowOffsetIntervalTree: null, // PrefixIntervalTree
     columnOffsetIntervalTree: null, // PrefixIntervalTree
-    columnGroupOffsetIntervalTree: null, // PrefixIntervalTree
   };
 }
 
@@ -246,13 +247,11 @@ function initializeRowHeightsAndOffsets(state) {
  * @private
  */
 function initializeColumnOffsets(state) {
-  const { scrollableColumns, scrollableColumnGroups } = columnWidths(state);
+  const { scrollableColumns } = columnWidths(state);
   const columnOffsetIntervalTree = new PrefixIntervalTree(scrollableColumns.map(column => column.width));
-  const columnGroupOffsetIntervalTree = new PrefixIntervalTree(scrollableColumnGroups.map(column => column.width));
 
   return Object.assign({}, state, {
     columnOffsetIntervalTree,
-    columnGroupOffsetIntervalTree,
   });
 }
 

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -35,28 +35,4 @@ function updateColumnWidth(state, columnIdx) {
   return newWidth;
 }
 
-/**
- * Update our cached col group width for a specific index
- *
- * NOTE (jordan) This alters state so it shouldn't be called
- * without state having been cloned first.
- *
- * @param {!Object} state
- * @param {number} columnIdx
- * @return {number} The new col width
- */
-function updateColumnGroupWidth(state, columnIdx) {
-  const { columnGroupProps, scrollableColumnGroupIndex } = columnWidths(state);
-  const { columnGroupOffsetIntervalTree } = state;
-
-  const newWidth = columnGroupProps[scrollableColumnGroupIndex[columnIdx]].width;
-  const oldWidth = columnGroupOffsetIntervalTree.get(columnIdx);
-
-  if (newWidth !== oldWidth) {
-    columnGroupOffsetIntervalTree.set(columnIdx, newWidth);
-  }
-
-  return newWidth;
-}
-
-export { updateColumnGroupWidth, updateColumnWidth };
+export { updateColumnWidth };

--- a/src/reducers/updateColumnWidth.js
+++ b/src/reducers/updateColumnWidth.js
@@ -35,4 +35,28 @@ function updateColumnWidth(state, columnIdx) {
   return newWidth;
 }
 
-export { updateColumnWidth };
+/**
+ * Update our cached col group width for a specific index
+ *
+ * NOTE (jordan) This alters state so it shouldn't be called
+ * without state having been cloned first.
+ *
+ * @param {!Object} state
+ * @param {number} columnIdx
+ * @return {number} The new col width
+ */
+function updateColumnGroupWidth(state, columnIdx) {
+  const { columnGroupProps, scrollableColumnGroupIndex } = columnWidths(state);
+  const { columnGroupOffsetIntervalTree } = state;
+
+  const newWidth = columnGroupProps[scrollableColumnGroupIndex[columnIdx]].width;
+  const oldWidth = columnGroupOffsetIntervalTree.get(columnIdx);
+
+  if (newWidth !== oldWidth) {
+    columnGroupOffsetIntervalTree.set(columnIdx, newWidth);
+  }
+
+  return newWidth;
+}
+
+export { updateColumnGroupWidth, updateColumnWidth };

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -54,14 +54,11 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     fixedRightColumns,
     scrollableColumns,
     scrollableColumnGroups,
-    scrollableColumnGroupIndex,
-    columnGroupIndex,
   } = groupColumns(newColumnProps, newColumnGroupProps);
 
   const availableScrollWidth = Math.max(viewportWidth - getTotalWidth(fixedColumns) - getTotalWidth(fixedRightColumns), 0);
   const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
   return {
-    columnGroupIndex,
     columnGroupProps: newColumnGroupProps,
     columnProps: newColumnProps,
     availableScrollWidth,
@@ -69,7 +66,6 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     fixedRightColumns,
     scrollableColumns,
     scrollableColumnGroups,
-    scrollableColumnGroupIndex,
     maxScrollX,
   };
 }
@@ -136,11 +132,9 @@ function flexWidths(columnGroupProps, columnProps, viewportWidth) {
  * @param {!Array.<columnDefinition>} columnProps
  * @param {!Array.<columnDefinition>} columnGroupProps
  * @return {{
- *   columnGroupIndex: !Array.<number>,
  *   fixedColumns: !Array.<columnDefinition>,
  *   fixedRightColumns: !Array.<columnDefinition>,
  *   scrollableColumns: !Array.<columnDefinition>,
- *   scrollableColumnGroupIndex: !Array.<number>,
  *   scrollableColumnGroups: !Array.<columnDefinition>,
  * }}
  */
@@ -149,8 +143,6 @@ function groupColumns(columnProps, columnGroupProps) {
   const fixedRightColumns = [];
   const scrollableColumns = [];
   const scrollableColumnGroups = [];
-  const columnGroupIndex = [];
-  const scrollableColumnGroupIndex = [];
 
   forEach(columnProps, columnProp => {
     let container = scrollableColumns;
@@ -162,13 +154,17 @@ function groupColumns(columnProps, columnGroupProps) {
     container.push(columnProp);
   });
 
-  // group the scrollable column groups together and also provide
-  // index mapping (and inverse mapping) from the column group to it's order in the view
-  forEach(columnGroupProps, (columnProp, index) => {
-    if (!columnProp.fixed && !columnProp.fixedRight) {
-      scrollableColumnGroupIndex.push(index); // index of scrollable group in columnGroupProps
-      columnGroupIndex[index] = scrollableColumnGroups.length; // index of column group in scrollableColumnGroups
-      scrollableColumnGroups.push(columnProp);
+  let cumilativeChildIndex = 0;
+
+  // group the scrollable column groups together and also provide index of the first child
+  forEach(columnGroupProps, (columnGroupProp) => {
+    if (!columnGroupProp.fixed && !columnGroupProp.fixedRight) {
+      columnGroupProp.firstChildIdx = cumilativeChildIndex;
+      for (let i = 0; i < columnGroupProp.childrenCount; i++) {
+        scrollableColumns[cumilativeChildIndex + i].parentIdx = scrollableColumnGroups.length;
+      }
+      cumilativeChildIndex += columnGroupProp.childrenCount;
+      scrollableColumnGroups.push(columnGroupProp);
     }
   });
 
@@ -177,8 +173,6 @@ function groupColumns(columnProps, columnGroupProps) {
     fixedRightColumns,
     scrollableColumns,
     scrollableColumnGroups,
-    columnGroupIndex,
-    scrollableColumnGroupIndex,
   };
 }
 

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -167,8 +167,8 @@ function groupColumns(columnProps, columnGroupProps) {
   forEach(columnGroupProps, (columnProp, index) => {
     if (!columnProp.fixed && !columnProp.fixedRight) {
       scrollableColumnGroupIndex.push(index); // index of scrollable group in columnGroupProps
-      scrollableColumnGroups.push(columnProp);
       columnGroupIndex[index] = scrollableColumnGroups.length; // index of column group in scrollableColumnGroups
+      scrollableColumnGroups.push(columnProp);
     }
   });
 

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -53,17 +53,23 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
     fixedColumns,
     fixedRightColumns,
     scrollableColumns,
-  } = groupColumns(newColumnProps);
+    scrollableColumnGroups,
+    scrollableColumnGroupIndex,
+    columnGroupIndex,
+  } = groupColumns(newColumnProps, newColumnGroupProps);
 
   const availableScrollWidth = Math.max(viewportWidth - getTotalWidth(fixedColumns) - getTotalWidth(fixedRightColumns), 0);
   const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
   return {
+    columnGroupIndex,
     columnGroupProps: newColumnGroupProps,
     columnProps: newColumnProps,
     availableScrollWidth,
     fixedColumns,
     fixedRightColumns,
     scrollableColumns,
+    scrollableColumnGroups,
+    scrollableColumnGroupIndex,
     maxScrollX,
   };
 }
@@ -128,16 +134,23 @@ function flexWidths(columnGroupProps, columnProps, viewportWidth) {
 
 /**
  * @param {!Array.<columnDefinition>} columnProps
+ * @param {!Array.<columnDefinition>} columnGroupProps
  * @return {{
+ *   columnGroupIndex: !Array.<number>,
  *   fixedColumns: !Array.<columnDefinition>,
  *   fixedRightColumns: !Array.<columnDefinition>,
- *   scrollableColumns: !Array.<columnDefinition>
+ *   scrollableColumns: !Array.<columnDefinition>,
+ *   scrollableColumnGroupIndex: !Array.<number>,
+ *   scrollableColumnGroups: !Array.<columnDefinition>,
  * }}
  */
-function groupColumns(columnProps) {
+function groupColumns(columnProps, columnGroupProps) {
   const fixedColumns = [];
   const fixedRightColumns = [];
   const scrollableColumns = [];
+  const scrollableColumnGroups = [];
+  const columnGroupIndex = [];
+  const scrollableColumnGroupIndex = [];
 
   forEach(columnProps, columnProp => {
     let container = scrollableColumns;
@@ -149,10 +162,23 @@ function groupColumns(columnProps) {
     container.push(columnProp);
   });
 
+  // group the scrollable column groups together and also provide
+  // index mapping (and inverse mapping) from the column group to it's order in the view
+  forEach(columnGroupProps, (columnProp, index) => {
+    if (!columnProp.fixed && !columnProp.fixedRight) {
+      scrollableColumnGroupIndex.push(index); // index of scrollable group in columnGroupProps
+      scrollableColumnGroups.push(columnProp);
+      columnGroupIndex[index] = scrollableColumnGroups.length; // index of column group in scrollableColumnGroups
+    }
+  });
+
   return {
     fixedColumns,
     fixedRightColumns,
     scrollableColumns,
+    scrollableColumnGroups,
+    columnGroupIndex,
+    scrollableColumnGroupIndex,
   };
 }
 

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -154,16 +154,16 @@ function groupColumns(columnProps, columnGroupProps) {
     container.push(columnProp);
   });
 
-  let cumilativeChildIndex = 0;
+  let cumulativeChildIndex = 0;
 
   // group the scrollable column groups together and also provide index of the first child
   forEach(columnGroupProps, (columnGroupProp) => {
     if (!columnGroupProp.fixed && !columnGroupProp.fixedRight) {
-      columnGroupProp.firstChildIdx = cumilativeChildIndex;
+      columnGroupProp.firstChildIdx = cumulativeChildIndex;
       for (let i = 0; i < columnGroupProp.childrenCount; i++) {
-        scrollableColumns[cumilativeChildIndex + i].parentIdx = scrollableColumnGroups.length;
+        scrollableColumns[cumulativeChildIndex + i].parentIdx = scrollableColumnGroups.length;
       }
-      cumilativeChildIndex += columnGroupProp.childrenCount;
+      cumulativeChildIndex += columnGroupProp.childrenCount;
       scrollableColumnGroups.push(columnGroupProp);
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use reducer output (`columnGroupsToRender` and `columnGroupOffsets`) when `allowColumnVirtualization` is turned on.

* Since column groups can be seen in a different order than the one in `React.Children` due to `fixed`/`fixedRight` columns, the calculation of the buffer wasn't so straightforward. It involved having a mapping for scrollable columns -> grouped columns -> indices in viewport -> grouped columns. Will explain in the review.

* Just pass the reducer output to our group header (which is a `FixedDataTableRow`).

## Navigate
#461 - Add reducer to virtualize columns  
#462 - Use virtualized columns from reducer in views
#463 - Virtualize Column Groups (*)
#464 - ~Introduce Virtualization API~
#472 - Cleanup + Fix tests


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Virtualize our grouped columns.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Column Group Example

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
