### PR TITLE
Column Virtualization - Introduce Virtualization API and Add Example (Step 4)

### DIFF
--- a/examples/ColumnVirtualizationExample.js
+++ b/examples/ColumnVirtualizationExample.js
@@ -4,9 +4,7 @@
 
 "use strict";
 
-const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
-const { TextCell } = require('./helpers/cells');
-const { Table, Column, ColumnGroup, Cell } = require('fixed-data-table-2');
+const { Table } = require('fixed-data-table-2');
 const React = require('react');
 
 class ColumnVirtualizationExample extends React.Component {

--- a/examples/ColumnVirtualizationExample.js
+++ b/examples/ColumnVirtualizationExample.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+"use strict";
+
+const FakeObjectDataListStore = require('./helpers/FakeObjectDataListStore');
+const { TextCell } = require('./helpers/cells');
+const { Table, Column, ColumnGroup, Cell } = require('fixed-data-table-2');
+const React = require('react');
+
+class ColumnVirtualizationExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const cellRenderer = ({columnKey, rowIndex}) => `${columnKey}, ${rowIndex}`;
+    const headerRenderer = ({columnKey}) => `${columnKey}`;
+
+    this.columnData = [];
+    this.columnGroupData = [];
+
+    // helper to construct object for a column/columnGroup given it's index
+    const getColumn = (index, groupIdx) => ({
+      columnKey: index,
+      header: headerRenderer,
+      cell: cellRenderer,
+      width: 100,
+      groupIdx: Math.floor(groupIdx),
+    });
+
+    // construct columns
+    for (let i = 0; i < 10000; i++) {
+      this.columnData.push(getColumn(i, i/2));
+    }
+
+    // construct column groups
+    for (let i = 0; i < this.columnData.length / 2; i++) {
+      this.columnGroupData.push(getColumn(i));
+    }
+  }
+
+  render() {
+    return (
+      <Table
+        rowHeight={50}
+        groupHeaderHeight={30}
+        headerHeight={30}
+        rowsCount={10000}
+        width={1000}
+        height={500}
+        columnData={this.columnData}
+        columnGroupData={this.columnGroupData}
+        allowColumnVirtualization // flag to turn on column virtualization
+        {...this.props}
+      >
+        /* notice that no children are passed */
+      </Table>
+    );
+  }
+}
+
+module.exports = ColumnVirtualizationExample;

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -175,6 +175,12 @@ exports.ExamplePages = {
     title: 'Auto Scroll',
     description: 'An example using Controlled Scrolling to mimic auto scrolling',
   },
+  COLUMN_VIRTUALIZATION_EXAMPLE: {
+    location: 'example-column-virtualization.html',
+    fileName: 'ColumnVirtualizationExample.js',
+    title: 'Column Virtualization',
+    description: 'An example using Column Virtualization API to render thousands of columns',
+  },
 };
 
 Object.keys(exports.ExamplePages).forEach(

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -51,6 +51,7 @@ var EXAMPLE_COMPONENTS = {
   [ExamplePages.FIXED_RIGHT_COLUMNS_EXAMPLE.location]: require('../../examples/FixedRightColumnsExample'),
   [ExamplePages.FIXED_ROWS_EXAMPLE.location]: require('../../examples/FixedRowsExample'),
   [ExamplePages.AUTO_SCROLL_EXAMPLE.location]: require('../../examples/AutoScrollExample'),
+  [ExamplePages.COLUMN_VIRTUALIZATION_EXAMPLE.location]: require('../../examples/ColumnVirtualizationExample'),
 };
 
 class ExamplesPage extends React.Component {

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -11,14 +11,12 @@
 
 'use strict';
 
-import React from 'react';
 import forEach from 'lodash/forEach';
-import invariant from 'invariant';
 import map from 'lodash/map';
 import pick from 'lodash/pick';
 
-function _extractProps(column) {
-  return pick(column.props, [
+function _extractProps(props) {
+  return pick(props, [
     'align',
     'allowCellsRecycling',
     'cellClassName',
@@ -26,7 +24,7 @@ function _extractProps(column) {
     'flexGrow',
     'fixed',
     'fixedRight',
-    'groupIdx', // only used when column virtualization is turned on
+    'groupIdx', // NOTE (pradeep): only used when column virtualization is turned on
     'maxWidth',
     'minWidth',
     'isReorderable',
@@ -34,20 +32,6 @@ function _extractProps(column) {
     'pureRendering',
     'width',
   ]);
-}
-
-function _extractPropsFromData(column) {
-  return _extractProps({ props: column });
-}
-
-function _extractTemplates(elementTemplates, columnElement) {
-  elementTemplates.cell.push(columnElement.props.cell);
-  elementTemplates.footer.push(columnElement.props.footer);
-  elementTemplates.header.push(columnElement.props.header);
-}
-
-function _extractTemplatesFromData(elementTemplates, column) {
-  return _extractTemplates(elementTemplates, { props: column });
 }
 
 function getDefaultElementTemplates() {
@@ -59,138 +43,37 @@ function getDefaultElementTemplates() {
   };
 }
 
-/**
- * Converts React column / column group elements into props and cell rendering templates
- */
-function convertColumnElementsToData(childComponents) {
-  const children = [];
-  React.Children.forEach(childComponents, (child, index) => {
-    if (child == null) {
-      return;
-    }
-    invariant(child.type.__TableColumnGroup__ || child.type.__TableColumn__,
-      'child type should be <FixedDataTableColumn /> or <FixedDataTableColumnGroup />');
+function extractPropsFromElement(column) {
+  return _extractProps(column.props);
+}
 
-    children.push(child);
-  });
+function extractPropsFromData(columnsData) {
+  return map(columnsData, _extractProps);
+}
 
+function extractTemplatesFromElement(elementTemplates, columnElement) {
+  elementTemplates.cell.push(columnElement.props.cell);
+  elementTemplates.footer.push(columnElement.props.footer);
+  elementTemplates.header.push(columnElement.props.header);
+}
+
+function _extractTemplateFromData(elementTemplates, columnData) {
+  elementTemplates.cell.push(columnData.cell);
+  elementTemplates.footer.push(columnData.footer);
+  elementTemplates.header.push(columnData.header);
+}
+
+function extractTemplatesFromData(columnsData, columnGroupsData) {
   const elementTemplates = getDefaultElementTemplates();
+  forEach(columnsData, _extractTemplateFromData.bind(null, elementTemplates));
+  forEach(columnGroupsData, (columnGroupData) => elementTemplates.groupHeader.push(columnGroupData.header));
+  return elementTemplates;
+}
 
-  const columnProps = [];
-  const hasGroupHeader = children.length && children[0].type.__TableColumnGroup__;
-  if (hasGroupHeader) {
-    const columnGroupProps = map(children, _extractProps);
-    forEach(children, (columnGroupElement, index) => {
-      elementTemplates.groupHeader.push(columnGroupElement.props.header);
-
-      React.Children.forEach(columnGroupElement.props.children, (child) => {
-        const column = _extractProps(child);
-        column.groupIdx = index;
-        columnProps.push(column);
-        _extractTemplates(elementTemplates, child);
-      });
-    });
-
-    return {
-      columnGroupProps,
-      columnProps,
-      elementTemplates,
-      useGroupHeader: true,
-    };
-  }
-
-  // Use a default column group
-  forEach(children, (child) => {
-    columnProps.push(_extractProps(child));
-    _extractTemplates(elementTemplates, child);
-  });
-  return {
-    columnGroupProps: [],
-    columnProps,
-    elementTemplates,
-    useGroupHeader: false,
-  };
+export {
+  extractPropsFromData,
+  extractPropsFromElement,
+  extractTemplatesFromData,
+  extractTemplatesFromElement,
+  getDefaultElementTemplates,
 };
-
-/**
- *
- */
-function collectPropsAndTemplatesFromColumnData(column, columnProps, elementTemplates) {
-  columnProps.push(_extractPropsFromData(column));
-  _extractTemplatesFromData(elementTemplates, column);
-}
-
-/**
- * Uses columnGetter to fetch column props and cell rendering templates
- *
- * @param {!function(number)} columnGetter
- * @param {!number} columnsCount
- * @return {{
- *   columnGroupProps: !Array.<columnDefinition>,
- *   columnProps: !Array.<columnDefinition>,
- *   elementTemplates: !Object.<string, Array>,
- *   useGroupHeader: boolean,
- * }}
- */
-function fetchColumnData(columnGetter, columnsCount) {
-  let columnProps = [];
-  let columnGroupProps = [];
-  let columnsWithDefinedGroupIndex = 0;
-  let columnGroups = [];
-
-  const elementTemplates = getDefaultElementTemplates();
-
-  // fetch column props and templates for each column
-  for (let index = 0; index < columnsCount; index++) {
-    collectPropsAndTemplatesFromColumnData(columnGetter({ index }), columnProps, elementTemplates);
-  }
-
-  // keep a map of group indexes which will be used to fetch the column groups
-  forEach(columnProps, (column) => {
-    const groupIndex = column.groupIdx;
-    if (groupIndex !== undefined && groupIndex !== null) {
-      columnGroups[groupIndex] = true;
-      columnsWithDefinedGroupIndex++;
-    }
-  });
-
-  // if group index was specified, it should be given for every column
-  if (columnsWithDefinedGroupIndex > 0) {
-    invariant(columnsWithDefinedGroupIndex === columnProps.length,
-      'group index if specified must be given for every column');
-  }
-
-  // fetch the column groups
-  for (let index = 0; index < Object.keys(columnGroups).length; index++) {
-    columnGroups[index] = Object.assign({}, columnGetter({ index, group: true }, { index }));
-  }
-
-  // the column groups can be specified out of order, but our reducers/selectors require
-  // it to be specified in order. So we'll sort it.
-  columnGroups.sort((a, b) => a.index - b.index);
-
-  // fetch column group props and templates for each column group
-  for (let index = 0; index < columnGroups.length; index++) {
-    columnGroupProps.push(_extractPropsFromData(columnGroups[index]));
-    elementTemplates.groupHeader.push(columnGroups[index].header);
-  }
-
-  return {
-    columnGroupProps,
-    columnProps,
-    elementTemplates,
-    useGroupHeader: columnsWithDefinedGroupIndex > 0,
-  };
-}
-
-function getColumnData({ allowColumnVirtualization, children, columnGetter, columnsCount }) {
-  // use column getter API to get the column data
-  if (allowColumnVirtualization && columnGetter) {
-    return fetchColumnData(columnGetter, columnsCount);
-  }
-
-  // use legacy API (React Children) to get the column data
-  return convertColumnElementsToData(children);
-}
-
-export default getColumnData;

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -26,6 +26,7 @@ function _extractProps(column) {
     'flexGrow',
     'fixed',
     'fixedRight',
+    'groupIdx', // only used when column virtualization is turned on
     'maxWidth',
     'minWidth',
     'isReorderable',
@@ -33,13 +34,30 @@ function _extractProps(column) {
     'pureRendering',
     'width',
   ]);
-};
+}
+
+function _extractPropsFromData(column) {
+  return _extractProps({ props: column });
+}
 
 function _extractTemplates(elementTemplates, columnElement) {
   elementTemplates.cell.push(columnElement.props.cell);
   elementTemplates.footer.push(columnElement.props.footer);
   elementTemplates.header.push(columnElement.props.header);
-};
+}
+
+function _extractTemplatesFromData(elementTemplates, column) {
+  return _extractTemplates(elementTemplates, { props: column });
+}
+
+function getDefaultElementTemplates() {
+  return {
+    cell: [],
+    footer: [],
+    groupHeader: [],
+    header: [],
+  };
+}
 
 /**
  * Converts React column / column group elements into props and cell rendering templates
@@ -56,12 +74,7 @@ function convertColumnElementsToData(childComponents) {
     children.push(child);
   });
 
-  const elementTemplates = {
-    cell: [],
-    footer: [],
-    groupHeader: [],
-    header: [],
-  };
+  const elementTemplates = getDefaultElementTemplates();
 
   const columnProps = [];
   const hasGroupHeader = children.length && children[0].type.__TableColumnGroup__;
@@ -99,4 +112,85 @@ function convertColumnElementsToData(childComponents) {
   };
 };
 
-export default convertColumnElementsToData;
+/**
+ *
+ */
+function collectPropsAndTemplatesFromColumnData(column, columnProps, elementTemplates) {
+  columnProps.push(_extractPropsFromData(column));
+  _extractTemplatesFromData(elementTemplates, column);
+}
+
+/**
+ * Uses columnGetter to fetch column props and cell rendering templates
+ *
+ * @param {!function(number)} columnGetter
+ * @param {!number} columnsCount
+ * @return {{
+ *   columnGroupProps: !Array.<columnDefinition>,
+ *   columnProps: !Array.<columnDefinition>,
+ *   elementTemplates: !Object.<string, Array>,
+ *   useGroupHeader: boolean,
+ * }}
+ */
+function fetchColumnData(columnGetter, columnsCount) {
+  let columnProps = [];
+  let columnGroupProps = [];
+  let columnsWithDefinedGroupIndex = 0;
+  let columnGroups = [];
+
+  const elementTemplates = getDefaultElementTemplates();
+
+  // fetch column props and templates for each column
+  for (let index = 0; index < columnsCount; index++) {
+    collectPropsAndTemplatesFromColumnData(columnGetter({ index }), columnProps, elementTemplates);
+  }
+
+  // keep a map of group indexes which will be used to fetch the column groups
+  forEach(columnProps, (column) => {
+    const groupIndex = column.groupIdx;
+    if (groupIndex !== undefined && groupIndex !== null) {
+      columnGroups[groupIndex] = true;
+      columnsWithDefinedGroupIndex++;
+    }
+  });
+
+  // if group index was specified, it should be given for every column
+  if (columnsWithDefinedGroupIndex > 0) {
+    invariant(columnsWithDefinedGroupIndex === columnProps.length,
+      'group index if specified must be given for every column');
+  }
+
+  // fetch the column groups
+  for (let index = 0; index < Object.keys(columnGroups).length; index++) {
+    columnGroups[index] = Object.assign({}, columnGetter({ index, group: true }, { index }));
+  }
+
+  // the column groups can be specified out of order, but our reducers/selectors require
+  // it to be specified in order. So we'll sort it.
+  columnGroups.sort((a, b) => a.index - b.index);
+
+  // fetch column group props and templates for each column group
+  for (let index = 0; index < columnGroups.length; index++) {
+    columnGroupProps.push(_extractPropsFromData(columnGroups[index]));
+    elementTemplates.groupHeader.push(columnGroups[index].header);
+  }
+
+  return {
+    columnGroupProps,
+    columnProps,
+    elementTemplates,
+    useGroupHeader: columnsWithDefinedGroupIndex > 0,
+  };
+}
+
+function getColumnData({ allowColumnVirtualization, children, columnGetter, columnsCount }) {
+  // use column getter API to get the column data
+  if (allowColumnVirtualization && columnGetter) {
+    return fetchColumnData(columnGetter, columnsCount);
+  }
+
+  // use legacy API (React Children) to get the column data
+  return convertColumnElementsToData(children);
+}
+
+export default getColumnData;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,11 +15,11 @@ import { getScrollAnchor, scrollTo } from 'scrollAnchor';
 import * as ActionTypes from 'ActionTypes';
 import IntegerBufferSet from 'IntegerBufferSet';
 import PrefixIntervalTree from 'PrefixIntervalTree';
+import columnData from 'columnData';
 import columnStateHelper from 'columnStateHelper'
 import columnWidths from 'columnWidths';
 import computeRenderedColumns from 'computeRenderedColumns';
 import computeRenderedRows from 'computeRenderedRows';
-import getColumnData from 'convertColumnElementsToData';
 import pick from 'lodash/pick';
 import shallowEqual from 'shallowEqual';
 
@@ -274,7 +274,7 @@ function setStateFromProps(state, props) {
     columnProps,
     elementTemplates,
     useGroupHeader,
-  } = getColumnData(props);
+  } = columnData(props);
 
   // column and cell props/templates
   Object.assign(newState, { columnGroupProps, columnProps, elementTemplates });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -19,7 +19,7 @@ import columnStateHelper from 'columnStateHelper'
 import columnWidths from 'columnWidths';
 import computeRenderedColumns from 'computeRenderedColumns';
 import computeRenderedRows from 'computeRenderedRows';
-import convertColumnElementsToData from 'convertColumnElementsToData';
+import getColumnData from 'convertColumnElementsToData';
 import pick from 'lodash/pick';
 import shallowEqual from 'shallowEqual';
 
@@ -265,22 +265,28 @@ function initializeColumnOffsets(state) {
  * @private
  */
 function setStateFromProps(state, props) {
+  // clone state
+  const newState = Object.assign({}, state);
+
+  // get column info from props
   const {
     columnGroupProps,
     columnProps,
     elementTemplates,
     useGroupHeader,
-  } = convertColumnElementsToData(props.children);
+  } = getColumnData(props);
 
-  const newState = Object.assign({}, state,
-    { columnGroupProps, columnProps, elementTemplates });
+  // column and cell props/templates
+  Object.assign(newState, { columnGroupProps, columnProps, elementTemplates });
 
+  // element heights
   newState.elementHeights = Object.assign({}, newState.elementHeights,
     pick(props, ['cellGroupWrapperHeight', 'footerHeight', 'groupHeaderHeight', 'headerHeight']));
   if (!useGroupHeader) {
     newState.elementHeights.groupHeaderHeight = 0;
   }
 
+  // row settings
   newState.rowSettings = Object.assign({}, newState.rowSettings,
     pick(props, ['bufferRowCount', 'rowHeight', 'rowsCount', 'subRowHeight']));
   const { rowHeight, subRowHeight } = newState.rowSettings;
@@ -289,9 +295,11 @@ function setStateFromProps(state, props) {
   newState.rowSettings.subRowHeightGetter =
     props.subRowHeightGetter || (() => subRowHeight || 0);
 
+  // scroll flags
   newState.scrollFlags = Object.assign({}, newState.scrollFlags,
     pick(props, ['overflowX', 'overflowY', 'showScrollbarX', 'showScrollbarY']));
 
+  // table size
   newState.tableSize = Object.assign({}, newState.tableSize,
     pick(props, ['height', 'maxHeight', 'ownerHeight', 'width']));
   newState.tableSize.useMaxHeight =

--- a/src/selectors/columnData.js
+++ b/src/selectors/columnData.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule columnData
+ */
+
+'use strict';
+
+import {
+  extractPropsFromData,
+  extractPropsFromElement,
+  extractTemplatesFromData,
+  extractTemplatesFromElement,
+  getDefaultElementTemplates
+} from 'convertColumnElementsToData';
+import React from 'react';
+import forEach from 'lodash/forEach';
+import invariant from 'invariant';
+import isFunction from 'lodash/isFunction';
+import map from 'lodash/map';
+import shallowEqualSelector from 'shallowEqualSelector';
+import pick from 'lodash/pick';
+
+/**
+ * Converts React column / column group elements into props and cell rendering templates
+ */
+function convertColumnElementsToData(childComponents) {
+  const children = [];
+  React.Children.forEach(childComponents, (child) => {
+    if (child == null) {
+      return;
+    }
+    invariant(child.type.__TableColumnGroup__ || child.type.__TableColumn__,
+      'child type should be <FixedDataTableColumn /> or <FixedDataTableColumnGroup />');
+
+    children.push(child);
+  });
+
+  const elementTemplates = getDefaultElementTemplates();
+
+  const columnProps = [];
+  const hasGroupHeader = children.length && children[0].type.__TableColumnGroup__;
+  if (hasGroupHeader) {
+    const columnGroupProps = map(children, extractPropsFromElement);
+    forEach(children, (columnGroupElement, index) => {
+      elementTemplates.groupHeader.push(columnGroupElement.props.header);
+
+      React.Children.forEach(columnGroupElement.props.children, (child) => {
+        const column = extractPropsFromElement(child);
+        column.groupIdx = index;
+        columnProps.push(column);
+        extractTemplatesFromElement(elementTemplates, child);
+      });
+    });
+
+    return {
+      columnGroupProps,
+      columnProps,
+      elementTemplates,
+      useGroupHeader: true,
+    };
+  }
+
+  // Use a default column group
+  forEach(children, (child) => {
+    columnProps.push(extractPropsFromElement(child));
+    extractTemplatesFromElement(elementTemplates, child);
+  });
+  return {
+    columnGroupProps: [],
+    columnProps,
+    elementTemplates,
+    useGroupHeader: false,
+  };
+}
+
+function fixColumnPropsWithColumnGroupProps(columnProps, columnGroupProps) {
+  const columnGroups = [];
+  let columnsWithDefinedGroupIndex = 0;
+
+  forEach(columnProps, ({ groupIdx }) => {
+    if (groupIdx !== undefined && groupIdx !== null) {
+      columnGroups[groupIdx] = true;
+      columnsWithDefinedGroupIndex++;
+    }
+  });
+
+  invariant(columnGroups.length === (columnGroupProps || []).length,
+    'column group data must fully and only contain every column groups');
+
+  invariant(columnsWithDefinedGroupIndex === columnProps.length,
+    'group index if specified must be given for every column');
+
+  forEach(columnProps, (columnProp) => {
+    columnProp.fixed = columnGroupProps[columnProp.groupIdx].fixed;
+    columnProp.fixedRight = columnGroupProps[columnProp.groupIdx].fixedRight;
+  });
+}
+
+/**
+ * Uses columnData to extract column props and cell rendering templates
+ *
+ * @param {!Array.<columnDefinition>} columnData
+ * @param {!Array.<columnDefinition>} columnGroupData
+ * @return {{
+ *   columnGroupProps: !Array.<columnDefinition>,
+ *   columnProps: !Array.<columnDefinition>,
+ *   elementTemplates: !Object.<string, Array>,
+ *   useGroupHeader: boolean,
+ * }}
+ */
+function getColumnPropsFromData(columnData, columnGroupData) {
+  const columnProps = extractPropsFromData(columnData);
+  const columnGroupProps = extractPropsFromData(columnGroupData);
+
+  const elementTemplates = extractTemplatesFromData(columnData, columnGroupData);
+
+  fixColumnPropsWithColumnGroupProps(columnProps, columnGroupProps);
+
+  return {
+    columnGroupProps,
+    columnProps,
+    elementTemplates,
+    useGroupHeader: columnGroupProps.length > 0,
+  };
+}
+
+function getColumnData(allowColumnVirtualization, columnData, columnGroupData, childComponents) {
+  // use columnData to directly get the column data
+  if (allowColumnVirtualization) {
+    return getColumnPropsFromData(columnData, columnGroupData);
+  }
+
+  // use legacy API (React Children) to get the column data
+  return convertColumnElementsToData(childComponents);
+}
+
+export default shallowEqualSelector([
+    props => props.allowColumnVirtualization,
+    props => props.columnData,
+    props => props.columnGroupData,
+    props => props.children,
+], getColumnData)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
FDT requires us to pass column details as React.Children. 
This means 
* we have to parse through the children
* hard/impossible to detect immutability in column data
* need to specify all the columns
* recalculation of columns whenever props change. This means for controlled scrolling with `N` total columns, there's an `O(N)` burden. This is stupid since column virtualization should only provide an `O(M)` complexity where `M` is no:of columns in the viewport.

With Column Virtualization, we should
* only ask the user to specify columns actually inside the columns
* which can lazy evaluate column widths/offsets (similar to rows)
* detect if column is same by keeping a cache, thus avoiding recalculations through immutability checks

**This PR doesn't do any of the above, but only provides the API. We'll do the goals above in later PRs.** 

Two immediate problems I see with achieving the goals through our current architecture are:
* If flexWidths are to be used, then we have to specify ALL the columns, otherwise they can't work
* ColumnWidths needs to be refactored, but this might shouldn't be too bad (😢 )

## Navigate
#461 - Add reducer to virtualize columns 
#462 - Use virtualized columns from reducer in views
#463 - Virtualize Column Groups
#464 - Introduce Virtualization API (*)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make controlled scrolling fast 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing Examples + New one

## Screenshots (**TODO: Add Example**)
With flag turned on using the new API (column data)
![FDT-Beta-Column-Virtualization-Example-Flag-turned-ON](https://user-images.githubusercontent.com/41563608/59182261-e8da2600-8b86-11e9-8184-1472b5c77803.gif)

With flag turned off using the old API (React children)
![FDT-Beta-Column-Virtualization-Example-Flag-turned-OFF](https://user-images.githubusercontent.com/41563608/59182263-e8da2600-8b86-11e9-86c2-f25cbd3a0073.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

