### PR TITLE
Provide last row's index (in the viewport) to the scroll callbacks

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -296,14 +296,14 @@ class FixedDataTable extends React.Component {
     scrollToRow: PropTypes.number,
 
     /**
-     * Callback that is called when scrolling starts with current horizontal
-     * and vertical scroll values.
+     * Callback that is called when scrolling starts. Current horizontal and vertical scroll values,
+     * and first and last row indexes will be provided to the callback.
      */
     onScrollStart: PropTypes.func,
 
     /**
-     * Callback that is called when scrolling ends or stops with new horizontal
-     * and vertical scroll values.
+     * Callback that is called when scrolling starts. The new horizontal and vertical scroll values,
+     * and the new first and last row indexes will be provided to the callback.
      */
     onScrollEnd: PropTypes.func,
 
@@ -1048,9 +1048,8 @@ class FixedDataTable extends React.Component {
     }
   }
 
-  /*
-    Appropriate
-    Handlers onScrollStart, onScrollEnd, onHorizontalScroll, and onVerticalScroll are called appropriately.
+  /**
+   * Calls the user specified scroll callbacks -- onScrollStart, onScrollEnd, onHorizontalScroll, and onVerticalScroll.
    */
   _didScroll = (/* !object */ nextProps) => {
     const {
@@ -1063,6 +1062,7 @@ class FixedDataTable extends React.Component {
     } = nextProps;
 
     const {
+      endRowIndex: oldEndRowIndex,
       firstRowIndex: oldFirstRowIndex,
       scrollX: oldScrollX,
       scrollY: oldScrollY,
@@ -1081,7 +1081,7 @@ class FixedDataTable extends React.Component {
 
     // only call onScrollStart if scrolling wasn't on previously
     if (!this.props.scrolling && onScrollStart) {
-      onScrollStart(oldScrollX, oldScrollY, oldFirstRowIndex)
+      onScrollStart(oldScrollX, oldScrollY, oldFirstRowIndex, oldEndRowIndex)
     }
 
     if (scrollXChanged && onHorizontalScroll) {
@@ -1101,6 +1101,7 @@ class FixedDataTable extends React.Component {
   // scroll handling.
   _didScrollStopSync = () => {
     const {
+      endRowIndex,
       firstRowIndex,
       onScrollEnd,
       scrollActions,
@@ -1116,7 +1117,7 @@ class FixedDataTable extends React.Component {
     scrollActions.stopScroll();
 
     if (onScrollEnd) {
-      onScrollEnd(scrollX, scrollY, firstRowIndex);
+      onScrollEnd(scrollX, scrollY, firstRowIndex, endRowIndex);
     }
   }
 };

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -296,13 +296,13 @@ class FixedDataTable extends React.Component {
     scrollToRow: PropTypes.number,
 
     /**
-     * Callback that is called when scrolling starts. Current horizontal and vertical scroll values,
-     * and first and last row indexes will be provided to the callback.
+     * Callback that is called when scrolling starts. The current horizontal and vertical scroll values,
+     * and the current first and last row indexes will be provided to the callback.
      */
     onScrollStart: PropTypes.func,
 
     /**
-     * Callback that is called when scrolling starts. The new horizontal and vertical scroll values,
+     * Callback that is called when scrolling ends. The new horizontal and vertical scroll values,
      * and the new first and last row indexes will be provided to the callback.
      */
     onScrollEnd: PropTypes.func,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Just passed the `endRowIndex` prop to the `onScrollStart` and `onScrollEnd` scroll callbacks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #467

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Our examples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
