### PR TITLE
Fix invalid aria attribute name

### DIFF
--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -278,7 +278,7 @@ class FixedDataTableRowImpl extends React.Component {
       <div
         className={joinClasses(className, this.props.className)}
         role={'row'}
-        aria-rowIndex={this.props.ariaRowIndex}
+        aria-rowindex={this.props.ariaRowIndex}
         onClick={this.props.onClick ? this._onClick : null}
         onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}


### PR DESCRIPTION
## Description
aria-rowIndex is an invalid attribute, the valid attribute name is aria-rowindex. This was merged incorrectly from the master branch to the beta branch.

## Motivation and Context
Invalid attributes causes accessibility to not be correct, and also logs console errors.

## How Has This Been Tested?
Manually tested that attribute gets set right

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
