### PR TITLE
Account for borders in spacer positioning

### DIFF
--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -253,7 +253,9 @@ class FixedDataTableRowImpl extends React.Component {
       var spacerStyles = {
         width: scrollbarOffset,
         height: this.props.height,
-        left: this.props.width - scrollbarOffset,
+        // Since the box-sizing = border-box the border on the table is included in the width
+        // so we need to account for the left and right border
+        left: this.props.width - scrollbarOffset - 2,
       };
       scrollbarSpacer =
         <div 


### PR DESCRIPTION
## Description
The scrollbar spacer in each row was 2px off. This is because the box-sizing is set to border-box and thus the borders are included in the width of the element. So we need to account for the borders when positioning the scroll bar spacer.

## Motivation and Context
The header row and its body's rows don't exactly line up.

## How Has This Been Tested?
Manually tested and attached screenshots for proof of fix.

## Screenshots (if appropriate):
Currently (without fix):
![image](https://user-images.githubusercontent.com/41756724/63624346-b5256e80-c5c1-11e9-9371-fc9938f3b8a6.png)

With fix:
![image](https://user-images.githubusercontent.com/41756724/63624383-c8383e80-c5c1-11e9-837e-61da027d0c84.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
