### PR TITLE
Fix scrolling - Beta

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -105,7 +105,7 @@ class FixedDataTableBufferedRows extends React.Component {
       });
     }
 
-    return <div> {this._staticRowArray} </div>;
+    return <div>{this._staticRowArray}</div>;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is going to be hard to explain. Basically this fixes the issue that users [mentioned](https://github.com/schrodinger/fixed-data-table-2/pull/460#issuecomment-506913766) in #460.
The bug only seems to affect a certain set of people, and until now we had no way of reproducing it.

Few hours ago a user created the issue (#482) , and gave a [minimal sandbox](https://codesandbox.io/embed/distracted-vaughan-crqe6?fontsize=14). 

After a lot of working around, I found out that the react version used there is `16.8.6`. If we roll it back to `16.0.0-alpha.2` or less, the bug doesn't occur.

Next step was finding why this was a bug only after #460. Turns out there was [whitespace](https://github.com/schrodinger/fixed-data-table-2/pull/460/files#diff-208559c5f4ccdf19767cbb4a781a182dR107) in the render method of `FixedDataTableBufferedRows`. As harmless as it seems, that single space (actually two of them, left and right), introduced a different render tree.

Before the whitespace, the render tree was like:
```
Buffered Rows -> {
  <div>
    [ array of rows ]
  </div>
}
```
After the whitespace, the render tree was like:
```
Buffered Rows -> {
  <div>
    [
       ' ',
       [ array of rows ],
       ' ',
    ]
  </div>
}
```

Now this is my understanding: after React 16, components in the tree won't be considered for rendering if the same object is passed in (checked through shallow equal comparison).

So in the first case, we take the array inside the parent div, shallow equal compare the elements, and see that they are all changed through each scroll. Hence React renders them.

In the second case, however, if we take the array inside the parent div, shallow equal compares the elements, and finds that between renders, they're all the same. 

Why? The object [ array of rows ] is mutable, (see [this._staticRowArray usage](https://github.com/schrodinger/fixed-data-table-2/blob/v1.0-beta/src/FixedDataTableBufferedRows.js#L101)), and hence the object reference won't change between renders. This makes react think that the tree is static, and skips rendering. This is only seen in v16 and up (more specifically from `16.0.0-alpha.2` and above from my quick testing).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #482

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Example site with latest React `16.8.6`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
