### PR TITLE
Aria selected and row attributes

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -446,9 +446,9 @@ class FixedDataTable extends React.Component {
     }),
 
     /**
-     * Whether the grid is multiselectable.
+     * Callback that returns an object of html attributes to add to the grid element
      */
-    isMultiselectable: PropTypes.bool,
+    gridAttributesGetter: PropTypes.func,
   }
 
   static defaultProps = /*object*/ {
@@ -665,7 +665,7 @@ class FixedDataTable extends React.Component {
       elementHeights,
       isColumnReordering,
       isColumnResizing,
-      isMultiselectable,
+      gridAttributesGetter,
       maxScrollX,
       maxScrollY,
       onColumnReorderEndCallback,
@@ -682,6 +682,7 @@ class FixedDataTable extends React.Component {
     const { cellGroupWrapperHeight, footerHeight, groupHeaderHeight, headerHeight } = elementHeights;
     const { scrollEnabledX, scrollEnabledY } = scrollbarsVisible(this.props);
     const onColumnReorder = onColumnReorderEndCallback ? this._onColumnReorder : null;
+    const attributes = gridAttributesGetter();
 
     let groupHeader;
     if (groupHeaderHeight > 0) {
@@ -855,7 +856,7 @@ class FixedDataTable extends React.Component {
         )}
         role="grid"
         aria-rowcount={ariaRowCount}
-        aria-multiselectable={isMultiselectable}
+        {...attributes}
         tabIndex={tabIndex}
         onKeyDown={this._onKeyDown}
         onTouchStart={touchScrollEnabled ? this._touchHandler.onTouchStart : null}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -682,7 +682,7 @@ class FixedDataTable extends React.Component {
     const { cellGroupWrapperHeight, footerHeight, groupHeaderHeight, headerHeight } = elementHeights;
     const { scrollEnabledX, scrollEnabledY } = scrollbarsVisible(this.props);
     const onColumnReorder = onColumnReorderEndCallback ? this._onColumnReorder : null;
-    const attributes = gridAttributesGetter();
+    const attributes = gridAttributesGetter && gridAttributesGetter();
 
     let groupHeader;
     if (groupHeaderHeight > 0) {

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -443,7 +443,12 @@ class FixedDataTable extends React.Component {
       footerHeight: PropTypes.number,
       groupHeaderHeight: PropTypes.number,
       headerHeight: PropTypes.number,
-    })
+    }),
+
+    /**
+     * Whether the grid is multiselectable.
+     */
+    isMultiselectable: PropTypes.bool,
   }
 
   static defaultProps = /*object*/ {
@@ -660,6 +665,7 @@ class FixedDataTable extends React.Component {
       elementHeights,
       isColumnReordering,
       isColumnResizing,
+      isMultiselectable,
       maxScrollX,
       maxScrollY,
       onColumnReorderEndCallback,
@@ -849,6 +855,7 @@ class FixedDataTable extends React.Component {
         )}
         role="grid"
         aria-rowcount={ariaRowCount}
+        aria-multiselectable={isMultiselectable}
         tabIndex={tabIndex}
         onKeyDown={this._onKeyDown}
         onTouchStart={touchScrollEnabled ? this._touchHandler.onTouchStart : null}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -128,7 +128,7 @@ class FixedDataTableBufferedRows extends React.Component {
       rowProps.offsetTop = Math.round(baseOffsetTop + props.rowOffsets[rowIndex]);
       rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
 
-      rowProps.attributes = props.rowAttributesGetter && props.rowAttributesGetter(rowIndex);
+      rowProps.attributes = props.rowSettings.rowAttributesGetter && props.rowSettings.rowAttributesGetter(rowIndex);
 
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) && props.showLastRowBorder;
       rowProps.className = joinClasses(

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -46,6 +46,7 @@ class FixedDataTableBufferedRows extends React.Component {
     rowOffsets: PropTypes.object.isRequired,
     rowKeyGetter: PropTypes.func,
     rowSettings: PropTypes.shape({
+      rowAttributesGetter: PropTypes.func,
       rowHeightGetter: PropTypes.func,
       rowsCount: PropTypes.number.isRequired,
       subRowHeightGetter: PropTypes.func,
@@ -126,6 +127,8 @@ class FixedDataTableBufferedRows extends React.Component {
       rowProps.subRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
       rowProps.offsetTop = Math.round(baseOffsetTop + props.rowOffsets[rowIndex]);
       rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
+
+      rowProps.attributes = props.rowAttributesGetter && props.rowAttributesGetter(rowIndex);
 
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) && props.showLastRowBorder;
       rowProps.className = joinClasses(

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -127,7 +127,6 @@ class FixedDataTableBufferedRows extends React.Component {
       rowProps.subRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
       rowProps.offsetTop = Math.round(baseOffsetTop + props.rowOffsets[rowIndex]);
       rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
-
       rowProps.attributes = props.rowSettings.rowAttributesGetter && props.rowSettings.rowAttributesGetter(rowIndex);
 
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) && props.showLastRowBorder;

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -161,6 +161,11 @@ class FixedDataTableRowImpl extends React.Component {
      * The value of the aria-rowindex attribute.
      */
     ariaRowIndex: PropTypes.number,
+
+    /**
+     * DOM attributes to be applied to the row.
+     */
+    attributes: PropTypes.object,
   };
 
   render() /*object*/ {
@@ -281,6 +286,7 @@ class FixedDataTableRowImpl extends React.Component {
         className={joinClasses(className, this.props.className)}
         role={'row'}
         aria-rowindex={this.props.ariaRowIndex}
+        {...this.props.attributes}
         onClick={this.props.onClick ? this._onClick : null}
         onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -48,6 +48,7 @@ function getInitialState() {
     },
     rowSettings: {
       bufferRowCount: undefined,
+      rowAttributesGetter: undefined,
       rowHeight: 0,
       rowHeightGetter: () => 0,
       rowsCount: 0,
@@ -248,6 +249,7 @@ function setStateFromProps(state, props) {
     props.rowHeightGetter || (() => rowHeight);
   newState.rowSettings.subRowHeightGetter =
     props.subRowHeightGetter || (() => subRowHeight || 0);
+  newState.rowSettings.rowAttributesGetter = props.rowAttributesGetter;
 
   newState.scrollFlags = Object.assign({}, newState.scrollFlags,
     pick(props, ['overflowX', 'overflowY', 'showScrollbarX', 'showScrollbarY']));


### PR DESCRIPTION
Added further capabilities for rendering aria attributes

## Description
Added a prop onto the Table for if it is multi-selectable. Additionally, added a callback function for adding DOM element attributes to the row div.

## Motivation and Context
Creates more support for screenreaders and user customization.
Fixes #490

## How Has This Been Tested?
Given that there aren't any existing tests on DOM attributes rendered, or an installed library that would do so, I did not test these changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.