### PR TITLE
Reserve Space for Last Border

### DIFF
--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -551,6 +551,5 @@ class Scrollbar extends React.PureComponent {
 
 Scrollbar.KEYBOARD_SCROLL_AMOUNT = KEYBOARD_SCROLL_AMOUNT;
 Scrollbar.SIZE = parseInt(cssVar('scrollbar-size'), 10);
-Scrollbar.OFFSET = 1;
 
 export default Scrollbar;

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -41,8 +41,8 @@ let columnDefinition;
  * }} The total width of all columns.
  */
 function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
-  const scrollbarSpace = scrollEnabledY ? Scrollbar.SIZE + Scrollbar.OFFSET : 0;
-  const viewportWidth = width - scrollbarSpace;
+  const scrollbarSpace = scrollEnabledY ? Scrollbar.SIZE : 0;
+  const viewportWidth = width - scrollbarSpace - 1; // Reserve space for last column border
 
   const {
     newColumnGroupProps,

--- a/src/selectors/roughHeights.js
+++ b/src/selectors/roughHeights.js
@@ -133,14 +133,14 @@ function roughHeights(columnProps, elementHeights, rowSettings,
 function getScrollStateX(columnProps, scrollFlags, width) {
   const { overflowX, showScrollbarX } = scrollFlags;
   const minColWidth = getTotalWidth(columnProps);
+  const adjustedWidth = width - 1; // Reserve space for last column border
   if (overflowX === 'hidden' || showScrollbarX === false) {
     return ScrollbarState.HIDDEN;
-  } else if (minColWidth > width) {
+  } else if (minColWidth > adjustedWidth) {
     return ScrollbarState.VISIBLE;
   }
 
-  const scrollbarSpace = Scrollbar.SIZE + Scrollbar.OFFSET;
-  if (minColWidth > width - scrollbarSpace) {
+  if (minColWidth > adjustedWidth - Scrollbar.SIZE) {
     return ScrollbarState.JOINT_SCROLLBARS;
   }
   return ScrollbarState.HIDDEN;

--- a/test/FixedDataTableRoot-test.js
+++ b/test/FixedDataTableRoot-test.js
@@ -93,7 +93,7 @@ describe('FixedDataTableRoot', function() {
 
     it('should set scrollToColumn correctly', function() {
       let table = renderTable({scrollToColumn: 3});
-      // extra 18 comes from Scrollbar.SIZE & Scrollbar.OFFSET
+      // extra 16 comes from Scrollbar.SIZE & reserved space for right border
       assert.equal(table.getTableState().scrollX, 300 * 2 + 16, 'should be third visible column');
     });
 
@@ -123,7 +123,7 @@ describe('FixedDataTableRoot', function() {
 
     it('should update scrollToColumn correctly', function() {
       let table = renderTable({scrollToColumn: 3});
-      // extra 18 comes from Scrollbar.SIZE & Scrollbar.OFFSET
+      // extra 16 comes from Scrollbar.SIZE & reserved space for right border
       assert.equal(table.getTableState().scrollX, 300 * 2 + 16, 'should be third visible column');
       table = renderTable({scrollToColumn: 1});
       assert.equal(table.getTableState().scrollX, 300, 'should be first visible column');

--- a/test/selectors/columnWidths-test.js
+++ b/test/selectors/columnWidths-test.js
@@ -107,7 +107,7 @@ describe('columnWidths', function() {
   });
 
   it('should distribute flex width', function() {
-    width = 640;
+    width = 641;
 
     const {
       columnGroupProps,
@@ -150,7 +150,7 @@ describe('columnWidths', function() {
   });
 
   it('should compute availableScrollWidth and maxScrollX', function() {
-    width = 300;
+    width = 301;
 
     const {
       availableScrollWidth,


### PR DESCRIPTION
Reserve 1px space for last border regardless of scrollbar visibility.

## Description
This fixes the issue in https://github.com/schrodinger/fixed-data-table-2/issues/495 by accounting for extra 1px regardless of whether or not the vertical scrollbar is shown.

## Motivation and Context
Fixes https://github.com/schrodinger/fixed-data-table-2/issues/495

## How Has This Been Tested?
Manual testing and updates to existing tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
