### PR TITLE
Remove unsafe react lifecycle hooks (Fixes  #492)

### DIFF
--- a/examples/helpers/ExampleImage.js
+++ b/examples/helpers/ExampleImage.js
@@ -19,15 +19,15 @@ class ExampleImage extends React.Component {
     ready: false,
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.componentId = imageIdCounter++;
     this._load(this.props.src);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.src !== this.props.src) {
-      this.setState({src: null});
-      this._load(nextProps.src);
+  componentDidUpdate(prevProps) {
+    if (prevProps.src !== this.props.src) {
+      this.setState({ src: null });
+      this._load(this.props.src);
     }
   }
 

--- a/examples/helpers/HOC.js
+++ b/examples/helpers/HOC.js
@@ -27,10 +27,10 @@ function DataCtxt(Wrapped) {
       };
     }
 
-    componentWillReceiveProps(nextProps) {
-      if (JSON.stringify(nextProps.data) !== JSON.stringify(this.state.data)) {
+    componentDidUpdate() {
+      if (JSON.stringify(this.props.data) !== JSON.stringify(this.state.data)) {
         this.setState({
-          data: nextProps.data,
+          data: this.props.data,
         });
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A React table component designed to allow presenting thousands of rows of data.",
   "main": "main.js",
   "peerDependencies": {
-    "react": ">=0.13.0 || ^0.14.0-beta3",
-    "react-dom": ">=0.14.0 || ^0.14.0-beta3"
+    "react": ">=15.3.0",
+    "react-dom": ">=15.3.0"
   },
   "dependencies": {
     "lodash": "^4.17.4",

--- a/src/ColumnResizerLine.js
+++ b/src/ColumnResizerLine.js
@@ -93,12 +93,12 @@ class ColumnResizerLine extends React.PureComponent {
     cursorDelta: 0,
   }
 
-  componentWillReceiveProps(/*object*/ newProps) {
-    if (newProps.initialEvent && !this._mouseMoveTracker.isDragging()) {
-      this._mouseMoveTracker.captureMouseMoves(newProps.initialEvent);
+  componentDidUpdate() {
+    if (this.props.initialEvent && !this._mouseMoveTracker.isDragging()) {
+      this._mouseMoveTracker.captureMouseMoves(this.props.initialEvent);
       this.setState({
-        width: newProps.initialWidth,
-        cursorDelta: newProps.initialWidth
+        width: this.props.initialWidth,
+        cursorDelta: this.props.initialWidth,
       });
     }
   }

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -469,7 +469,9 @@ class FixedDataTable extends React.Component {
     stopScrollPropagation: false,
   }
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
+
     this._didScrollStop = debounceCore(this._didScrollStopSync, 200, this);
     this._onKeyDown = this._onKeyDown.bind(this);
 
@@ -629,11 +631,10 @@ class FixedDataTable extends React.Component {
     this._reportContentHeight();
   }
 
-  componentWillReceiveProps(/*object*/ nextProps) {
-    this._didScroll(nextProps);
-  }
-
-  componentDidUpdate() {
+  componentDidUpdate(/*object*/ prevProps) {
+    if (prevProps !== this.props) {
+      this._didScroll(prevProps);
+    }
     this._reportContentHeight();
   }
 
@@ -836,7 +837,7 @@ class FixedDataTable extends React.Component {
             cx('fixedDataTableLayout/topShadow'),
             cx('public/fixedDataTable/topShadow'),
           )}
-          style={{top: bodyOffsetTop}}
+          style={{ top: bodyOffsetTop }}
         />;
     }
 
@@ -852,7 +853,7 @@ class FixedDataTable extends React.Component {
             cx('fixedDataTableLayout/bottomShadow'),
             cx('public/fixedDataTable/bottomShadow'),
           )}
-          style={{top: footOffsetTop}}
+          style={{ top: footOffsetTop }}
         />;
     }
     var tabIndex = null;
@@ -1112,7 +1113,7 @@ class FixedDataTable extends React.Component {
   /**
    * Calls the user specified scroll callbacks -- onScrollStart, onScrollEnd, onHorizontalScroll, and onVerticalScroll.
    */
-  _didScroll = (/* !object */ nextProps) => {
+  _didScroll = (/* !object */ prevProps) => {
     const {
       onScrollStart,
       scrollX,
@@ -1120,7 +1121,7 @@ class FixedDataTable extends React.Component {
       onHorizontalScroll,
       onVerticalScroll,
       tableSize: { ownerHeight },
-    } = nextProps;
+    } = this.props;
 
     const {
       endRowIndex: oldEndRowIndex,
@@ -1128,7 +1129,7 @@ class FixedDataTable extends React.Component {
       scrollX: oldScrollX,
       scrollY: oldScrollY,
       tableSize: { ownerHeight: oldOwnerHeight },
-    } = this.props;
+    } = prevProps;
 
     // check if scroll values have changed - we have an extra check on NaN because (NaN !== NaN)
     const ownerHeightChanged = ownerHeight !== oldOwnerHeight && !(isNaN(ownerHeight) && isNaN(oldOwnerHeight));
@@ -1191,14 +1192,6 @@ class HorizontalScrollbar extends React.PureComponent {
     position: PropTypes.number.isRequired,
     size: PropTypes.number.isRequired,
     isRTL: PropTypes.bool,
-  }
-
-  componentWillMount() {
-    this._initialRender = true;
-  }
-
-  componentDidMount() {
-    this._initialRender = false;
   }
 
   render() /*object*/ {

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -61,7 +61,8 @@ class FixedDataTableBufferedRows extends React.Component {
     isRTL: PropTypes.bool,
   }
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     this._staticRowArray = [];
     this._initialRender = true;
   }

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -125,7 +125,12 @@ class FixedDataTableCell extends React.Component {
     return false;
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(prevProps) {
+    if (prevProps === this.props) {
+      return;
+    }
+
+    const props = this.props;
     var left = props.left + this.state.displacement;
 
     var newState = {
@@ -203,18 +208,18 @@ class FixedDataTableCell extends React.Component {
   render() /*object*/ {
 
     var { height, width, columnKey, isHeaderOrFooter, ...props } = this.props;
-    
+
     var style = {
       height,
       width,
     };
-    
+
     if (this.props.isRTL) {
       style.right = props.left;
     } else {
       style.left = props.left;
     }
-    
+
     if (this.state.isReorderingThisColumn) {
       const DIR_SIGN = this.props.isRTL ? -1 : 1;
       style.transform = `translateX(${this.state.displacement * DIR_SIGN}px) translateZ(0)`;

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -64,7 +64,8 @@ class FixedDataTableCellGroupImpl extends React.Component {
     isRTL: PropTypes.bool,
   }
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     this._initialRender = true;
   }
 
@@ -209,7 +210,7 @@ class FixedDataTableCellGroup extends React.Component {
   }
 
   render() /*object*/ {
-    var {offsetLeft, ...props} = this.props;
+    var { offsetLeft, ...props } = this.props;
 
     var style = {
       height: props.cellGroupWrapperHeight || props.height,

--- a/src/FixedDataTableColumnReorderHandle.js
+++ b/src/FixedDataTableColumnReorderHandle.js
@@ -50,9 +50,6 @@ class FixedDataTableColumnReorderHandle extends React.PureComponent {
     dragDistance: 0
   }
 
-  componentWillReceiveProps(/*object*/ newProps) {
-  }
-
   componentWillUnmount() {
     if (this._mouseMoveTracker) {
       cancelAnimationFrame(this.frameId);

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -483,7 +483,8 @@ class FixedDataTableRow extends React.Component {
     width: PropTypes.number.isRequired,
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     this._initialRender = true;
   }
 

--- a/src/FixedDataTableStore.js
+++ b/src/FixedDataTableStore.js
@@ -15,7 +15,5 @@ import reducers from 'reducers'
 import { createStore } from 'redux'
 
 export default {
-  get: () => {
-    return createStore(reducers)
-  },
+  get: () => createStore(reducers)
 };

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -58,28 +58,29 @@ class Scrollbar extends React.PureComponent {
       props.contentSize,
       props.orientation
     );
+    this._initialRender = true;
   }
 
-  componentWillReceiveProps(/*object*/ nextProps) {
-    var controlledPosition = nextProps.position;
+  componentDidUpdate() {
+    var controlledPosition = this.props.position;
     if (controlledPosition === undefined) {
       this._setNextState(
         this._calculateState(
           this.state.position,
-          nextProps.size,
-          nextProps.contentSize,
-          nextProps.orientation
+          this.props.size,
+          this.props.contentSize,
+          this.props.orientation
         )
       );
     } else {
       this._setNextState(
         this._calculateState(
           controlledPosition,
-          nextProps.size,
-          nextProps.contentSize,
-          nextProps.orientation
+          this.props.size,
+          this.props.contentSize,
+          this.props.orientation
         ),
-        nextProps
+        this.props
       );
     }
   }
@@ -186,7 +187,7 @@ class Scrollbar extends React.PureComponent {
     );
   }
 
-  componentWillMount() {
+  componentDidMount() {
     var isHorizontal = this.props.orientation === 'horizontal';
     var onWheel = isHorizontal ? this._onWheelX : this._onWheelY;
 
@@ -196,10 +197,7 @@ class Scrollbar extends React.PureComponent {
       this._shouldHandleY, // Should handle vertical scroll
       this.props.isRTL
     );
-    this._initialRender = true;
-  }
 
-  componentDidMount() {
     this._rootRef && this._rootRef.addEventListener(
         'wheel',
         this._wheelHandler.onWheel,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Removes all use of `componentWillMount` and `componentWillReceive Props`

## Motivation and Context
As discussed in #492 -- React will be deprecating some of its lifecycle methods in the next major version. https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

## How Has This Been Tested?
All unit tests pass, and all of the examples in the sample site also work as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
