### PR TITLE
Fix issue with empty space in table if row heights change (#510)

### DIFF
--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -145,20 +145,19 @@ function calculateRenderedRowRange(state, scrollAnchor) {
     rowIdx += step;
   }
 
-  /* Handle the case where we rows have shrunk and we don't have enough content
-     between our start scroll anchor and the end of the table to fill the available space.
+  /* Handle the case where rows have shrunk and there's not enough content
+     between the start scroll anchor and the end of the table to fill the available space.
      In this case process earlier rows as needed and act as if we've scrolled to the last row.
    */
   let forceScrollToLastRow = false;
   if (totalHeight < maxAvailableHeight && rowIdx === rowsCount && lastIndex === undefined) {
     forceScrollToLastRow = true;
-    const reverseStep = -1;
     rowIdx = firstIndex - 1;
 
     while (rowIdx >= 0 && totalHeight < maxAvailableHeight) {
       totalHeight += updateRowHeight(state, rowIdx);
       startIdx = rowIdx;
-      rowIdx += reverseStep;
+      --rowIdx;
     }
   }
 
@@ -181,6 +180,8 @@ function calculateRenderedRowRange(state, scrollAnchor) {
   if (lastIndex !== undefined || forceScrollToLastRow) {
     // Calculate offset needed to position last row at bottom of viewport
     // This should be negative and represent how far the first row needs to be offscreen
+    // NOTE (jordan): The first offset should always be 0 when lastIndex is defined
+    // since we don't currently support scrolling the last row into view with an offset.
     firstOffset = firstOffset + Math.min(availableHeight - totalHeight, 0);
 
     // Handle a case where the offset puts the first row fully offscreen


### PR DESCRIPTION
## Description
Fix issue with empty space in table if row heights change

This can happen if you scroll to the last row of the Expanded rows
example.  Then expand and collapse the last row.

Primary: @pradeepnschrodinger 

## Motivation and Context
Fixes issue #510 

## How Has This Been Tested?
Tested on the Expanded Rows example, both w/ 2000 rows and w/ 3 rows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
