### PR TITLE
Fix an issue where column resize may not result in cells (#533)

### DIFF
--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -108,8 +108,8 @@ class FixedDataTableCell extends React.Component {
       return true;
     }
 
-    const { cell: oldCell, isScrolling: oldIsScrolling, ...oldProps } = this.props;
-    const { cell: newCell, isScrolling: newIsScrolling, ...newProps } = nextProps;
+    const { cell: oldCell, ...oldProps } = this.props;
+    const { cell: newCell, ...newProps } = nextProps;
 
     if (!shallowEqual(oldProps, newProps)) {
       return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When cell props change while a scroll is happening they don't cause cell's to re-render as expected.
In the issue #533 the resize also causes a horizontal scroll which leads to this issue.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #533 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Replicated the codepen from the linked issue with our ResizeExample.  Reproduced and fixed there.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
