### PR TITLE
Reduce dom levels in the default cell renderer

### DIFF
--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ImageCell, LinkCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class AutoScrollExample extends React.Component {
@@ -109,7 +109,7 @@ class AutoScrollExample extends React.Component {
         />
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<LinkCell data={dataList} />}
           fixed={true}
           width={100}

--- a/examples/ColumnGroupsExample.js
+++ b/examples/ColumnGroupsExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, ColumnGroup, Cell } from 'fixed-data-table-2';
+import { Table, Column, ColumnGroup, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class ColumnGroupsExample extends React.Component {
@@ -32,34 +32,34 @@ class ColumnGroupsExample extends React.Component {
         {...this.props}>
         <ColumnGroup
           fixed={true}
-          header={<Cell>Name</Cell>}>
+          header={<DataCell>Name</DataCell>}>
           <Column
             columnKey="firstName"
             fixed={true}
-            header={<Cell>First Name</Cell>}
+            header={<DataCell>First Name</DataCell>}
             cell={<TextCell data={dataList} />}
             width={150}
           />
           <Column
             columnKey="lastName"
             fixed={true}
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<TextCell data={dataList} />}
             width={150}
           />
         </ColumnGroup>
         <ColumnGroup
-          header={<Cell>About</Cell>}>
+          header={<DataCell>About</DataCell>}>
           <Column
             columnKey="companyName"
-            header={<Cell>Company</Cell>}
+            header={<DataCell>Company</DataCell>}
             cell={<TextCell data={dataList} />}
             flexGrow={1}
             width={150}
           />
           <Column
             columnKey="sentence"
-            header={<Cell>Sentence</Cell>}
+            header={<DataCell>Sentence</DataCell>}
             cell={<TextCell data={dataList} />}
             flexGrow={1}
             width={150}

--- a/examples/ContextExample.js
+++ b/examples/ContextExample.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import { DataCtxt, AddFilter } from './helpers/HOC';
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import examplePropTypes from './helpers/examplePropTypes';
@@ -116,9 +116,9 @@ class PendingCell extends React.PureComponent {
     const { data, rowIndex, columnKey, dataVersion, ...props } = this.props;
     const rowObject = data.getObjectAt(rowIndex);
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         {rowObject ? rowObject[columnKey] : 'pending'}
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -194,33 +194,33 @@ class ContextExample extends React.Component {
         >
           <Column
             columnKey="firstName"
-            header={<Cell>First</Cell>}
+            header={<DataCell>First</DataCell>}
             cell={<PagedCell />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<PagedCell />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
-            header={<Cell>City</Cell>}
+            header={<DataCell>City</DataCell>}
             cell={<PagedCell />}
             width={100}
           />
           <Column
             columnKey="street"
-            header={<Cell>Street</Cell>}
+            header={<DataCell>Street</DataCell>}
             cell={<PagedCell />}
             width={200}
           />
           <Column
             columnKey="zipCode"
-            header={<Cell>Zip Code</Cell>}
+            header={<DataCell>Zip Code</DataCell>}
             cell={<PagedCell />}
             width={200}
           />

--- a/examples/ExpandedExample.js
+++ b/examples/ExpandedExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { CollapseCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 import { StyleSheet, css } from 'aphrodite';
 
@@ -85,33 +85,33 @@ class ExpandedExample extends React.Component {
           />
           <Column
             columnKey="firstName"
-            header={<Cell>First Name</Cell>}
+            header={<DataCell>First Name</DataCell>}
             cell={<TextCell data={dataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<TextCell data={dataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
-            header={<Cell>City</Cell>}
+            header={<DataCell>City</DataCell>}
             cell={<TextCell data={dataList} />}
             width={100}
           />
           <Column
             columnKey="street"
-            header={<Cell>Street</Cell>}
+            header={<DataCell>Street</DataCell>}
             cell={<TextCell data={dataList} />}
             width={200}
           />
           <Column
             columnKey="zipCode"
-            header={<Cell>Zip Code</Cell>}
+            header={<DataCell>Zip Code</DataCell>}
             cell={<TextCell data={dataList} />}
             width={200}
           />

--- a/examples/FilterExample.js
+++ b/examples/FilterExample.js
@@ -7,7 +7,7 @@
 import ExampleImage from './helpers/ExampleImage';
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ImageCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class DataListWrapper {
@@ -85,33 +85,33 @@ class FilterExample extends React.Component {
           />
           <Column
             columnKey="firstName"
-            header={<Cell>First Name</Cell>}
+            header={<DataCell>First Name</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
-            header={<Cell>City</Cell>}
+            header={<DataCell>City</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={100}
           />
           <Column
             columnKey="street"
-            header={<Cell>Street</Cell>}
+            header={<DataCell>Street</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="zipCode"
-            header={<Cell>Zip Code</Cell>}
+            header={<DataCell>Zip Code</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />

--- a/examples/FixedRightColumnsExample.js
+++ b/examples/FixedRightColumnsExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { DateCell, ImageCell, LinkCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class FixedRightColumnsExample extends React.Component {
@@ -36,45 +36,45 @@ class FixedRightColumnsExample extends React.Component {
         />
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<LinkCell data={dataList} />}
           fixedRight={true}
           width={100}
         />
         <Column
           columnKey="lastName"
-          header={<Cell>Last Name</Cell>}
+          header={<DataCell>Last Name</DataCell>}
           cell={<TextCell data={dataList} />}
           fixedRight={true}
           width={100}
         />
         <Column
           columnKey="city"
-          header={<Cell>City</Cell>}
+          header={<DataCell>City</DataCell>}
           cell={<TextCell data={dataList} />}
           width={100}
         />
         <Column
           columnKey="street"
-          header={<Cell>Street</Cell>}
+          header={<DataCell>Street</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="zipCode"
-          header={<Cell>Zip Code</Cell>}
+          header={<DataCell>Zip Code</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="email"
-          header={<Cell>Email</Cell>}
+          header={<DataCell>Email</DataCell>}
           cell={<LinkCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="date"
-          header={<Cell>DOB</Cell>}
+          header={<DataCell>DOB</DataCell>}
           cell={<DateCell data={dataList} />}
           width={200}
         />

--- a/examples/FixedRowsExample.js
+++ b/examples/FixedRowsExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { DateCell, ImageCell, LinkCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 // wrapper over a DataList that allows you to specify custom index mapping
@@ -115,80 +115,80 @@ class FixedRowsExample extends React.Component {
       >
         <Column
           columnKey="id"
-          header={<Cell>Id</Cell>}
+          header={<DataCell>Id</DataCell>}
           cell={<TextCell data={dataList} />}
           fixed={true}
           width={100}
         />
         <Column
           columnKey="avatar"
-          header={<Cell>Avatar</Cell>}
+          header={<DataCell>Avatar</DataCell>}
           cell={<ImageCell data={dataList} />}
           width={50}
         />
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<LinkCell data={dataList} />}
           width={100}
         />
         <Column
           columnKey="lastName"
-          header={<Cell>Last Name</Cell>}
+          header={<DataCell>Last Name</DataCell>}
           cell={<TextCell data={dataList} />}
           width={100}
         />
         <Column
           columnKey="city"
-          header={<Cell>City</Cell>}
+          header={<DataCell>City</DataCell>}
           cell={<TextCell data={dataList} />}
           width={250}
         />
         <Column
           columnKey="street"
-          header={<Cell>Street</Cell>}
+          header={<DataCell>Street</DataCell>}
           cell={<TextCell data={dataList} />}
           width={250}
         />
         <Column
           columnKey="zipCode"
-          header={<Cell>Zip Code</Cell>}
+          header={<DataCell>Zip Code</DataCell>}
           cell={<TextCell data={dataList} />}
           width={100}
         />
         <Column
           columnKey="email"
-          header={<Cell>Email</Cell>}
+          header={<DataCell>Email</DataCell>}
           cell={<LinkCell data={dataList} />}
           width={400}
         />
         <Column
           columnKey="date"
-          header={<Cell>DOB</Cell>}
+          header={<DataCell>DOB</DataCell>}
           cell={<DateCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="catchPhrase"
-          header={<Cell>Catch Phrase</Cell>}
+          header={<DataCell>Catch Phrase</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="companyName"
-          header={<Cell>Company Name</Cell>}
+          header={<DataCell>Company Name</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="words"
-          header={<Cell>Words</Cell>}
+          header={<DataCell>Words</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="sentence"
-          header={<Cell>Sentence</Cell>}
+          header={<DataCell>Sentence</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />

--- a/examples/FlexGrowExample.js
+++ b/examples/FlexGrowExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell, ColoredTextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class FlexGrowExample extends React.Component {
@@ -30,21 +30,21 @@ class FlexGrowExample extends React.Component {
         {...this.props}>
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<TextCell data={dataList} />}
           fixed={true}
           width={100}
         />
         <Column
           columnKey="sentence"
-          header={<Cell>Sentence! (flexGrow greediness=2)</Cell>}
+          header={<DataCell>Sentence! (flexGrow greediness=2)</DataCell>}
           cell={<ColoredTextCell data={dataList} />}
           flexGrow={2}
           width={200}
         />
         <Column
           columnKey="companyName"
-          header={<Cell>Company (flexGrow greediness=1)</Cell>}
+          header={<DataCell>Company (flexGrow greediness=1)</DataCell>}
           cell={<TextCell data={dataList} />}
           flexGrow={1}
           width={200}
@@ -52,7 +52,7 @@ class FlexGrowExample extends React.Component {
         <Column
           columnKey="lastName"
           width={100}
-          header={<Cell>Last Name</Cell>}
+          header={<DataCell>Last Name</DataCell>}
           cell={<TextCell data={dataList} />}
         />
       </Table>

--- a/examples/FooterExample.js
+++ b/examples/FooterExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { DateCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class FooterExample extends React.Component {
@@ -30,8 +30,8 @@ class FooterExample extends React.Component {
         footerHeight={30}>
         <Column
           columnKey="date"
-          header={<Cell>DOB</Cell>}
-          footer={<Cell>sample footer</Cell>}
+          header={<DataCell>DOB</DataCell>}
+          footer={<DataCell>sample footer</DataCell>}
           cell={<DateCell data={dataList} />}
           width={200}
         />

--- a/examples/HideColumnExample.js
+++ b/examples/HideColumnExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ColoredTextCell, RemovableHeaderCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 let columnTitles = {

--- a/examples/InfiniteScrollExample.js
+++ b/examples/InfiniteScrollExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { PagedCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class PagedData {
@@ -81,40 +81,40 @@ class InfiniteScrollExample extends React.Component {
           height={500}
           {...this.props}>
           <Column
-            header={<Cell></Cell>}
-            cell={({rowIndex}) => (<Cell>{rowIndex}</Cell>)}
+            header={<DataCell></DataCell>}
+            cell={({rowIndex}) => (<DataCell>{rowIndex}</DataCell>)}
             fixed={true}
             width={50}
           />
           <Column
             columnKey="firstName"
-            header={<Cell>First Name</Cell>}
+            header={<DataCell>First Name</DataCell>}
             cell={<PagedCell data={pagedData} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<PagedCell data={pagedData} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
-            header={<Cell>City</Cell>}
+            header={<DataCell>City</DataCell>}
             cell={<PagedCell data={pagedData} />}
             width={100}
           />
           <Column
             columnKey="street"
-            header={<Cell>Street</Cell>}
+            header={<DataCell>Street</DataCell>}
             cell={<PagedCell data={pagedData} />}
             width={200}
           />
           <Column
             columnKey="zipCode"
-            header={<Cell>Zip Code</Cell>}
+            header={<DataCell>Zip Code</DataCell>}
             cell={<PagedCell data={pagedData} />}
             width={200}
           />

--- a/examples/LongClickExample.js
+++ b/examples/LongClickExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class LongClickExample extends React.Component {
@@ -61,7 +61,7 @@ class LongClickExample extends React.Component {
           key={columnKey}
           columnKey={columnKey}
           flexGrow={2}
-          header={<Cell>{columns[columnKey]}</Cell>}
+          header={<DataCell>{columns[columnKey]}</DataCell>}
           cell={cell => this.getCell(cell.rowIndex, cell.columnKey)}
           width={100}
         />);

--- a/examples/MaxHeightExample.js
+++ b/examples/MaxHeightExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { DateCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class MaxHeightExample extends React.Component {
@@ -40,8 +40,8 @@ class MaxHeightExample extends React.Component {
           footerHeight={30}>
           <Column
             columnKey="date"
-            header={<Cell>DOB</Cell>}
-            footer={<Cell>sample footer</Cell>}
+            header={<DataCell>DOB</DataCell>}
+            footer={<DataCell>sample footer</DataCell>}
             cell={<DateCell data={dataList} />}
             width={500}
           />

--- a/examples/ObjectDataExample.js
+++ b/examples/ObjectDataExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { DateCell, ImageCell, LinkCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class ObjectDataExample extends React.Component {
@@ -36,45 +36,45 @@ class ObjectDataExample extends React.Component {
         />
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<LinkCell data={dataList} />}
           fixed={true}
           width={100}
         />
         <Column
           columnKey="lastName"
-          header={<Cell>Last Name</Cell>}
+          header={<DataCell>Last Name</DataCell>}
           cell={<TextCell data={dataList} />}
           fixed={true}
           width={100}
         />
         <Column
           columnKey="city"
-          header={<Cell>City</Cell>}
+          header={<DataCell>City</DataCell>}
           cell={<TextCell data={dataList} />}
           width={100}
         />
         <Column
           columnKey="street"
-          header={<Cell>Street</Cell>}
+          header={<DataCell>Street</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="zipCode"
-          header={<Cell>Zip Code</Cell>}
+          header={<DataCell>Zip Code</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="email"
-          header={<Cell>Email</Cell>}
+          header={<DataCell>Email</DataCell>}
           cell={<LinkCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="date"
-          header={<Cell>DOB</Cell>}
+          header={<DataCell>DOB</DataCell>}
           cell={<DateCell data={dataList} />}
           width={200}
         />

--- a/examples/OwnerHeightExample.js
+++ b/examples/OwnerHeightExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { DateCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 import Dimensions from 'react-dimensions';
 
@@ -51,8 +51,8 @@ class OwnerExample extends React.Component {
         ownerHeight={this.props.height + 60 + pageYOffset}>
         <Column
           columnKey="date"
-          header={<Cell>DOB</Cell>}
-          footer={<Cell>sample footer</Cell>}
+          header={<DataCell>DOB</DataCell>}
+          footer={<DataCell>sample footer</DataCell>}
           cell={<DateCell data={dataList} />}
           width={500}
         />

--- a/examples/ReorderExample.js
+++ b/examples/ReorderExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 var columnTitles = {
@@ -94,7 +94,7 @@ class ReorderExample extends React.Component {
             columnKey={columnKey}
             key={i}
             isReorderable={true}
-            header={<Cell>{columnTitles[columnKey]}</Cell>}
+            header={<DataCell>{columnTitles[columnKey]}</DataCell>}
             cell={<TextCell data={dataList} />}
             fixed={fixedColumns.indexOf(columnKey) !== -1}
             width={columnWidths[columnKey]}

--- a/examples/ResizeExample.js
+++ b/examples/ResizeExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class ResizeExample extends React.Component {
@@ -50,7 +50,7 @@ class ResizeExample extends React.Component {
         {...this.props}>
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<TextCell data={dataList} />}
           fixed={true}
           width={columnWidths.firstName}
@@ -58,7 +58,7 @@ class ResizeExample extends React.Component {
         />
         <Column
           columnKey="lastName"
-          header={<Cell>Last Name (min/max constrained)</Cell>}
+          header={<DataCell>Last Name (min/max constrained)</DataCell>}
           cell={<TextCell data={dataList} />}
           width={columnWidths.lastName}
           isResizable={true}
@@ -67,14 +67,14 @@ class ResizeExample extends React.Component {
         />
         <Column
           columnKey="companyName"
-          header={<Cell>Company</Cell>}
+          header={<DataCell>Company</DataCell>}
           cell={<TextCell data={dataList} />}
           width={columnWidths.companyName}
           isResizable={true}
         />
         <Column
           columnKey="sentence"
-          header={<Cell>Sentence</Cell>}
+          header={<DataCell>Sentence</DataCell>}
           cell={<TextCell data={dataList} />}
           width={columnWidths.sentence}
           isResizable={true}

--- a/examples/ResponsiveExample.js
+++ b/examples/ResponsiveExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 import Dimensions from 'react-dimensions';
 
@@ -32,21 +32,21 @@ class ResponsiveExample extends React.Component {
         {...props}>
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<TextCell data={dataList} />}
           flexGrow={1}
           width={20}
         />
         <Column
           columnKey="lastName"
-          header={<Cell>Last Name</Cell>}
+          header={<DataCell>Last Name</DataCell>}
           cell={<TextCell data={dataList} />}
           flexGrow={1}
           width={20}
         />
         <Column
           columnKey="companyName"
-          header={<Cell>Company</Cell>}
+          header={<DataCell>Company</DataCell>}
           cell={<TextCell data={dataList} />}
           flexGrow={1}
           width={50}

--- a/examples/ScrollToColumnExample.js
+++ b/examples/ScrollToColumnExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ImageCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class ScrollToColumnExample extends React.Component {
@@ -50,63 +50,63 @@ class ScrollToColumnExample extends React.Component {
           {...this.props}>
           <Column
             columnKey="firstName"
-            header={<Cell>First Name [0]</Cell>}
+            header={<DataCell>First Name [0]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name [1]</Cell>}
+            header={<DataCell>Last Name [1]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
-            header={<Cell>City [2]</Cell>}
+            header={<DataCell>City [2]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={100}
           />
           <Column
             columnKey="street"
-            header={<Cell>Street [3]</Cell>}
+            header={<DataCell>Street [3]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="zipCode"
-            header={<Cell>Zip Code [4]</Cell>}
+            header={<DataCell>Zip Code [4]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="bs"
-            header={<Cell>BS [5]</Cell>}
+            header={<DataCell>BS [5]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="catchPhrase"
-            header={<Cell>Catch Phrase [6]</Cell>}
+            header={<DataCell>Catch Phrase [6]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="companyName"
-            header={<Cell>Company Name [7]</Cell>}
+            header={<DataCell>Company Name [7]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="words"
-            header={<Cell>Words [8]</Cell>}
+            header={<DataCell>Words [8]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="sentence"
-            header={<Cell>Sentence [9]</Cell>}
+            header={<DataCell>Sentence [9]</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />

--- a/examples/ScrollToRowExample.js
+++ b/examples/ScrollToRowExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ImageCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class ScrollToRowExample extends React.Component {
@@ -121,33 +121,33 @@ class ScrollToRowExample extends React.Component {
           />
           <Column
             columnKey="firstName"
-            header={<Cell>First Name</Cell>}
+            header={<DataCell>First Name</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             fixed={true}
             width={100}
           />
           <Column
             columnKey="city"
-            header={<Cell>City</Cell>}
+            header={<DataCell>City</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={100}
           />
           <Column
             columnKey="street"
-            header={<Cell>Street</Cell>}
+            header={<DataCell>Street</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />
           <Column
             columnKey="zipCode"
-            header={<Cell>Zip Code</Cell>}
+            header={<DataCell>Zip Code</DataCell>}
             cell={<TextCell data={filteredDataList} />}
             width={200}
           />

--- a/examples/SortExample.js
+++ b/examples/SortExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 var SortTypes = {
@@ -28,11 +28,11 @@ class SortHeaderCell extends React.Component {
   render() {
     var {onSortChange, sortDir, children, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         <a onClick={this._onSortChange}>
           {children} {sortDir ? (sortDir === SortTypes.DESC ? '↓' : '↑') : ''}
         </a>
-      </Cell>
+      </DataCell>
     );
   }
 

--- a/examples/StylingExample.js
+++ b/examples/StylingExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ImageCell, TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 import { StyleSheet, css } from 'aphrodite';
 
@@ -33,27 +33,27 @@ class StylingExample extends React.Component {
         {...props}>
         <Column
           columnKey='avatar'
-          header={<Cell className={css(styles.newTableHeader)}></Cell>}
+          header={<DataCell className={css(styles.newTableHeader)}></DataCell>}
           cell={<ImageCell className={css(styles.newCellBorder)} data={dataList} />}
           fixed={true}
           width={50}
         />
         <Column
           columnKey='firstName'
-          header={<Cell className={css(styles.newTableHeader)}>First Name</Cell>}
+          header={<DataCell className={css(styles.newTableHeader)}>First Name</DataCell>}
           cell={<TextCell className={css(styles.newCellBorder)} data={dataList} />}
           fixed={true}
           width={150}
         />
         <Column
           columnKey='lastName'
-          header={<Cell className={css(styles.newTableHeader)}>Last Name</Cell>}
+          header={<DataCell className={css(styles.newTableHeader)}>Last Name</DataCell>}
           cell={<TextCell className={css(styles.newCellBorder)} data={dataList} />}
           width={150}
         />
         <Column
           columnKey='companyName'
-          header={<Cell className={css(styles.newTableHeader)}>Company</Cell>}
+          header={<DataCell className={css(styles.newTableHeader)}>Company</DataCell>}
           cell={<TextCell className={css(styles.newCellBorder)} data={dataList} />}
           width={200}
         />

--- a/examples/TooltipExample.js
+++ b/examples/TooltipExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { ImageCell, TooltipCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import { findDOMNode } from 'react-dom';
@@ -39,20 +39,20 @@ class TooltipExample extends React.Component {
           />
           <Column
             columnKey="firstName"
-            header={<Cell>First Name</Cell>}
+            header={<DataCell>First Name</DataCell>}
             cell={<TooltipCell data={dataList} />}
             fixed={true}
             width={150}
           />
           <Column
             columnKey="lastName"
-            header={<Cell>Last Name</Cell>}
+            header={<DataCell>Last Name</DataCell>}
             cell={<TooltipCell data={dataList} />}
             width={150}
           />
           <Column
             columnKey="companyName"
-            header={<Cell>Company</Cell>}
+            header={<DataCell>Company</DataCell>}
             cell={<TooltipCell data={dataList} />}
             width={200}
           />

--- a/examples/TouchScrollExample.js
+++ b/examples/TouchScrollExample.js
@@ -6,7 +6,7 @@
 
 import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
 import { TextCell } from './helpers/cells';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
 import React from 'react';
 
 class TouchScrollExample extends React.Component {
@@ -32,33 +32,33 @@ class TouchScrollExample extends React.Component {
       >
         <Column
           columnKey="firstName"
-          header={<Cell>First Name</Cell>}
+          header={<DataCell>First Name</DataCell>}
           cell={<TextCell data={dataList} />}
           fixed={true}
           width={100}
         />
         <Column
           columnKey="lastName"
-          header={<Cell>Last Name</Cell>}
+          header={<DataCell>Last Name</DataCell>}
           cell={<TextCell data={dataList} />}
           fixed={true}
           width={100}
         />
         <Column
           columnKey="city"
-          header={<Cell>City</Cell>}
+          header={<DataCell>City</DataCell>}
           cell={<TextCell data={dataList} />}
           width={100}
         />
         <Column
           columnKey="street"
-          header={<Cell>Street</Cell>}
+          header={<DataCell>Street</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />
         <Column
           columnKey="zipCode"
-          header={<Cell>Zip Code</Cell>}
+          header={<DataCell>Zip Code</DataCell>}
           cell={<TextCell data={dataList} />}
           width={200}
         />

--- a/examples/helpers/cells.js
+++ b/examples/helpers/cells.js
@@ -5,7 +5,7 @@
 "use strict";
 
 import ExampleImage from './ExampleImage';
-import { Cell } from 'fixed-data-table-2';
+import { DataCell } from 'fixed-data-table-2';
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
 
@@ -13,11 +13,11 @@ class CollapseCell extends React.PureComponent {
   render() {
     const {data, rowIndex, columnKey, collapsedRows, callback, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         <a onClick={() => callback(rowIndex)}>
           {collapsedRows.has(rowIndex) ? '\u25BC' : '\u25BA'}
         </a>
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -26,9 +26,9 @@ class ColoredTextCell extends React.PureComponent {
   render() {
     const {data, rowIndex, columnKey, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         {this.colorizeText(data.getObjectAt(rowIndex)[columnKey], rowIndex)}
-      </Cell>
+      </DataCell>
     );
   }
 
@@ -46,9 +46,9 @@ class DateCell extends React.PureComponent {
   render() {
     const {data, rowIndex, columnKey, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         {data.getObjectAt(rowIndex)[columnKey].toLocaleString()}
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -68,9 +68,9 @@ class LinkCell extends React.PureComponent {
   render() {
     const {data, rowIndex, columnKey, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         <a href="#">{data.getObjectAt(rowIndex)[columnKey]}</a>
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -80,9 +80,9 @@ class PendingCell extends React.PureComponent {
     const {data, rowIndex, columnKey, dataVersion, ...props} = this.props;
     const rowObject = data.getObjectAt(rowIndex);
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         {rowObject ? rowObject[columnKey] : 'pending'}
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -101,12 +101,12 @@ class RemovableHeaderCell extends React.PureComponent {
   render() {
     const {data, rowIndex, columnKey, callback, children, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         {children}
         <a style={{float: 'right'}} onClick={() => callback(columnKey)}>
           {'\u274C'}
         </a>
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -115,9 +115,9 @@ class TextCell extends React.PureComponent {
   render() {
     const {data, rowIndex, columnKey, ...props} = this.props;
     return (
-      <Cell {...props}>
+      <DataCell {...props}>
         {data.getObjectAt(rowIndex)[columnKey]}
-      </Cell>
+      </DataCell>
     );
   }
 }
@@ -127,14 +127,14 @@ class TooltipCell extends React.PureComponent {
     const {data, rowIndex, columnKey, ...props} = this.props;
     const value = data.getObjectAt(rowIndex)[columnKey];
     return (
-      <Cell
+      <DataCell
         {...props}
         onMouseEnter={() => { ReactTooltip.show(); }}
         onMouseLeave={() => { ReactTooltip.hide(); }}>
         <div data-tip={value}>
           {value}
         </div>
-      </Cell>
+      </DataCell>
     );
   }
 }

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -10,7 +10,7 @@
  * @typechecks
  */
 
-import FixedDataTableCellDefault from 'FixedDataTableCellDefault';
+import FixedDataTableCellDefaultDeprecated from 'FixedDataTableCellDefaultDeprecated';
 import FixedDataTableColumnReorderHandle from './FixedDataTableColumnReorderHandle';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -294,10 +294,9 @@ class FixedDataTableCell extends React.Component {
       content = props.cell(cellProps);
     } else {
       content = (
-        <FixedDataTableCellDefault
-          {...cellProps}>
+        <FixedDataTableCellDefaultDeprecated {...cellProps}>
           {props.cell}
-        </FixedDataTableCellDefault>
+        </FixedDataTableCellDefaultDeprecated>
       );
     }
 

--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -87,26 +87,14 @@ class FixedDataTableCellDefault extends React.Component {
       <div
         {...props}
         className={joinClasses(
-          cx('fixedDataTableCellLayout/wrap1'),
-          cx('public/fixedDataTableCell/wrap1'),
+          cx('fixedDataTableCellLayout/wrap'),
+          cx('public/fixedDataTableCell/wrap'),
+          cx('public/fixedDataTableCell/cellContent'),
           className,
         )}
-        style={innerStyle}>
-        <div
-          className={joinClasses(
-            cx('fixedDataTableCellLayout/wrap2'),
-            cx('public/fixedDataTableCell/wrap2'),
-          )}>
-          <div
-            className={joinClasses(
-              cx('fixedDataTableCellLayout/wrap3'),
-              cx('public/fixedDataTableCell/wrap3'),
-            )}>
-            <div className={cx('public/fixedDataTableCell/cellContent')}>
-              {children}
-            </div>
-          </div>
-        </div>
+        style={innerStyle}
+      >
+        {children}
       </div>
     );
   }

--- a/src/FixedDataTableCellDefaultDeprecated.js
+++ b/src/FixedDataTableCellDefaultDeprecated.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule FixedDataTableCellDefaultDeprecated
+ * @typechecks
+ */
+
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+import cx from 'cx';
+import joinClasses from 'joinClasses';
+
+/**
+ * NOTE (pradeep): This component is deprecated since it uses a lot of wrapper DIV nodes for styling/layout.
+ * The replacement is src/FixedDataTableCell.js which uses a single wrapper to achieve the same table cell layout.
+ *
+ * Component that handles default cell layout and styling.
+ *
+ * All props unless specified below will be set onto the top level `div`
+ * rendered by the cell.
+ *
+ * Example usage via from a `Column`:
+ * ```
+ * const MyColumn = (
+ *   <Column
+ *     cell={({rowIndex, width, height}) => (
+ *       <Cell
+ *         width={width}
+ *         height={height}
+ *         className="my-class">
+ *         Cell number: <span>{rowIndex}</span>
+*        </Cell>
+ *     )}
+ *     width={100}
+ *   />
+ * );
+ * ```
+ */
+class FixedDataTableCellDefault extends React.Component {
+  static propTypes = {
+
+    /**
+     * Outer height of the cell.
+     */
+    height: PropTypes.number,
+
+    /**
+     * Outer width of the cell.
+     */
+    width: PropTypes.number,
+
+    /**
+     * Optional prop that if specified on the `Column` will be passed to the
+     * cell. It can be used to uniquely identify which column is the cell is in.
+     */
+    columnKey: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+
+    /**
+     * Optional prop that represents the rows index in the table.
+     * For the 'cell' prop of a Column, this parameter will exist for any
+     * cell in a row with a positive index.
+     *
+     * Below that entry point the user is welcome to consume or
+     * pass the prop through at their discretion.
+     */
+    rowIndex: PropTypes.number
+  };
+
+  render() {
+    //Remove some props like columnKey and rowIndex so we don't pass it into the div
+    var {height, width, style, className, children, columnKey, rowIndex, ...props} = this.props;
+
+    var innerStyle = {
+      height,
+      width,
+      ...style,
+    };
+
+    return (
+      <div
+        {...props}
+        className={joinClasses(
+          cx('fixedDataTableCellLayout/wrap1'),
+          cx('public/fixedDataTableCell/wrap1'),
+          className,
+        )}
+        style={innerStyle}>
+        <div
+          className={joinClasses(
+            cx('fixedDataTableCellLayout/wrap2'),
+            cx('public/fixedDataTableCell/wrap2'),
+          )}>
+          <div
+            className={joinClasses(
+              cx('fixedDataTableCellLayout/wrap3'),
+              cx('public/fixedDataTableCell/wrap3'),
+            )}>
+            <div className={cx('public/fixedDataTableCell/cellContent')}>
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default FixedDataTableCellDefault;

--- a/src/FixedDataTableRoot.js
+++ b/src/FixedDataTableRoot.js
@@ -12,8 +12,8 @@
 'use strict';
 
 import Table from 'FixedDataTableContainer';
-import Cell from 'FixedDataTableCellDefault';
-import CellDeprecated from 'FixedDataTableCellDefaultDeprecated';
+import Cell from 'FixedDataTableCellDefaultDeprecated';
+import DataCell from 'FixedDataTableCellDefault';
 import Column from 'FixedDataTableColumn';
 import ColumnGroup from 'FixedDataTableColumnGroup';
 
@@ -21,7 +21,7 @@ const version = '1.1.0';
 
 export {
   Cell,
-  CellDeprecated,
+  DataCell,
   Column,
   ColumnGroup,
   Table,

--- a/src/FixedDataTableRoot.js
+++ b/src/FixedDataTableRoot.js
@@ -13,6 +13,7 @@
 
 import Table from 'FixedDataTableContainer';
 import Cell from 'FixedDataTableCellDefault';
+import CellDeprecated from 'FixedDataTableCellDefaultDeprecated';
 import Column from 'FixedDataTableColumn';
 import ColumnGroup from 'FixedDataTableColumnGroup';
 
@@ -20,6 +21,7 @@ const version = '1.1.0';
 
 export {
   Cell,
+  CellDeprecated,
   Column,
   ColumnGroup,
   Table,

--- a/src/css/layout/fixedDataTableCellLayout.css
+++ b/src/css/layout/fixedDataTableCellLayout.css
@@ -38,17 +38,10 @@
   text-align: center;
 }
 
-.fixedDataTableCellLayout/wrap1 {
-  display: table;
-}
-
-.fixedDataTableCellLayout/wrap2 {
-  display: table-row;
-}
-
-.fixedDataTableCellLayout/wrap3 {
+.fixedDataTableCellLayout/wrap {
   display: table-cell;
   vertical-align: middle;
+  box-sizing: border-box;
 }
 
 .fixedDataTableCellLayout/columnResizerContainer {

--- a/src/css/layout/fixedDataTableCellLayout.css
+++ b/src/css/layout/fixedDataTableCellLayout.css
@@ -44,6 +44,19 @@
   box-sizing: border-box;
 }
 
+.fixedDataTableCellLayout/wrap1 {
+  display: table;
+}
+
+.fixedDataTableCellLayout/wrap2 {
+  display: table-row;
+}
+
+.fixedDataTableCellLayout/wrap3 {
+  display: table-cell;
+  vertical-align: middle;
+}
+
 .fixedDataTableCellLayout/columnResizerContainer {
   position: absolute;
   right: 0px;

--- a/src/css/style/fixedDataTableCell.css
+++ b/src/css/style/fixedDataTableCell.css
@@ -29,10 +29,9 @@
   background-color: #0284ff;
 }
 .public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/cellContent {
-  margin-left: 12px;
+  padding-left: 20px;
 }
 
 .fixedDataTable_isRTL .public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/cellContent {
-  margin-left: auto;
-  margin-right: 12px;
+  padding-right: 20px;
 }

--- a/src/css/style/fixedDataTableCell.css
+++ b/src/css/style/fixedDataTableCell.css
@@ -28,10 +28,19 @@
 .public/fixedDataTableCell/columnResizerKnob {
   background-color: #0284ff;
 }
-.public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/cellContent {
+
+.public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/wrap1 .public/fixedDataTableCell/cellContent {
+  margin-left: 12px;
+}
+.public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/wrap.public/fixedDataTableCell/cellContent {
   padding-left: 20px;
 }
 
-.fixedDataTable_isRTL .public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/cellContent {
+.fixedDataTable_isRTL .public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/wrap1 .public/fixedDataTableCell/cellContent {
+  margin-left: auto;
+  margin-right: 12px;
+}
+
+.fixedDataTable_isRTL .public/fixedDataTableCell/hasReorderHandle .public/fixedDataTableCell/wrap.public/fixedDataTableCell/cellContent {
   padding-right: 20px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minimize dom components in the default cell renderer, as part of #396.
See LD side changes required at [SB-18854](https://crucible.bb.schrodinger.com/cru/SB-18854)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase performance by reducing 3 dom levels per cell.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our examples and also on LD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
