### PR TITLE
fix condition for onScrollStart

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1196,8 +1196,8 @@ class FixedDataTable extends React.Component {
     }
 
     // only call onScrollStart if scrolling wasn't on previously
-    if (!this.props.scrolling && onScrollStart) {
-      onScrollStart(oldScrollX, oldScrollY, oldFirstRowIndex, oldEndRowIndex)
+    if (!prevProps.scrolling && this.props.scrolling && onScrollStart) {
+      onScrollStart(oldScrollX, oldScrollY, oldFirstRowIndex, oldEndRowIndex);
     }
 
     if (scrollXChanged && onHorizontalScroll) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Fixed condition for scroll callback - onScrollStart**

## Motivation and Context
In this commit https://github.com/schrodinger/fixed-data-table-2/commit/a59831dbb94e8aa64db540aaa7946935d651e1c4#diff-293ddd101833c33e0069803f5068f2f7R1132 condition to call onScrollStart is incorrect, because forgot  to change (!this.props.scrolling -> !prevProps.scrolling)

**onScrollStart** is called if scrolling wasn't on previously and is scrolling now (!prevProps.scrolling && this.props.scrolling)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
