### PR TITLE
[DESIS Internal] SS-31260: Add redux-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react-dom": ">=15.3.0"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.4.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.7.2",
     "react-lifecycles-compat": "^3.0.4",

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -146,6 +146,7 @@ class FixedDataTableCell extends React.Component {
     reorderCellLeft = Math.max(reorderCellLeft, 0);
     reorderCellLeft = Math.min(reorderCellLeft, farthestPossiblePoint);
 
+    // Todo: nextProps are supposed to be readonly
     // check if current cell belongs to the column that's being reordered
     if (nextProps.columnKey === nextProps.columnReorderingData.columnKey) {
       newState.displacement = reorderCellLeft - nextProps.left;

--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -16,13 +16,11 @@ import { bindActionCreators } from 'redux';
 import invariant from './stubs/invariant';
 import pick from 'lodash/pick';
 
-import * as ActionTypes from './actions/ActionTypes';
-import * as columnActions from './actions/columnActions';
-import * as scrollActions from './actions/scrollActions';
 import FixedDataTable from './FixedDataTable';
 import FixedDataTableStore from './FixedDataTableStore';
 import Scrollbar from './plugins/Scrollbar';
 import ScrollContainer from './plugins/ScrollContainer';
+import { initialize, propChange, scrollActions, columnActions } from "./actions";
 
 class FixedDataTableContainer extends React.Component {
   static defaultProps = {
@@ -41,10 +39,7 @@ class FixedDataTableContainer extends React.Component {
     this.scrollActions = bindActionCreators(scrollActions, this.reduxStore.dispatch);
     this.columnActions = bindActionCreators(columnActions, this.reduxStore.dispatch);
 
-    this.reduxStore.dispatch({
-      type: ActionTypes.INITIALIZE,
-      props,
-    });
+    this.reduxStore.dispatch(initialize(props));
 
     this.unsubscribe = this.reduxStore.subscribe(this.update);
     this.state = this.getBoundState();
@@ -56,11 +51,7 @@ class FixedDataTableContainer extends React.Component {
       'You must set either a height or a maxHeight'
     );
 
-    this.reduxStore.dispatch({
-      type: ActionTypes.PROP_CHANGE,
-      newProps: nextProps,
-      oldProps: this.props,
-    });
+    this.reduxStore.dispatch(propChange(nextProps, this.props));
   }
 
   componentWillUnmount() {
@@ -73,19 +64,19 @@ class FixedDataTableContainer extends React.Component {
 
   render() {
     const fdt = (
-        <FixedDataTable
-            {...this.props}
-            {...this.state}
-            scrollActions={this.scrollActions}
-            columnActions={this.columnActions}
-        />
+      <FixedDataTable
+        {...this.props}
+        {...this.state}
+        scrollActions={this.scrollActions}
+        columnActions={this.columnActions}
+      />
     );
     // For backward compatibility, by default we render FDT-2 scrollbars
     if (this.props.defaultScrollbars) {
       return (
-          <ScrollContainer {...this.props}>
-            {fdt}
-          </ScrollContainer>
+        <ScrollContainer {...this.props}>
+          {fdt}
+        </ScrollContainer>
       );
     }
     return fdt;

--- a/src/FixedDataTableStore.js
+++ b/src/FixedDataTableStore.js
@@ -11,10 +11,15 @@
 
 'use strict';
 
-import { createStore } from 'redux'
-
 import reducers from './reducers'
+import { configureStore } from "@reduxjs/toolkit";
 
 export default {
-  get: () => createStore(reducers)
+  get: () => configureStore({
+    reducer: reducers,
+    middleware: getDefaultMiddleware => getDefaultMiddleware({
+      immutableCheck: false,
+      serializableCheck: false
+    })
+  })
 };

--- a/src/actions/columnActions.js
+++ b/src/actions/columnActions.js
@@ -7,46 +7,30 @@
 
 'use strict';
 
-import {
-  COLUMN_REORDER_START,
-  COLUMN_REORDER_END,
-  COLUMN_REORDER_MOVE,
-  COLUMN_RESIZE,
-} from './ActionTypes';
+import { columnActions } from "../reducers";
 
 /**
  * Initiates column reordering
  *
  * @param {{scrollStart: number, columnKey: string, with: number, left: number}} reorderData
  */
-export const startColumnReorder = (reorderData) => ({
-  type: COLUMN_REORDER_START,
-  reorderData,
-});
+export const startColumnReorder = columnActions.startColumnReorder;
 
 /**
  * Stops column reordering
  */
-export const stopColumnReorder = () => ({
-  type: COLUMN_REORDER_END,
-});
+export const stopColumnReorder = columnActions.stopColumnReorder;
 
 /**
  * Stops column reordering
  *
  * @param {number} deltaX
  */
-export const moveColumnReorder = (deltaX) => ({
-  type: COLUMN_REORDER_MOVE,
-  deltaX
-});
+export const moveColumnReorder = columnActions.moveColumnReorder;
 
 /**
  * Fires a resize on column
  *
  * @param {!Object} reorderData
  */
-export const resizeColumn = (resizeData) => ({
-  type: COLUMN_RESIZE,
-  resizeData,
-});
+export const resizeColumn = columnActions.resizeColumn;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,3 @@
+export * as columnActions from './columnActions';
+export * as scrollActions from './scrollActions';
+export { initialize, propChange } from '../reducers';

--- a/src/actions/scrollActions.js
+++ b/src/actions/scrollActions.js
@@ -7,43 +7,30 @@
 
 'use strict';
 
-import {
-  SCROLL_END,
-  SCROLL_START,
-  SCROLL_TO_X,
-  SCROLL_TO_Y,
-} from './ActionTypes';
+import { scrollActions } from "../reducers";
 
 /**
  * Scrolls the table horizontally to position
  *
  * @param {number} scrollX
  */
-export const scrollToX = (scrollX) => ({
-  type: SCROLL_TO_X,
-  scrollX,
-});
+export const scrollToX = scrollActions.scrollToX;
 
 /**
  * Scrolls the table vertically to position
  *
  * @param {number} scrollY
  */
-export const scrollToY = (scrollY) => ({
-  type: SCROLL_TO_Y,
-  scrollY,
-});
+export const scrollToY = scrollActions.scrollToY;
 
 /**
  * Fire when user starts scrolling
  */
-export const startScroll = () => ({
-  type: SCROLL_START,
-});
+// Todo: Not used anywhere
+// export const startScroll = scrollActions.startScroll.
 
 /**
  * Fire when user starts scrolling
  */
-export const stopScroll = () => ({
-  type: SCROLL_END,
-});
+export const stopScroll = scrollActions.stopScroll;
+

--- a/src/selectors/ariaAttributes.js
+++ b/src/selectors/ariaAttributes.js
@@ -8,7 +8,7 @@
  *
  * @providesModule ariaAttributes
  */
-import shallowEqualSelector from '../helper/shallowEqualSelector';
+import { createSelector } from 'reselect';
 
 /**
  * Calculate the aria attributes for the rows and the grid.
@@ -57,7 +57,7 @@ function calculateAriaAttributes(rowsCount, useGroupHeader, useFooter) {
   };
 }
 
-export default shallowEqualSelector([
+export default createSelector([
   state => state.rowsCount,
   state => state.groupHeaderHeight > 0,
   state => state.footerHeight > 0,

--- a/src/selectors/columnTemplates.js
+++ b/src/selectors/columnTemplates.js
@@ -9,8 +9,8 @@
  * @providesModule columnTemplates
  */
 import forEach from 'lodash/forEach';
+import { createSelector } from 'reselect';
 
-import shallowEqualSelector from '../helper/shallowEqualSelector';
 import columnWidths from './columnWidths';
 
 /**
@@ -123,7 +123,7 @@ function columnTemplates(columnWidths, elementTemplates) {
   };
 }
 
-export default shallowEqualSelector([
+export default createSelector([
   state => columnWidths(state),
   state => state.elementTemplates,
 ], columnTemplates);

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -11,9 +11,9 @@
 import forEach from 'lodash/forEach';
 import map from 'lodash/map';
 
-import shallowEqualSelector from '../helper/shallowEqualSelector';
 import { getTotalFlexGrow, getTotalWidth } from '../helper/widthHelper';
 import scrollbarsVisible from './scrollbarsVisible';
+import { createSelector } from 'reselect';
 
 /**
  * @typedef {{
@@ -155,7 +155,7 @@ function groupColumns(columnProps) {
   };
 }
 
-export default shallowEqualSelector([
+export default createSelector([
   state => state.columnGroupProps,
   state => state.columnProps,
   state => scrollbarsVisible(state).scrollEnabledY,

--- a/src/selectors/roughHeights.js
+++ b/src/selectors/roughHeights.js
@@ -11,7 +11,7 @@
 
 import clamp from '../vendor_upstream/core/clamp';
 
-import shallowEqualSelector from '../helper/shallowEqualSelector';
+import { createSelector } from 'reselect';
 import { getTotalWidth } from '../helper/widthHelper';
 
 const BORDER_HEIGHT = 1;
@@ -77,7 +77,7 @@ export const ScrollbarState = {
  * }}
  */
 function roughHeights(columnProps, elementHeights, rowSettings,
-  scrollFlags, tableSize, scrollbarXHeight, scrollbarYWidth) {
+                      scrollFlags, tableSize, scrollbarXHeight, scrollbarYWidth) {
   const { cellGroupWrapperHeight, footerHeight, headerHeight, groupHeaderHeight } = elementHeights;
   // we don't need border height to be added to the table if we are using cellGroupWrapperHeight
   const borderHeight = cellGroupWrapperHeight ? 0 : 2 * BORDER_HEIGHT;
@@ -171,7 +171,7 @@ function getBufferRowCount(maxAvailableHeight, rowSettings) {
   );
 }
 
-export default shallowEqualSelector([
+export default createSelector([
   state => state.columnProps,
   state => state.elementHeights,
   state => state.rowSettings,

--- a/src/selectors/scrollbarsVisible.js
+++ b/src/selectors/scrollbarsVisible.js
@@ -9,8 +9,8 @@
  * @providesModule scrollbarsVisible
  */
 
-import shallowEqualSelector from '../helper/shallowEqualSelector';
 import roughHeights, { ScrollbarState } from './roughHeights';
+import { createSelector } from 'reselect';
 
 /**
  * State regarding which scrollbars will be shown.
@@ -61,10 +61,10 @@ function scrollbarsVisible(roughHeights, scrollContentHeight, scrollFlags) {
     availableHeight,
     scrollEnabledX,
     scrollEnabledY,
-  }
+  };
 }
 
-export default shallowEqualSelector([
+export default createSelector([
   roughHeights,
   state => state.scrollContentHeight,
   state => state.scrollFlags,

--- a/src/selectors/tableHeights.js
+++ b/src/selectors/tableHeights.js
@@ -9,9 +9,9 @@
  * @providesModule tableHeights
  */
 
-import shallowEqualSelector from '../helper/shallowEqualSelector';
 import roughHeights from './roughHeights';
 import scrollbarsVisible from './scrollbarsVisible';
+import { createSelector } from 'reselect';
 
 /**
  * Compute the necessary heights for rendering parts of the table
@@ -41,7 +41,7 @@ import scrollbarsVisible from './scrollbarsVisible';
  * }}
  */
 function tableHeights(elementHeights, ownerHeight, reservedHeight,
-  scrollContentHeight, scrollbarsVisible, useMaxHeight, scrollbarXHeight) {
+                      scrollContentHeight, scrollbarsVisible, useMaxHeight, scrollbarXHeight) {
   const { availableHeight, scrollEnabledX } = scrollbarsVisible;
   let reservedWithScrollbar = reservedHeight;
   if (scrollEnabledX) {
@@ -95,7 +95,7 @@ function tableHeights(elementHeights, ownerHeight, reservedHeight,
   };
 }
 
-export default shallowEqualSelector([
+export default createSelector([
   state => state.elementHeights,
   state => state.tableSize.ownerHeight,
   state => roughHeights(state).reservedHeight,

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,6 +937,16 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@reduxjs/toolkit@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.4.0.tgz#ee2e2384cc3d1d76780d844b9c2da3580d32710d"
+  integrity sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==
+  dependencies:
+    immer "^7.0.3"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -3469,6 +3479,11 @@ image-size@~0.5.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
+immer@^7.0.3:
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
+  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -5357,7 +5372,12 @@ recast@^0.17.3:
     private "^0.1.8"
     source-map "~0.6.1"
 
-redux@^4.0.1:
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0, redux@^4.0.1:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
Added @redux/toolkit to simplify the use of redux.

## Description

1. Created slice and exported actions and reducer from it to use in other places.
2. Removed ShallowEqualSelector because, whenever it is used in a slice, the prev state will be a revoked proxy and there is no need of comparison as it will always return false and throw error because we will performing operations on a revoked proxy.

## Motivation and Context

1. To simplify the usage of redux.
2. It uses immer internally. Hence, we don't need to care about state mutation.

## How Has This Been Tested?
1. Tested manually
2. Passing all tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
