### PR TITLE
Improve publish script

### DIFF
--- a/build_helpers/buildNPMInternals.sh
+++ b/build_helpers/buildNPMInternals.sh
@@ -5,12 +5,12 @@
 var glob = require('glob');
 var path = require('path');
 var fs = require('fs');
+var rimraf = require('rimraf');
 var babel = require('@babel/core');
 
 var internalPath = path.join(__dirname, '../internal');
-if (!fs.existsSync(internalPath)) {
-  fs.mkdirSync(internalPath);
-}
+rimraf.sync(internalPath); // remove older entries
+fs.mkdirSync(internalPath);
 
 var providesModuleRegex = /@providesModule ([^\s*]+)/;
 var moduleRequireRegex = /require\((?:'|")([\w\.\/]+)(?:'|")\)/gm;

--- a/build_helpers/publishPackage.sh
+++ b/build_helpers/publishPackage.sh
@@ -1,16 +1,40 @@
 #!/bin/bash
+# example usages:
+# ./publishPackage.sh --branch=v1.0.x
+# ./publishPackage.sh --branch=v1.1.x --latest
+# ./publishPackage.sh --branch=v1.0-beta --beta
+
 set -e
 
 # Defaults that can be overridden in the CLI (except the cookie file)
-export BETA=0
+export BETA=false
+export LATEST=false
+export BRANCH=""
 
+# Parse flags
 while (( "$#" )); do
   opt=$1
   VALUE=$2
   # Make sure to shift here and any option that uses the $VALUE
   shift
   case $opt in
-    --beta) BETA=$VALUE; shift ;;
+    --beta)
+      BETA=true
+      ;;
+
+    --latest)
+      LATEST=true
+      ;;
+
+    --branch)
+      if [ -z $VALUE ] ; then
+        echo "Please specify branch name"
+        exit 192
+      fi
+      BRANCH=$VALUE;
+      shift
+      ;;
+
     * ) # Invalid flag
       echo "Invalid flag: $opt"
       exit 192
@@ -18,18 +42,29 @@ while (( "$#" )); do
   esac
 done
 
+# branch name is required
+if [ -z "$BRANCH" ] ; then
+  echo "Please specify branch name using the --branch flag"
+  exit 192
+fi
+
 current_version=$(node -p "require('./package').version")
 
-printf "Next version (current is $current_version)? "
-read next_version
-
-if ! [[ $next_version =~ ^[0-9]\.[0-9]+\.[0-9](-.+)? ]]; then
-  echo "Version must be a valid semver string, e.g. 1.0.2 or 2.3.0-beta.1"
-  exit 1
-fi
+# prompt next version
+while [ true ]; do
+  printf "Next version (current is $current_version)? "
+  read next_version
+  if ! [[ $next_version =~ ^[0-9]\.[0-9]+\.[0-9](-.+)? ]]; then
+    echo "Version must be a valid semver string, e.g. 1.0.2 or 2.3.0-beta.1"
+    continue
+  else
+    break
+  fi
+done
 
 # npm test -- --single-run
 
+# update references of current version to next version
 echo "$(node -p "p=require('./package.json');p.version='${next_version}';JSON.stringify(p,null,2)")" > 'package.json'
 sed -i.DELETEME -e "s/version = '$current_version';/version = '$next_version';/g" src/*.js
 rm src/*.js.DELETEME
@@ -60,14 +95,21 @@ git commit -m "Version $next_version"
 
 next_ref="v$next_version"
 
+echo "Tagging $next_version"
 git tag "$next_ref"
 git push origin "$next_ref"
 
-if [ $BETA = 1 ]; then
+echo "Pushing release cut"
+git push origin $BRANCH
+
+if [ $BETA = true ]; then
+  echo "Publishing beta tag"
   npm publish --tag beta
-else
+elif [ $LATEST = true ]; then
+  echo "Tagging" $next_ref "as 'latest'"
   git tag latest -f
   git push origin latest -f
-  git push origin master
-  npm publish
+
+  echo "Publishing latest tag"
+  npm publish --tag latest
 fi

--- a/build_helpers/publishPackage.sh
+++ b/build_helpers/publishPackage.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 # example usages:
-# ./publishPackage.sh --branch=v1.0.x
-# ./publishPackage.sh --branch=v1.1.x --latest
-# ./publishPackage.sh --branch=v1.0-beta --beta
+# ./publishPackage.sh
+# ./publishPackage.sh --latest
+# ./publishPackage.sh --beta
 
 set -e
 
 # Defaults that can be overridden in the CLI (except the cookie file)
 export BETA=false
 export LATEST=false
-export BRANCH=""
 
 # Parse flags
 while (( "$#" )); do
@@ -26,15 +25,6 @@ while (( "$#" )); do
       LATEST=true
       ;;
 
-    --branch)
-      if [ -z $VALUE ] ; then
-        echo "Please specify branch name"
-        exit 192
-      fi
-      BRANCH=$VALUE;
-      shift
-      ;;
-
     * ) # Invalid flag
       echo "Invalid flag: $opt"
       exit 192
@@ -42,25 +32,15 @@ while (( "$#" )); do
   esac
 done
 
-# branch name is required
-if [ -z "$BRANCH" ] ; then
-  echo "Please specify branch name using the --branch flag"
-  exit 192
-fi
-
-current_version=$(node -p "require('./package').version")
-
 # prompt next version
-while [ true ]; do
-  printf "Next version (current is $current_version)? "
-  read next_version
-  if ! [[ $next_version =~ ^[0-9]\.[0-9]+\.[0-9](-.+)? ]]; then
-    echo "Version must be a valid semver string, e.g. 1.0.2 or 2.3.0-beta.1"
-    continue
-  else
-    break
-  fi
-done
+current_version=$(node -p "require('./package').version")
+printf "Next version (current is $current_version)? "
+read next_version
+
+if ! [[ $next_version =~ ^[0-9]\.[0-9]+\.[0-9](-.+)? ]]; then
+  echo "Version must be a valid semver string, e.g. 1.0.2 or 2.3.0-beta.1"
+  exit 1
+fi
 
 # npm test -- --single-run
 
@@ -100,16 +80,21 @@ git tag "$next_ref"
 git push origin "$next_ref"
 
 echo "Pushing release cut"
-git push origin $BRANCH
+git push
 
 if [ $BETA = true ]; then
   echo "Publishing beta tag"
   npm publish --tag beta
-elif [ $LATEST = true ]; then
+else
+  echo "Publishing $next_version to npm"
+  npm publish --tag $next_version
+fi
+
+if [ $LATEST = true ]; then
   echo "Tagging" $next_ref "as 'latest'"
   git tag latest -f
   git push origin latest -f
 
-  echo "Publishing latest tag"
+  echo "Publishing latest tag to npm"
   npm publish --tag latest
 fi

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-dom": "15.6.2",
     "react-tools": "0.13.3",
     "react-tooltip": "3.11.1",
+    "rimraf": "^3.0.2",
     "sinon": "7.4.2",
     "style-loader": "1.0.0",
     "uglifyjs-webpack-plugin": "^2.2.0",
@@ -70,7 +71,7 @@
     "build-docs": "./build_helpers/buildAPIDocs.sh",
     "publish-site": "./build_helpers/publishStaticSite.sh",
     "publish-package": "./build_helpers/publishPackage.sh",
-    "publish-beta": "./build_helpers/publishPackage.sh --beta 1",
+    "publish-beta": "./build_helpers/publishPackage.sh --beta",
     "test": "mocha-webpack --webpack-config webpack.config-test.js \"test/**/*-test.js\" --require build_helpers/test-globals.js",
     "test:watch": "mocha-webpack --webpack-config webpack.config-test.js --watch \"test/**/*-test.js\" --require build_helpers/test-globals.js",
     "test:server": "webpack-dev-server --config webpack.config-test.js --hot --inline"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5295,6 +5295,13 @@ rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
We make use of a shell script ([publishPackage.sh](https://github.com/schrodinger/fixed-data-table-2/blob/2a2406550d5a1cb58d094e1f67edac1a38f06de9/build_helpers/publishPackage.sh)) for publishing fixed data table to npm. 
The script also bumps up the package version and releases new tags prior to publishing.

I saw a few problems while working on them:

* Currently, the script always overwrites the `latest` tag. This'll mean that attempting to publish a new release under v1.0.x using the 
script will lead to the latest tag being overwritten. This should be forbidden since we have v1.1.x.
Let's fix this by having an option flag passed to the script that overwrites the latest.

* Entering the next package version exits the script if the version is invalid. Let's re-prompt the user instead.

* The script does multiple operations that might require authentication. If user fails at authentication, the script just exits, and it becomes difficult to know at which step it had failed. To keep track of it, let's log before such operations.

* The [script for building internal](https://github.com/schrodinger/fixed-data-table-2/blob/v1.1.x/build_helpers/buildNPMInternals.sh) doesn't clear up the internal directory if it already exists. This means, it's possible for the user to publish stale files which might have came up from a previous build, but is no longer needed. 