### PR TITLE
595 - pass firstRowIndex and endRowIndex to 'onVerticalScroll'

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1130,7 +1130,8 @@ class FixedDataTable extends React.Component {
       scrollFlags,
       scrollX,
       scrollY,
-      scrolling,
+      firstRowIndex,
+      endRowIndex,
     } = this.props;
     const { overflowX, overflowY } = scrollFlags;
 
@@ -1142,7 +1143,11 @@ class FixedDataTable extends React.Component {
       y = y > maxScrollY ? maxScrollY : y;
 
       //NOTE (jordan) This is a hacky workaround to prevent FDT from setting its internal state
-      if (onVerticalScroll ? onVerticalScroll(y) : true) {
+      if (
+        onVerticalScroll
+          ? onVerticalScroll(y, firstRowIndex, endRowIndex)
+          : true
+      ) {
         scrollActions.scrollToY(y);
       }
     } else if (deltaX && overflowX !== 'hidden') {
@@ -1188,13 +1193,23 @@ class FixedDataTable extends React.Component {
   };
 
   _scrollToY = (/*number*/ scrollPos) => {
-    const { onVerticalScroll, scrollActions, scrollY } = this.props;
+    const {
+      onVerticalScroll,
+      scrollActions,
+      scrollY,
+      firstRowIndex,
+      endRowIndex,
+    } = this.props;
 
     if (scrollPos === scrollY) {
       return;
     }
 
-    if (onVerticalScroll ? onVerticalScroll(scrollPos) : true) {
+    if (
+      onVerticalScroll
+        ? onVerticalScroll(scrollPos, firstRowIndex, endRowIndex)
+        : true
+    ) {
       scrollActions.scrollToY(scrollPos);
     }
   };
@@ -1211,6 +1226,8 @@ class FixedDataTable extends React.Component {
       onVerticalScroll,
       tableSize: { ownerHeight },
       scrolling,
+      firstRowIndex,
+      endRowIndex,
     } = this.props;
 
     const {
@@ -1244,7 +1261,7 @@ class FixedDataTable extends React.Component {
     }
 
     if (scrollYChanged && onVerticalScroll) {
-      onVerticalScroll(scrollY);
+      onVerticalScroll(scrollY, firstRowIndex, endRowIndex);
     }
 
     // debounced version of didScrollStop as we don't immediately stop scrolling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just passed the `firstRowIndex` and `endRowIndex` prop to the `onVerticalScroll` callback.
Did not touch `onHorizontalScroll` , since on that particular scroll, the first and last row indexes should not change.

## Motivation and Context
https://github.com/schrodinger/fixed-data-table-2/issues/595

## How Has This Been Tested?
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
