### PR TITLE
removing final instance of componentWillReceiveProps

### DIFF
--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -56,16 +56,20 @@ class FixedDataTableContainer extends React.Component {
     this.state = this.getBoundState();
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
+    if (this.props === prevProps) {
+      return;
+    }
+
     invariant(
-      nextProps.height !== undefined || nextProps.maxHeight !== undefined,
+      this.props.height !== undefined || this.props.maxHeight !== undefined,
       'You must set either a height or a maxHeight'
     );
 
     this.reduxStore.dispatch({
       type: ActionTypes.PROP_CHANGE,
-      newProps: nextProps,
-      oldProps: this.props,
+      newProps: this.props,
+      oldProps: prevProps,
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the final usage of `componentWillReceiveProps` that causes deprecation warnings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Github issue https://github.com/schrodinger/fixed-data-table-2/issues/492 - React has already deprecated `componentWillReceiveProps` and plans a breaking change in v18. In the meantime, this causes console warnings for users.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Console tests all pass. The sample site (`test:server`) also appears to be fully functional.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

