### PR TITLE
Remove usage of componentWillReceiveProps

### DIFF
--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -48,6 +48,7 @@ class FixedDataTableContainer extends React.Component {
     this.state = {
       boundState: FixedDataTableContainer.getBoundState(this.reduxStore), // the state from the redux store
       reduxStore: this.reduxStore, // put store instance in local state so that getDerivedStateFromProps can access it
+      props, // put props in local state so that getDerivedStateFromProps can access it
     };
   }
 
@@ -68,7 +69,7 @@ class FixedDataTableContainer extends React.Component {
     currentState.reduxStore.dispatch({
       type: ActionTypes.PROP_CHANGE,
       newProps: nextProps,
-      oldProps: currentState.boundState.propsReference,
+      oldProps: currentState.props,
     });
 
     // return the new state from the updated redux store
@@ -76,6 +77,7 @@ class FixedDataTableContainer extends React.Component {
       boundState: FixedDataTableContainer.getBoundState(
         currentState.reduxStore
       ),
+      props: nextProps,
     };
   }
 
@@ -122,7 +124,7 @@ class FixedDataTableContainer extends React.Component {
       'isColumnResizing',
       'maxScrollX',
       'maxScrollY',
-      'propsReference',
+      'propsRevision',
       'rows',
       'rowOffsets',
       'rowSettings',
@@ -145,7 +147,7 @@ class FixedDataTableContainer extends React.Component {
 
     // If onStoreUpdate was called through a prop change, then skip updating local state.
     // This is fine because getDerivedStateFromProps already calculates the new state.
-    if (this.state.boundState.propsReference !== newBoundState.propsReference) {
+    if (this.state.boundState.propsRevision !== newBoundState.propsRevision) {
       return;
     }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -47,7 +47,7 @@ function getInitialState() {
       groupHeaderHeight: 0,
       headerHeight: 0,
     },
-    propsReference: null,
+    propsRevision: null,
     rowSettings: {
       bufferRowCount: undefined,
       rowAttributesGetter: undefined,
@@ -238,7 +238,7 @@ function setStateFromProps(state, props) {
   } = convertColumnElementsToData(props.children);
 
   const newState = Object.assign({}, state,
-    { columnGroupProps, columnProps, elementTemplates, propsReference: props });
+    { columnGroupProps, columnProps, elementTemplates, propsRevision: state.propsRevision + 1 });
 
   newState.elementHeights = Object.assign({}, newState.elementHeights,
     pick(props, ['cellGroupWrapperHeight', 'footerHeight', 'groupHeaderHeight', 'headerHeight']));

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -47,6 +47,7 @@ function getInitialState() {
       groupHeaderHeight: 0,
       headerHeight: 0,
     },
+    propsReference: null,
     rowSettings: {
       bufferRowCount: undefined,
       rowAttributesGetter: undefined,
@@ -237,7 +238,7 @@ function setStateFromProps(state, props) {
   } = convertColumnElementsToData(props.children);
 
   const newState = Object.assign({}, state,
-    { columnGroupProps, columnProps, elementTemplates });
+    { columnGroupProps, columnProps, elementTemplates, propsReference: props });
 
   newState.elementHeights = Object.assign({}, newState.elementHeights,
     pick(props, ['cellGroupWrapperHeight', 'footerHeight', 'groupHeaderHeight', 'headerHeight']));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the last usage of the `componentWillReceiveProps` lifecycle method in our codebase.

The usage is in `FixedDataTableContainer.js` where the redux store is made to update against the new props passed by the user.
I replaced the lifecycle method with the new static `getDerivedStateFromProps` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* [SS-31705](https://jira.schrodinger.com/browse/SS-31705): FDT: Replace deprecated React life cycle methods
* #492

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested examples and in LD, and everything works fine.
Also verified that there's no additional rerenders happening.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
