### PR TITLE
Fix row expansion erroring out in v2.0-beta

### DIFF
--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -23,7 +23,6 @@ const DRAG_SCROLL_BUFFER = 100;
 
 /**
  * Initialize scrollX state
- * TODO (jordan) Audit this method for cases where deep values are not properly cloned
  *
  * @param {!Object} state
  * @param {!Object} props
@@ -53,7 +52,7 @@ function initialize(state, props, oldProps) {
       : isColumnResizing;
   columnResizingData = isColumnResizing ? columnResizingData : {};
 
-  return Object.assign({}, state, {
+  Object.assign(state, {
     columnResizingData,
     isColumnResizing,
     maxScrollX,

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -34,12 +34,11 @@ import updateRowHeight from './updateRowHeight';
  * @return {!Object} The updated state object
  */
 export default function computeRenderedRows(state, scrollAnchor) {
-  const newState = Object.assign({}, state);
-  let rowRange = calculateRenderedRowRange(newState, scrollAnchor);
+  let rowRange = calculateRenderedRowRange(state, scrollAnchor);
 
-  const { rowSettings, scrollContentHeight } = newState;
+  const { rowSettings, scrollContentHeight } = state;
   const { rowsCount } = rowSettings;
-  const { bodyHeight } = tableHeightsSelector(newState);
+  const { bodyHeight } = tableHeightsSelector(state);
   const maxScrollY = scrollContentHeight - bodyHeight;
   let firstRowOffset;
 
@@ -47,7 +46,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
   // leave only a subset of rows shown, but no scrollbar to scroll up to the first rows.
   if (maxScrollY === 0) {
     if (rowRange.firstViewportIdx > 0) {
-      rowRange = calculateRenderedRowRange(newState, {
+      rowRange = calculateRenderedRowRange(state, {
         firstOffset: 0,
         lastIndex: rowsCount - 1,
       });
@@ -61,15 +60,15 @@ export default function computeRenderedRows(state, scrollAnchor) {
   const firstRowIndex = rowRange.firstViewportIdx;
   const endRowIndex = rowRange.endViewportIdx;
 
-  computeRenderedRowOffsets(newState, rowRange, state.scrolling);
+  computeRenderedRowOffsets(state, rowRange, state.scrolling);
 
   let scrollY = 0;
   if (rowsCount > 0) {
-    scrollY = newState.rowOffsets[rowRange.firstViewportIdx] - firstRowOffset;
+    scrollY = state.rowOffsets[rowRange.firstViewportIdx] - firstRowOffset;
   }
   scrollY = clamp(scrollY, 0, maxScrollY);
 
-  return Object.assign(newState, {
+  Object.assign(state, {
     firstRowIndex,
     firstRowOffset,
     endRowIndex,
@@ -84,9 +83,6 @@ export default function computeRenderedRows(state, scrollAnchor) {
  * while the viewport rows are based on their height and the viewport height
  * We use the scrollAnchor to determine what either the first or last row
  * will be, as well as the offset.
- *
- * NOTE (jordan) This alters state so it shouldn't be called
- * without state having been cloned first.
  *
  * @param {!Object} state
  * @param {{
@@ -211,9 +207,6 @@ function calculateRenderedRowRange(state, scrollAnchor) {
 /**
  * Walk the rows to render and compute the height offsets and
  * positions in the row buffer.
- *
- * NOTE (jordan) This alters state so it shouldn't be called
- * without state having been cloned first.
  *
  * @param {!Object} state
  * @param {{

--- a/src/reducers/updateRowHeight.js
+++ b/src/reducers/updateRowHeight.js
@@ -15,9 +15,6 @@
  * Update our cached row height for a specific index
  * based on the value from rowHeightGetter
  *
- * NOTE (jordan) This alters state so it shouldn't be called
- * without state having been cloned first.
- *
  * @param {!Object} state
  * @param {number} rowIdx
  * @return {number} The new row height


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the beta branch, trying to trigger a row expansion makes redux-toolkit throw an hard error.
The propsChange reducer was mutating state AND returning a new state object.
This is unsupported in immer, and the fix is to either only mutate the state, or only return a new state object.

I went ahead with mutation as it's much easier on the developer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the examples, specifically the [row expansion example](http://schrodinger.github.io/fixed-data-table-2/example-expanded-rows.html).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
