### PR TITLE
Add null checks to prevent client exception when reading 'releaseMouseMoves'

### DIFF
--- a/src/ColumnResizerLine.js
+++ b/src/ColumnResizerLine.js
@@ -110,8 +110,10 @@ class ColumnResizerLine extends React.PureComponent {
   }
 
   componentWillUnmount() {
-    this._mouseMoveTracker.releaseMouseMoves();
-    this._mouseMoveTracker = null;
+    if (this._mouseMoveTracker) {
+      this._mouseMoveTracker.releaseMouseMoves();
+      this._mouseMoveTracker = null;
+    }
   }
 
   render() /*object*/ {
@@ -128,8 +130,8 @@ class ColumnResizerLine extends React.PureComponent {
       <div
         className={cx({
           'fixedDataTableColumnResizerLineLayout/main': true,
-          'fixedDataTableColumnResizerLineLayout/hiddenElem': !this.props
-            .visible,
+          'fixedDataTableColumnResizerLineLayout/hiddenElem':
+            !this.props.visible,
           'public/fixedDataTableColumnResizerLine/main': true,
         })}
         style={style}
@@ -162,7 +164,9 @@ class ColumnResizerLine extends React.PureComponent {
   };
 
   _onColumnResizeEnd = () => {
-    this._mouseMoveTracker.releaseMouseMoves();
+    if (this._mouseMoveTracker) {
+      this._mouseMoveTracker.releaseMouseMoves();
+    }
     this.props.onColumnResizeEnd(this.state.width, this.props.columnKey);
   };
 }

--- a/src/FixedDataTableColumnReorderHandle.js
+++ b/src/FixedDataTableColumnReorderHandle.js
@@ -126,7 +126,9 @@ class FixedDataTableColumnReorderHandle extends React.PureComponent {
     this._animating = false;
     cancelAnimationFrame(this.frameId);
     this.frameId = null;
-    this._mouseMoveTracker.releaseMouseMoves();
+    if (this._mouseMoveTracker) {
+      this._mouseMoveTracker.releaseMouseMoves();
+    }
     this.props.columnReorderingData.cancelReorder = cancelReorder;
     this.props.onColumnReorderEnd();
   };

--- a/src/plugins/Scrollbar.js
+++ b/src/plugins/Scrollbar.js
@@ -242,11 +242,11 @@ class Scrollbar extends React.PureComponent {
     this._nextState = null;
     if (this._mouseMoveTracker) {
       this._mouseMoveTracker.releaseMouseMoves();
+      this._mouseMoveTracker = null;
     }
     if (_lastScrolledScrollbar === this) {
       _lastScrolledScrollbar = null;
     }
-    delete this._mouseMoveTracker;
   }
 
   scrollBy = (/*number*/ delta) => {

--- a/src/plugins/Scrollbar.js
+++ b/src/plugins/Scrollbar.js
@@ -240,7 +240,9 @@ class Scrollbar extends React.PureComponent {
         passive: false,
       });
     this._nextState = null;
-    this._mouseMoveTracker.releaseMouseMoves();
+    if (this._mouseMoveTracker) {
+      this._mouseMoveTracker.releaseMouseMoves();
+    }
     if (_lastScrolledScrollbar === this) {
       _lastScrolledScrollbar = null;
     }


### PR DESCRIPTION
Add null checks to prevent client exception when reading 'releaseMouseMoves'

## Description
Add null checks similar to one that was already there to all calls to releaseMouseMoves. I am not sure of the reproduction steps needed but felt like adding a null check would not hurt anything.

## Motivation and Context
This is to prevent exceptions seen by some of our end users.

## How Has This Been Tested?
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
