### PR TITLE
Column Resizer Double Click Listener

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -436,6 +436,16 @@ class FixedDataTable extends React.Component {
      * ```
      */
     onColumnReorderEndCallback: PropTypes.func,
+    /**
+     * Callback that is called when column resizer is doubled clicked
+     *
+     * ```
+     * function(
+     *  columnKey: string,
+     * )
+     * ```
+     */
+    onColumnResizerDoubleClick: PropTypes.func,
 
     /**
      * Whether a column is currently being resized.
@@ -885,6 +895,7 @@ class FixedDataTable extends React.Component {
         scrollableColumns={scrollableColumns.header}
         touchEnabled={touchScrollEnabled}
         onColumnResize={this._onColumnResize}
+        onColumnResizerDoubleClick={this.props.onColumnResizerDoubleClick}
         onColumnReorder={onColumnReorder}
         onColumnReorderMove={this._onColumnReorderMove}
         onColumnReorderEnd={this._onColumnReorderEnd}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -61,6 +61,7 @@ class FixedDataTableCell extends React.Component {
      * @param object event
      */
     onColumnResize: PropTypes.func,
+    onColumnResizerDoubleClick: PropTypes.func,
     onColumnReorder: PropTypes.func,
 
     /**
@@ -253,6 +254,7 @@ class FixedDataTableCell extends React.Component {
           className={cx('fixedDataTableCellLayout/columnResizerContainer')}
           style={columnResizerStyle}
           onMouseDown={this._onColumnResizerMouseDown}
+          onDoubleClick={this._onColumnResizerDoubleClick}
           onTouchStart={
             this.props.touchEnabled ? this._onColumnResizerMouseDown : null
           }
@@ -337,6 +339,10 @@ class FixedDataTableCell extends React.Component {
       event.stopPropagation();
     }
   };
+
+  _onColumnResizerDoubleClick = () => {
+    this.props.onColumnResizerDoubleClick(this.props.columnKey);
+  }
 
   _onColumnReorderMouseDown = (/*object*/ event) => {
     this.props.onColumnReorder(

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -37,6 +37,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
     left: PropTypes.number,
 
     onColumnResize: PropTypes.func,
+    onColumnResizerDoubleClick: PropTypes.func,
 
     onColumnReorder: PropTypes.func,
     onColumnReorderMove: PropTypes.func,
@@ -170,6 +171,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
         minWidth={columnProps.minWidth}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={onColumnResize}
+        onColumnResizerDoubleClick={this.props.onColumnResizerDoubleClick}
         onColumnReorder={onColumnReorder}
         onColumnReorderMove={this.props.onColumnReorderMove}
         onColumnReorderEnd={this.props.onColumnReorderEnd}

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -121,6 +121,7 @@ class FixedDataTableRowImpl extends React.Component {
      * @param object event
      */
     onColumnResize: PropTypes.func,
+    onColumnResizerDoubleClick: PropTypes.func,
 
     isColumnReordering: PropTypes.bool,
     /**
@@ -220,6 +221,7 @@ class FixedDataTableRowImpl extends React.Component {
         columns={this.props.fixedColumns}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
+        onColumnResizerDoubleClick={this.props.onColumnResizerDoubleClick}
         onColumnReorder={this.props.onColumnReorder}
         onColumnReorderMove={this.props.onColumnReorderMove}
         onColumnReorderEnd={this.props.onColumnReorderEnd}
@@ -248,6 +250,7 @@ class FixedDataTableRowImpl extends React.Component {
         columns={this.props.fixedRightColumns}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
+        onColumnResizerDoubleClick={this.props.onColumnResizerDoubleClick}
         onColumnReorder={this.props.onColumnReorder}
         onColumnReorderMove={this.props.onColumnReorderMove}
         onColumnReorderEnd={this.props.onColumnReorderEnd}
@@ -283,6 +286,7 @@ class FixedDataTableRowImpl extends React.Component {
         columns={this.props.scrollableColumns}
         touchEnabled={this.props.touchEnabled}
         onColumnResize={this.props.onColumnResize}
+        onColumnResizerDoubleClick={this.props.onColumnResizerDoubleClick}
         onColumnReorder={this.props.onColumnReorder}
         onColumnReorderMove={this.props.onColumnReorderMove}
         onColumnReorderEnd={this.props.onColumnReorderEnd}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added support to pass a callback to listen to double click event of column resizer knob.
This can be very useful to enable excel like autofit columns in the table.

## Motivation and Context
In Excel we have a very simple but cool ability to autofit the columns based on its contents, adding a listener for double click event on column resizer can help in implementing the same excel like autofit column feature in the table. 

## How Has This Been Tested?
Currently this has been tested locally in my system. Open to add test cases in any form wherever required.

## Screenshots (if appropriate):


![fdtos2](https://user-images.githubusercontent.com/7591673/147899598-a4d29e32-f9bd-4215-8a40-ed2e74d520bc.gif)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
