### PR TITLE
Fix an issue where rows outside the viewport aren't updated

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -129,6 +129,9 @@ class FixedDataTableBufferedRows extends React.Component {
       if (rowIndex === undefined) {
         rowIndex =
           this._staticRowArray[i] && this._staticRowArray[i].props.index;
+        if (rowIndex === undefined) {
+          this._staticRowArray[i] = null;
+        }
       }
       const rowOffsetTop =
         rowOffsets[rowIndex] -
@@ -159,32 +162,25 @@ class FixedDataTableBufferedRows extends React.Component {
   renderRow({ rowIndex, key, rowOffsetTop }) /*object*/ {
     const props = this.props;
     const rowClassNameGetter = props.rowClassNameGetter || emptyFunction;
-    const fake = rowIndex === undefined;
     let rowProps = {};
+    rowProps.height = this.props.rowSettings.rowHeightGetter(rowIndex);
+    rowProps.subRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
+    rowProps.offsetTop = rowOffsetTop;
+    rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
+    rowProps.attributes =
+      props.rowSettings.rowAttributesGetter &&
+      props.rowSettings.rowAttributesGetter(rowIndex);
 
-    // if row exists, then calculate row specific props
-    if (!fake) {
-      rowProps.height = this.props.rowSettings.rowHeightGetter(rowIndex);
-      rowProps.subRowHeight = this.props.rowSettings.subRowHeightGetter(
-        rowIndex
-      );
-      rowProps.offsetTop = rowOffsetTop;
-      rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
-      rowProps.attributes =
-        props.rowSettings.rowAttributesGetter &&
-        props.rowSettings.rowAttributesGetter(rowIndex);
-
-      const hasBottomBorder =
-        rowIndex === props.rowSettings.rowsCount - 1 && props.showLastRowBorder;
-      rowProps.className = joinClasses(
-        rowClassNameGetter(rowIndex),
-        cx('public/fixedDataTable/bodyRow'),
-        cx({
-          'fixedDataTableLayout/hasBottomBorder': hasBottomBorder,
-          'public/fixedDataTable/hasBottomBorder': hasBottomBorder,
-        })
-      );
-    }
+    const hasBottomBorder =
+      rowIndex === props.rowSettings.rowsCount - 1 && props.showLastRowBorder;
+    rowProps.className = joinClasses(
+      rowClassNameGetter(rowIndex),
+      cx('public/fixedDataTable/bodyRow'),
+      cx({
+        'fixedDataTableLayout/hasBottomBorder': hasBottomBorder,
+        'public/fixedDataTable/hasBottomBorder': hasBottomBorder,
+      })
+    );
 
     const visible = inRange(
       rowIndex,
@@ -218,7 +214,6 @@ class FixedDataTableBufferedRows extends React.Component {
         scrollbarYWidth={props.scrollbarYWidth}
         isRTL={props.isRTL}
         visible={visible}
-        fake={fake}
         {...rowProps}
       />
     );

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -131,6 +131,7 @@ class FixedDataTableBufferedRows extends React.Component {
           this._staticRowArray[i] && this._staticRowArray[i].props.index;
         if (rowIndex === undefined) {
           this._staticRowArray[i] = null;
+          continue;
         }
       }
       const rowOffsetTop =

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -86,11 +86,6 @@ class FixedDataTableRowImpl extends React.Component {
     scrollLeft: PropTypes.number.isRequired,
 
     /**
-     * Pass true to not render the row. This is used internally for buffering rows.
-     */
-    fake: PropTypes.bool,
-
-    /**
      * Width of the row.
      */
     width: PropTypes.number.isRequired,
@@ -170,31 +165,26 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   shouldComponentUpdate(nextProps) {
+    // only skip updates while scrolling
+    if (!nextProps.isScrolling) {
+      return true;
+    }
+
     // if row is not visible then no need to render it
     // change in visibility is handled by the parent
     if (!nextProps.visible) {
       return false;
     }
 
-    // always render if fakeness has changed
-    if (this.props.fake !== nextProps.fake) {
-      return true;
-    }
-
     // Only update the row if scrolling leads to a change in horizontal offsets.
     // The vertical offset is taken care of by the wrapper
     return !(
-      nextProps.isScrolling &&
       this.props.index === nextProps.index &&
       this.props.scrollLeft === nextProps.scrollLeft
     );
   }
 
   render() /*object*/ {
-    if (this.props.fake) {
-      return null;
-    }
-
     var subRowHeight = this.props.subRowHeight || 0;
     var style = {
       width: this.props.width,
@@ -540,16 +530,18 @@ class FixedDataTableRow extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    // if row's visibility or fakeness has changed, then update it
-    if (
-      this.props.visible !== nextProps.visible ||
-      this.props.fake !== nextProps.fake
-    ) {
+    // only skip updates while scrolling
+    if (!nextProps.isScrolling) {
       return true;
     }
 
-    // if row is still fake or still not visible then no need to update
-    if (nextProps.fake || !nextProps.visible) {
+    // if row's visibility has changed, then update it
+    if (this.props.visible !== nextProps.visible) {
+      return true;
+    }
+
+    // if row is still not visible then no need to update
+    if (!nextProps.visible) {
       return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes an edge case where rows outside the viewport aren't updated with latest props.
The cause of the bug is a bad check in `shouldComponentDidUpdate` which tried to improve scroll performance by ignoring updates to rows outside the viewport.
The check was bad because it didn't actually check if we were in the middle of scrolling.

I also removed a redundant prop `fake` to simplify the checks in `shouldComponentDidUpdate`.

## Tracked issue(s)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SS-37225](https://jira.schrodinger.com/browse/SS-37225) - FDT: Fix cells outside the viewport not being updated

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local examples and also in LD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
