### PR TITLE
Fix cell order in DOM

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -142,7 +142,13 @@ class FixedDataTableBufferedRows extends React.Component {
     // We translate all the rows together with a parent div. This saves a lot of renders.
     const style = {};
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
-    return <div style={style}>{this._staticRowArray}</div>;
+
+    // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
+    const sortedRows = _.sortBy(this._staticRowArray, (row) =>
+      _.get(row, 'props.index', Infinity)
+    );
+
+    return <div style={style}>{sortedRows}</div>;
   }
 
   /**

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -145,7 +145,7 @@ class FixedDataTableBufferedRows extends React.Component {
 
     // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
     const sortedRows = _.sortBy(this._staticRowArray, (row) =>
-      _.get(row, 'props.index', Infinity)
+      _.get(row, 'props.ariaRowIndex', Infinity)
     );
 
     return <div style={style}>{sortedRows}</div>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description and Motiviation
<!--- Describe your changes in detail -->
FDT recycles rows to avoid unmounts during scrolling. This greatly gives performance but leads to rows being rendered out of order in the DOM. 
This is fine visually because FDT always translates the individual rows to the correct position.

However, this implementation detail becomes a pain when the user has code that depends on DOM ordering.
For instance, in #221, the user wanted to apply a border style to each row, but the unordered row elements messes up the CSS.
Another issue is that text selection inside the grid appears to split up here and there.

Another issue which I recently found in LD was that we often have cases like selenium tests which query the text value seen in the DOM. 
If the query was done on the table, then the contents will be jumbled up because the rows are unordered in the DOM.

## Fix
We simply sort the list of row React elements rendered by FDT by their row index rather than their recycle "key".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on this [codesandbox](https://codesandbox.io/s/currying-glitter-c3xb9d) and verified both the style issue and text selection issues are gone.
Also verified this on our examples locally, and also on LD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
