### PR TITLE
Move out internal-state from redux store

### DIFF
--- a/examples/DynamicRowHeightExample.js
+++ b/examples/DynamicRowHeightExample.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright Schrodinger, LLC
+ */
+
+'use strict';
+
+import FakeObjectDataListStore from './helpers/FakeObjectDataListStore';
+import { TextCell } from './helpers/cells';
+import { Table, Column, DataCell } from 'fixed-data-table-2';
+import React from 'react';
+
+class DynamicRowHeightExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const rowCount = 100;
+    this.state = {
+      dataList: new FakeObjectDataListStore(rowCount),
+      rowHeights: new Array(rowCount),
+      useDynamicRowHeights: true,
+    };
+
+    // fill up random row heights
+    for (let i = 0; i < rowCount; i++) {
+      this.state.rowHeights[i] = Math.floor(Math.random() * 100) + 50; // height varies from the range [50, 150]
+    }
+  }
+
+  render() {
+    return (
+      <div className="dynamic-row-heights-example">
+        {this.renderControls()}
+        {this.renderTable()}
+      </div>
+    );
+  }
+
+  renderControls() {
+    return (
+      <label className="toggle-dynamic-heights">
+        Use dynamic row heights:
+        <input
+          type="checkbox"
+          checked={this.state.useDynamicRowHeights}
+          onChange={this.toggleDynamicRowHeights}
+        />
+      </label>
+    );
+  }
+
+  renderTable() {
+    const { dataList, useDynamicRowHeights } = this.state;
+    return (
+      <Table
+        rowHeight={50}
+        rowHeightGetter={
+          useDynamicRowHeights
+            ? (rowIndex) => this.state.rowHeights[rowIndex]
+            : null
+        }
+        headerHeight={50}
+        rowsCount={dataList.getSize()}
+        width={1000}
+        height={500}
+        {...this.props}
+      >
+        <Column
+          columnKey="id"
+          header={<DataCell>Id</DataCell>}
+          cell={<TextCell data={dataList} />}
+          width={100}
+        />
+        <Column
+          columnKey="firstName"
+          header={<DataCell>First Name</DataCell>}
+          cell={<TextCell data={dataList} />}
+          width={150}
+        />
+        <Column
+          columnKey="lastName"
+          header={<DataCell>Last Name</DataCell>}
+          cell={<TextCell data={dataList} />}
+          width={150}
+        />
+        <Column
+          columnKey="city"
+          header={<DataCell>City</DataCell>}
+          cell={<TextCell data={dataList} />}
+          width={200}
+        />
+      </Table>
+    );
+  }
+
+  toggleDynamicRowHeights = () => {
+    this.setState((prevState) => ({
+      useDynamicRowHeights: !prevState.useDynamicRowHeights,
+    }));
+  };
+}
+
+export default DynamicRowHeightExample;

--- a/examples/DynamicRowHeightExample.js
+++ b/examples/DynamicRowHeightExample.js
@@ -13,7 +13,7 @@ class DynamicRowHeightExample extends React.Component {
   constructor(props) {
     super(props);
 
-    const rowCount = 100;
+    const rowCount = 100000;
     this.state = {
       dataList: new FakeObjectDataListStore(rowCount),
       rowHeights: new Array(rowCount),

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -45,6 +45,12 @@ exports.ExamplePages = {
     description:
       'A basic table example with two fixed columns, fed in some JSON data.',
   },
+  DYNAMIC_ROW_HEIGHTS_EXAMPLE: {
+    location: 'dynamic-row-heights.html',
+    fileName: 'DynamicRowHeightExample.js',
+    title: 'Dynamic Row Heights',
+    description: 'A table example where each row has a different height.',
+  },
   FIXED_RIGHT_COLUMNS_EXAMPLE: {
     location: 'fixed-right-columns.html',
     fileName: 'FixedRightColumnsExample.js',

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -28,6 +28,8 @@ var ExamplePages = Constants.ExamplePages;
 var EXAMPLE_COMPONENTS = {
   [ExamplePages.OBJECT_DATA_EXAMPLE
     .location]: require('../../examples/ObjectDataExample'),
+  [ExamplePages.DYNAMIC_ROW_HEIGHTS_EXAMPLE
+    .location]: require('../../examples/DynamicRowHeightExample'),
   [ExamplePages.RESIZE_EXAMPLE
     .location]: require('../../examples/ResizeExample'),
   [ExamplePages.REORDER_EXAMPLE

--- a/site/examples/examplesPageStyle.less
+++ b/site/examples/examplesPageStyle.less
@@ -341,6 +341,13 @@
   }
 }
 
+.dynamic-row-heights-example {
+  .toggle-dynamic-heights {
+    display: flex;
+    cursor: pointer;
+  }
+}
+
 html[dir="rtl"] .exampleContents {
   margin-right: @sidebar-width;
 }

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -188,7 +188,7 @@ function calculateRenderedRowRange(state, scrollAnchor) {
 
     // Handle a case where the offset puts the first row fully offscreen
     // This can happen if availableHeight & maxAvailableHeight are different
-    const { storedHeights } = state;
+    const { storedHeights } = state.getInternal();
     if (-1 * firstOffset >= storedHeights[firstViewportIdx]) {
       firstViewportIdx += 1;
       firstOffset += storedHeights[firstViewportIdx];
@@ -219,7 +219,8 @@ function calculateRenderedRowRange(state, scrollAnchor) {
  * @private
  */
 function computeRenderedRowOffsets(state, rowRange, viewportOnly) {
-  const { rowBufferSet, rowOffsetIntervalTree, storedHeights } = state;
+  const { rowBufferSet, rowOffsetIntervalTree, storedHeights } =
+    state.getInternal();
   const { endBufferIdx, endViewportIdx, firstBufferIdx, firstViewportIdx } =
     rowRange;
 

--- a/src/reducers/scrollAnchor.js
+++ b/src/reducers/scrollAnchor.js
@@ -70,7 +70,8 @@ export function getScrollAnchor(state, newProps, oldProps) {
  */
 export function scrollTo(state, scrollY) {
   const { availableHeight } = scrollbarsVisibleSelector(state);
-  const { rowOffsetIntervalTree, rowSettings, scrollContentHeight } = state;
+  const { rowSettings, scrollContentHeight } = state;
+  const { rowOffsetIntervalTree } = state.getInternal();
   const { rowsCount } = rowSettings;
 
   if (rowsCount === 0) {
@@ -133,7 +134,8 @@ export function scrollTo(state, scrollY) {
  */
 function scrollToRow(state, rowIndex) {
   const { availableHeight } = scrollbarsVisibleSelector(state);
-  const { rowOffsetIntervalTree, rowSettings, storedHeights, scrollY } = state;
+  const { rowSettings, scrollY } = state;
+  const { rowOffsetIntervalTree, storedHeights } = state.getInternal();
   const { rowsCount } = rowSettings;
 
   if (rowsCount === 0) {

--- a/src/reducers/updateRowHeight.js
+++ b/src/reducers/updateRowHeight.js
@@ -20,7 +20,8 @@
  * @return {number} The new row height
  */
 export default function updateRowHeight(state, rowIdx) {
-  const { storedHeights, rowOffsetIntervalTree, rowSettings } = state;
+  const { rowSettings } = state;
+  const { storedHeights, rowOffsetIntervalTree } = state.getInternal();
   const { rowHeightGetter, subRowHeightGetter } = rowSettings;
 
   const newHeight = rowHeightGetter(rowIdx) + subRowHeightGetter(rowIdx);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Context
<!--- Describe your changes in detail -->
Our redux store has a group of state fields known as "internal state".
These are only used within our reducers, but are **mutated** for performance. 
Fields like `storedHeights` (which stores the height for each row), `rowBufferSet`, and `rowOffsetIntervalTree` are part of the internal state.

Starting from FDT v2 onwards, we use `reduxjs/toolkit`, which in turn uses `immer`. 
With `immer`, [our reducers no longer need to worry about immutability](https://redux-toolkit.js.org/usage/immer-reducers).
 
## Problem
Internally, immer uses proxies on the entire redux store state inorder to detect mutations. 
This is slightly inefficient against large data structures (eg: an array containing 1 million elements).

Unfortunately, fields in "internal state", like `storedHeights`, are pretty big most of the time and are expensive for immer.
There's performance drops when we start modifying internal state every render, which is often the case when we scroll in a table having dynamic row heights. 

## Solution
We move out internal state out of the final redux store state, and instead expose it through a getter function `getInternal()`.
The getter function has a **closure** on "internal state", and can easily return it.
This means there's no proxies watching over the actual internal state, and hence mutating it has no overheads. 

## Additional Changes
I also added a "dynamic row heights" example where a table with 100k rows with varying heights are rendered.
Without the fix, there's performance drops while vertically scrolling across the table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in LD, and our existing examples.

## Screenshots (if appropriate):
<img width="1566" alt="image" src="https://user-images.githubusercontent.com/41563608/167790207-6144e79a-0e7b-4200-9040-45484d9a188c.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
