### PR TITLE
Add github actions to build, test, and deploy site automatically

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -1,0 +1,45 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node.
+# This workflow will be run whenever a new commit is pushed or when a PR is opened up.
+# Guide: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build and Run Tests
+
+on:
+  # run this for every push (CI)
+  push:
+  # also run this for PR
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    # run this job for every combination of given matrix variables
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+
+    # checkout our repo for the current commit
+    - name: Check out repo
+      uses: actions/checkout@v3
+
+    # setup specified node version
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
+
+    # build our library to catch any build errors
+    - name: Build!
+      run: yarn run build-dist
+
+    # run all of our tests
+    - name: Test!
+      run: yarn test

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,81 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and site, and run the deploy script.
+# The deploy script will publish the build to gh-pages.
+# This workflow will be run whenever a new release is published.
+
+# NOTE (pradeep): I'm having this workflow bail out if the release doesn't target v1.2.x. 
+# This is because we don't have a way (yet) to support multiple FDT versions/docs  be deployed at the same time,
+# and hence we choose to deploy only the most stable release.
+
+# Guide: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Deploy to gh-pages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  check-release:
+    name: Check if release is stable
+    runs-on: ubuntu-latest
+
+    # map step output to job output
+    outputs: 
+      is_stable: ${{ steps.check-release-stable.outputs.is_stable }}
+
+    steps:
+    - name: Check if release is stable
+      id: check-release-stable
+      env:
+        # Store the tag name of the release in `RELEASE_TAG` (eg: v1.0.10)
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+      # Check if the release tag name is a stable candidate for deployment
+      # NOTE (pradeep): Only allow 1.2.x versions to be deployed right now
+      run: |
+        echo "RELEASE_TAG is: " $RELEASE_TAG
+        if [[ $RELEASE_TAG =~ ^v1\.2\.[0-9]+$ ]]; 
+        then
+          echo "This is a stable release!"
+          echo "::set-output name=is_stable::true"
+        else
+          echo "This is not a stable release!"
+          echo "::set-output name=is_stable::false"
+        fi
+
+  
+  deploy:
+    name: Deploy website via gh-pages!
+    needs: check-release
+    runs-on: ubuntu-latest
+    
+    # skip deploying to gh-pages if release is not "stable"
+    if: ${{ needs.check-release.outputs.is_stable == 'true' }}
+
+    steps:
+
+    # checkout our repo for the current commit
+    - name: Check out repo
+      uses: actions/checkout@v3
+
+    # setup node version 16 which is not old but still stable
+    - name: Use Node.js 16
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
+
+    # build our static contents
+    - name: Build static site!
+      run: yarn run site-build
+
+    # publish our site to gh-pages
+    - name: Deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }} # authenticate the action to our workflow
+        publish_dir: ./__site__ # this directory will be copied over to gh-pages

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "bugs": {
     "url": "https://github.com/schrodinger/fixed-data-table-2/issues"
   },
-  "homepage": "http://schrodinger.github.io/fixed-data-table-2",
+  "homepage": "https://schrodinger.github.io/fixed-data-table-2",
   "tags": [
     "react",
     "table"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I'm adding two GitHub action workflows to automate
1. building and testing changes made to the repo
2. deploying our FDT site to gh-pages whenever a release is published (see: http://schrodinger.github.io/fixed-data-table-2/)

For more information on github actions, see [docs](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#overview.).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### Deployment
I often forget to publish our static site to gh-pages after doing a release.
I wanted a way to automate the process so I don't have to do this (and remember to do this) every time a release happens.

### CI
We had travis integrated to our repo for CI, but it stopped working for some reason **since May 25th last year** (based on our [commit history](https://github.com/schrodinger/fixed-data-table-2/commits/master)).
I only realized this some days back. 
Luckily we were always manually running `yarn run test` so our mainlines are still in a good state.
I could look into setting up / fixing travis once more, but I figured that I could do just use GitHub actions to automate testing instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the workflows in [my fork of FDT](https://github.com/pradeepnschrodinger/fixed-data-table-2/tree/pradeepnschrodinger_v1.2.x).
See the various actions being dispatched there: https://github.com/pradeepnschrodinger/fixed-data-table-2/actions

## Screenshots (taken from my fork):
### Starting logs of build-test workflow
<img width="1299" alt="Screen Shot 2022-06-13 at 11 53 52 PM" src="https://user-images.githubusercontent.com/41563608/173419695-1eb9254e-c352-4d01-8783-eff33149702c.png">

### Ending logs of build-test workflow
<img width="805" alt="Screen Shot 2022-06-13 at 11 55 01 PM" src="https://user-images.githubusercontent.com/41563608/173420066-156e8650-a483-4c44-a1f8-019174e8813e.png">

### Graph of deploy workflow
<img width="1017" alt="Screen Shot 2022-06-13 at 11 53 13 PM" src="https://user-images.githubusercontent.com/41563608/173419673-81558d16-895a-49d3-80ce-7807c7701970.png">
