### PR TITLE
Do not assign null to rowIndex (#644)

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -129,8 +129,9 @@ class FixedDataTableBufferedRows extends React.Component {
       let rowIndex = rowsToRender[i];
       // if the row doesn't exist in the buffer set, then take the previous one
       if (rowIndex === undefined) {
-        rowIndex =
-          this._staticRowArray[i] && this._staticRowArray[i].props.index;
+        rowIndex = this._staticRowArray[i]
+          ? this._staticRowArray[i].props.index
+          : undefined;
         if (rowIndex === undefined) {
           this._staticRowArray[i] = null;
           continue;


### PR DESCRIPTION
## Description
Do not assign `null` to rowIndex.

## Motivation and Context
Fixes issue #644 

## How Has This Been Tested?
There was a flaw in assigning rowIndex logic. When `this._staticRowArray[i]` is null, runing statement `rowIndex = this._staticRowArray[i] && this._staticRowArray[i].props.index;`, actually assign `null` value, but it should remain undefined.

Verified locally when scrolling up, issue does not appear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
