### PR TITLE
Add Infinite Scroll Example

### DIFF
--- a/examples/helpers/FakeObjectDataListStore.js
+++ b/examples/helpers/FakeObjectDataListStore.js
@@ -10,6 +10,15 @@ class FakeObjectDataListStore {
     this._cache = [];
   }
 
+  setSize(size) {
+    // truncate cache if necessary
+    if (this.size < size) {
+      this._cache = this._cache.slice(0, size);
+    }
+
+    this.size = size;
+  }
+
   createFakeRowObjectData(/*number*/ index) /*object*/ {
     return {
       id: index,

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -119,12 +119,19 @@ exports.ExamplePages = {
     title: 'Column Groups',
     description: 'Table with column groupings.',
   },
+  PAGINATION_EXAMPLE: {
+    location: 'example-pagination.html',
+    fileName: 'PaginationExample.js',
+    title: 'Pagination',
+    description:
+      'A table example that pages in data as the user scrolls. We fake this by having a promise that resolves after a few milliseconds',
+  },
   INFINITE_SCROLL_EXAMPLE: {
     location: 'example-infinite-scroll.html',
     fileName: 'InfiniteScrollExample.js',
     title: 'Infinite Scroll',
     description:
-      'A table example that pages in data as the user scrolls. We fake this by having a promise that resolves after a few milliseconds',
+      'A table example where we add more data as the user scrolls near the end of the table, thus simulating an Infinite Scroll.',
   },
   FILTER_EXAMPLE: {
     location: 'example-filter.html',

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -48,6 +48,8 @@ var EXAMPLE_COMPONENTS = {
     .location]: require('../../examples/FlexGrowExample'),
   [ExamplePages.COLUMN_GROUPS_EXAMPLE
     .location]: require('../../examples/ColumnGroupsExample'),
+  [ExamplePages.PAGINATION_EXAMPLE
+    .location]: require('../../examples/PaginationExample'),
   [ExamplePages.INFINITE_SCROLL_EXAMPLE
     .location]: require('../../examples/InfiniteScrollExample'),
   [ExamplePages.FILTER_EXAMPLE


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I'm adding an example that shows how Infinite Scrolling can be achieved.
The way it works is that we add more rows to the table whenever user vertically scrolls to the end of the table.

Note that we already had an example called "Infinite Scroll", but it was badly named because it doesn't do an infinite scroll.
Instead, it does pagination of data. I fixed this by renaming the example.

## Screenshots:
<img width="928" alt="image" src="https://user-images.githubusercontent.com/41563608/176616535-aad61ec7-f518-421f-a7b4-7466589a4591.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
