### PR TITLE
Decrease available width only when vertical scroll bar visible not wh…

### DIFF
--- a/src/selectors/roughHeights.js
+++ b/src/selectors/roughHeights.js
@@ -120,19 +120,16 @@ function roughHeights(
    */
   let minAvailableHeight = roughAvailableHeight;
   let maxAvailableHeight = roughAvailableHeight;
-  let minAvailableWidth = roughAvailableWidth;
+  const minAvailableWidth = roughAvailableWidth - scrollbarYWidth;
   let maxAvailableWidth = roughAvailableWidth;
   switch (scrollStateX) {
     case ScrollbarState.VISIBLE: {
       minAvailableHeight -= scrollbarXHeight;
       maxAvailableHeight -= scrollbarXHeight;
-      minAvailableWidth -= scrollbarYWidth;
-      maxAvailableWidth -= scrollbarYWidth;
       break;
     }
     case ScrollbarState.JOINT_SCROLLBARS: {
       minAvailableHeight -= scrollbarXHeight;
-      minAvailableWidth -= scrollbarYWidth;
       break;
     }
   }

--- a/src/selectors/roughHeights.js
+++ b/src/selectors/roughHeights.js
@@ -85,7 +85,8 @@ function roughHeights(
   scrollbarYWidth,
   columnSettings,
   fixedContentWidth,
-  scrollContentWidth
+  scrollContentWidth,
+  scrollContentHeight
 ) {
   const {
     cellGroupWrapperHeight,
@@ -120,7 +121,7 @@ function roughHeights(
    */
   let minAvailableHeight = roughAvailableHeight;
   let maxAvailableHeight = roughAvailableHeight;
-  const minAvailableWidth = roughAvailableWidth - scrollbarYWidth;
+  let minAvailableWidth = roughAvailableWidth;
   let maxAvailableWidth = roughAvailableWidth;
   switch (scrollStateX) {
     case ScrollbarState.VISIBLE: {
@@ -132,6 +133,16 @@ function roughHeights(
       minAvailableHeight -= scrollbarXHeight;
       break;
     }
+  }
+
+  const scrollStateY = getScrollStateY(
+    scrollFlags,
+    maxAvailableHeight,
+    scrollContentHeight
+  );
+
+  if (scrollStateY === ScrollbarState.VISIBLE) {
+    minAvailableWidth -= scrollbarYWidth;
   }
 
   return {
@@ -177,6 +188,27 @@ function getScrollStateX(
   if (minColWidth > width - scrollbarYWidth) {
     return ScrollbarState.JOINT_SCROLLBARS;
   }
+  return ScrollbarState.HIDDEN;
+}
+
+/**
+ * @param {{
+ *   overflowX: string,
+ *   showScrollbarX: boolean,
+ * }} scrollFlags
+ * @param {number} height
+ * @param {number} scrollContentHeight
+ * @return {ScrollbarState}
+ */
+function getScrollStateY(scrollFlags, height, scrollContentHeight) {
+  const { overflowY, showScrollbarY } = scrollFlags;
+
+  if (overflowY === 'hidden' || showScrollbarY === false) {
+    return ScrollbarState.HIDDEN;
+  } else if (scrollContentHeight > height) {
+    return ScrollbarState.VISIBLE;
+  }
+
   return ScrollbarState.HIDDEN;
 }
 
@@ -230,6 +262,7 @@ export default shallowEqualSelector(
     (state) => state.columnSettings,
     (state) => state.fixedContentWidth,
     (state) => state.scrollContentWidth,
+    (state) => state.scrollContentHeight,
   ],
   roughHeights
 );

--- a/src/selectors/roughHeights.js
+++ b/src/selectors/roughHeights.js
@@ -137,12 +137,21 @@ function roughHeights(
 
   const scrollStateY = getScrollStateY(
     scrollFlags,
-    maxAvailableHeight,
+    roughAvailableHeight,
+    scrollbarXHeight,
     scrollContentHeight
   );
 
-  if (scrollStateY === ScrollbarState.VISIBLE) {
-    minAvailableWidth -= scrollbarYWidth;
+  switch (scrollStateY) {
+    case ScrollbarState.VISIBLE: {
+      minAvailableWidth -= scrollbarYWidth;
+      maxAvailableWidth -= scrollbarYWidth;
+      break;
+    }
+    case ScrollbarState.JOINT_SCROLLBARS: {
+      minAvailableWidth -= scrollbarYWidth;
+      break;
+    }
   }
 
   return {
@@ -197,16 +206,26 @@ function getScrollStateX(
  *   showScrollbarX: boolean,
  * }} scrollFlags
  * @param {number} height
+ * @param {number} scrollbarXHeight
  * @param {number} scrollContentHeight
  * @return {ScrollbarState}
  */
-function getScrollStateY(scrollFlags, height, scrollContentHeight) {
+function getScrollStateY(
+  scrollFlags,
+  height,
+  scrollbarXHeight,
+  scrollContentHeight
+) {
   const { overflowY, showScrollbarY } = scrollFlags;
 
   if (overflowY === 'hidden' || showScrollbarY === false) {
     return ScrollbarState.HIDDEN;
   } else if (scrollContentHeight > height) {
     return ScrollbarState.VISIBLE;
+  }
+
+  if (scrollContentHeight > height - scrollbarXHeight) {
+    return ScrollbarState.JOINT_SCROLLBARS;
   }
 
   return ScrollbarState.HIDDEN;


### PR DESCRIPTION
## Description
There is a bug that is when horizontal scroll bar is visible we are subtracting scrollBarWidth from availableWidth and we are not subtracting it when vertical scroll bar present which is exactly opposite of what expected. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
