### PR TITLE
Fix NPE for mouse/touch handlers in StrictMode

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -508,43 +508,77 @@ class FixedDataTable extends React.Component {
     this._didScrollStop = debounceCore(this._didScrollStopSync, 200, this);
     this._onKeyDown = this._onKeyDown.bind(this);
 
-    this._wheelHandler = new ReactWheelHandler(
-      this._onScroll,
-      this._shouldHandleWheelX,
-      this._shouldHandleWheelY,
-      this.props.isRTL,
-      this.props.stopScrollDefaultHandling,
-      this.props.stopScrollPropagation
-    );
-
-    this._touchHandler = new ReactTouchHandler(
-      this._onScroll,
-      this._shouldHandleTouchX,
-      this._shouldHandleTouchY,
-      this.props.stopScrollDefaultHandling,
-      this.props.stopScrollPropagation
-    );
+    this._setupHandlers();
   }
 
   componentWillUnmount() {
-    // TODO (pradeep): Remove these and pass to our table component directly after
-    // React provides an API where event handlers can be specified to be non-passive (facebook/react#6436)
-    this._divRef &&
-      this._divRef.removeEventListener('wheel', this._wheelHandler.onWheel, {
-        passive: false,
-      });
-    this._divRef &&
-      this._divRef.removeEventListener(
-        'touchmove',
-        this._touchHandler.onTouchMove,
-        { passive: false }
-      );
-    this._wheelHandler = null;
-    this._touchHandler = null;
+    this._cleanupHandlers();
 
     // Cancel any pending debounced scroll handling and handle immediately.
     this._didScrollStop.reset();
     this._didScrollStopSync();
+  }
+
+  _setupHandlers() {
+    if (!this._wheelHandler) {
+      this._wheelHandler = new ReactWheelHandler(
+        this._onScroll,
+        this._shouldHandleWheelX,
+        this._shouldHandleWheelY,
+        this.props.isRTL,
+        this.props.stopScrollDefaultHandling,
+        this.props.stopScrollPropagation
+      );
+    }
+
+    if (!this._touchHandler) {
+      this._touchHandler = new ReactTouchHandler(
+        this._onScroll,
+        this._shouldHandleTouchX,
+        this._shouldHandleTouchY,
+        this.props.stopScrollDefaultHandling,
+        this.props.stopScrollPropagation
+      );
+    }
+
+    // TODO (pradeep): Remove these and pass to our table component directly after
+    // React provides an API where event handlers can be specified to be non-passive (facebook/react#6436)
+    if (this._divRef) {
+      this._divRef.addEventListener('wheel', this._wheelHandler.onWheel, {
+        passive: false,
+      });
+    }
+    if (this.props.touchScrollEnabled && this._divRef) {
+      this._divRef.addEventListener(
+        'touchmove',
+        this._touchHandler.onTouchMove,
+        { passive: false }
+      );
+    }
+  }
+
+  _cleanupHandlers() {
+    if (this._wheelHandler) {
+      if (this._divRef) {
+        this._divRef.removeEventListener('wheel', this._wheelHandler.onWheel, {
+          passive: false,
+        });
+      }
+      this._wheelHandler = null;
+    }
+
+    if (this._touchHandler) {
+      if (this._divRef) {
+        this._divRef.removeEventListener(
+          'touchmove',
+          this._touchHandler.onTouchMove,
+          {
+            passive: false,
+          }
+        );
+      }
+      this._touchHandler = null;
+    }
   }
 
   _shouldHandleTouchX = (/*number*/ delta) /*boolean*/ =>
@@ -646,18 +680,7 @@ class FixedDataTable extends React.Component {
   }
 
   componentDidMount() {
-    this._divRef &&
-      this._divRef.addEventListener('wheel', this._wheelHandler.onWheel, {
-        passive: false,
-      });
-    if (this.props.touchScrollEnabled) {
-      this._divRef &&
-        this._divRef.addEventListener(
-          'touchmove',
-          this._touchHandler.onTouchMove,
-          { passive: false }
-        );
-    }
+    this._setupHandlers();
     this._reportContentHeight();
     this._reportScrollBarsUpdates();
   }
@@ -1037,6 +1060,8 @@ class FixedDataTable extends React.Component {
     this._divRef = div;
     if (this.props.stopReactWheelPropagation) {
       this._wheelHandler.setRoot(div);
+    } else {
+      this._wheelHandler.setRoot(null);
     }
   };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When React's [StrictMode](https://reactjs.org/docs/strict-mode.html) is turned on, certain methods like lifecycle methods, constructors, setState methods, etc will be double invoked (in dev mode).
In fact, in future versions, it's possible that the [same instance might be mounted/"destroyed" multiple times](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state).

In StrictMode, the order of constructor/Lifecycle methods being called changes to:
```
constructor
componentDidMount
componentWillUnmount
componentDidMount
```

However, our code in FDT is written under the assumption that life cycle methods are just called once. 
So the current code only initializes the mouse/touch handlers in the constructor, and destroys them in componentWillUnmount.
This leads to the second call to componentDidMount working with invalid mouse/touch handlers, thus causing a NPE.

## Fix
The fix was to move out initialization and cleanup to separate methods, namely `_setupHandlers` and `_cleanupHandlers`.
Setting up the handlers will be done in both the `constructor` and `componentDidMount` methods.
Cleaning up will be done in just the `componentWillUnmount` method.

I've also added guard checks to ensure we won't reinitialize/cleanup more than needed.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid errors in future versions of React/StrictMode.
Fixes #656.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in local examples as well as the repo linked in #656 (https://github.com/savaparoski/not-working)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.