### PR TITLE
Expose cell visibility information to cell renderers

### DIFF
--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -87,6 +87,11 @@ class FixedDataTableCell extends React.Component {
      * If the component should render for RTL direction
      */
     isRTL: PropTypes.bool,
+
+    /**
+     * Whether this cell is visible (i.e, inside the viewport) or not.
+     */
+    isVisible: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -96,7 +101,11 @@ class FixedDataTableCell extends React.Component {
   };
 
   shouldComponentUpdate(nextProps) {
-    if (nextProps.isScrolling && this.props.rowIndex === nextProps.rowIndex) {
+    if (
+      nextProps.isScrolling &&
+      this.props.rowIndex === nextProps.rowIndex &&
+      this.props.isVisible === nextProps.isVisible
+    ) {
       return false;
     }
 
@@ -206,7 +215,14 @@ class FixedDataTableCell extends React.Component {
   };
 
   render() /*object*/ {
-    var { height, width, columnKey, isHeaderOrFooter, ...props } = this.props;
+    var {
+      height,
+      width,
+      isVisible,
+      columnKey,
+      isHeaderOrFooter,
+      ...props
+    } = this.props;
 
     var style = {
       height,
@@ -289,6 +305,7 @@ class FixedDataTableCell extends React.Component {
       columnKey,
       height,
       width,
+      isVisible,
     };
 
     if (props.rowIndex >= 0) {

--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -73,6 +73,7 @@ class FixedDataTableCellDefault extends React.Component {
     var {
       height,
       width,
+      isVisible,
       style,
       className,
       children,

--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -66,6 +66,11 @@ class FixedDataTableCellDefault extends React.Component {
      * pass the prop through at their discretion.
      */
     rowIndex: PropTypes.number,
+
+    /**
+     * Whether this cell is currently within the viewport.
+     */
+    isVisible: PropTypes.boolean,
   };
 
   render() {

--- a/src/FixedDataTableCellDefaultDeprecated.js
+++ b/src/FixedDataTableCellDefaultDeprecated.js
@@ -76,6 +76,7 @@ class FixedDataTableCellDefault extends React.Component {
     var {
       height,
       width,
+      isVisible,
       style,
       className,
       children,

--- a/src/FixedDataTableCellDefaultDeprecated.js
+++ b/src/FixedDataTableCellDefaultDeprecated.js
@@ -69,6 +69,11 @@ class FixedDataTableCellDefault extends React.Component {
      * pass the prop through at their discretion.
      */
     rowIndex: PropTypes.number,
+
+    /**
+     * Whether this cell is currently within the viewport.
+     */
+    isVisible: PropTypes.boolean,
   };
 
   render() {

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -62,6 +62,8 @@ class FixedDataTableCellGroupImpl extends React.Component {
     isHeaderOrFooter: PropTypes.bool,
 
     isRTL: PropTypes.bool,
+
+    isVisible: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -92,11 +94,10 @@ class FixedDataTableCellGroupImpl extends React.Component {
       var columnProps = columns[i].props;
       var cellTemplate = columns[i].template;
       var recyclable = columnProps.allowCellsRecycling && !isColumnReordering;
-      if (
-        !recyclable ||
-        (currentPosition - props.left <= props.width &&
-          currentPosition - props.left + columnProps.width >= 0)
-      ) {
+      const isHorizontallyVisible =
+        currentPosition - props.left <= props.width &&
+        currentPosition - props.left + columnProps.width >= 0;
+      if (!recyclable || isHorizontallyVisible) {
         var key = columnProps.columnKey || 'cell_' + i;
         cells[i] = this._renderCell(
           props.rowIndex,
@@ -106,7 +107,8 @@ class FixedDataTableCellGroupImpl extends React.Component {
           currentPosition,
           key,
           contentWidth,
-          isColumnReordering
+          isColumnReordering,
+          isHorizontallyVisible
         );
       }
       currentPosition += columnProps.width;
@@ -143,7 +145,8 @@ class FixedDataTableCellGroupImpl extends React.Component {
     /*number*/ left,
     /*string*/ key,
     /*number*/ columnGroupWidth,
-    /*boolean*/ isColumnReordering
+    /*boolean*/ isColumnReordering,
+    /*boolean*/ isHorizontallyVisible
   ) /*object*/ => {
     var cellIsResizable = columnProps.isResizable && this.props.onColumnResize;
     var onColumnResize = cellIsResizable ? this.props.onColumnResize : null;
@@ -183,6 +186,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
         columnGroupWidth={columnGroupWidth}
         pureRendering={pureRendering}
         isRTL={this.props.isRTL}
+        isVisible={this.props.isVisible && isHorizontallyVisible}
       />
     );
   };
@@ -212,12 +216,13 @@ class FixedDataTableCellGroup extends React.Component {
   };
 
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {
-    /// if offsets haven't changed for the same cell group while scrolling, then skip update
+    /// if offsets and visibility haven't changed for the same cell group while scrolling, then skip update
     return !(
       nextProps.isScrolling &&
       this.props.rowIndex === nextProps.rowIndex &&
       this.props.left === nextProps.left &&
-      this.props.offsetLeft === nextProps.offsetLeft
+      this.props.offsetLeft === nextProps.offsetLeft &&
+      this.props.isVisible === nextProps.isVisible
     );
   }
 

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -170,8 +170,12 @@ class FixedDataTableRowImpl extends React.Component {
       return true;
     }
 
-    // if row is not visible then no need to render it
-    // change in visibility is handled by the parent
+    // if row's visibility has changed, then update it
+    if (this.props.visible !== nextProps.visible) {
+      return true;
+    }
+
+    // if row is still not visible then no need to update
     if (!nextProps.visible) {
       return false;
     }
@@ -219,6 +223,7 @@ class FixedDataTableRowImpl extends React.Component {
         rowIndex={this.props.index}
         isHeaderOrFooter={this.props.isHeaderOrFooter}
         isRTL={this.props.isRTL}
+        isVisible={this.props.visible}
       />
     );
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
@@ -247,6 +252,7 @@ class FixedDataTableRowImpl extends React.Component {
         rowIndex={this.props.index}
         isHeaderOrFooter={this.props.isHeaderOrFooter}
         isRTL={this.props.isRTL}
+        isVisible={this.props.visible}
       />
     );
     var fixedRightColumnsShadow = fixedRightColumnsWidth
@@ -282,6 +288,7 @@ class FixedDataTableRowImpl extends React.Component {
         rowIndex={this.props.index}
         isHeaderOrFooter={this.props.isHeaderOrFooter}
         isRTL={this.props.isRTL}
+        isVisible={this.props.visible}
       />
     );
     var scrollableColumnsWidth = sumPropWidths(this.props.scrollableColumns);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Not all cells rendered by FDT are visible to the user.
eg: Cells for columns outside the viewport will be rendered if `allowCellsRecycling` column prop is turned off. 
Similarly, if the user has specified a positive value for `bufferRowCount`, then FDT prerenders a given count of rows before/after the viewport.

I'm adding a new cell prop `isVisible`, which can be used to figure out if the rendered cell is visible to the user.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #650, where the user wanted to run some side effects for a cell based on whether it's visible or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using our local examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
