### PR TITLE
Refactor ColumnIndex APIs in Column Virtualization

### DIFF
--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -21,10 +21,8 @@ class AutoScrollExample extends React.Component {
       horizontalScrollDelta: 0,
       verticalScrollDelta: 0,
       columns: [],
-      fixedColumnsCount: 2,
-      fixedRightColumnsCount: 2,
-      scrollableColumnsCount: 10000 - 2 - 2,
       columnGroups: [],
+      columnsCount: 10000,
     };
 
     const cellRenderer = (props) => `${props.columnKey}, ${props.rowIndex}`;
@@ -39,6 +37,8 @@ class AutoScrollExample extends React.Component {
         cell: cellRenderer,
         width: 100,
         allowCellsRecycling: true,
+        fixed: i < 2 ? true : false,
+        fixedRight: i >= 10000 - 4 ? true : false,
       };
       this.state.columnGroups[columnGroupIndex] = {
         columnKey: 'Column Group ' + columnGroupIndex,
@@ -120,18 +120,8 @@ class AutoScrollExample extends React.Component {
         scrollTop={scrollTop}
         onVerticalScroll={this.onVerticalScroll}
         onHorizontalScroll={this.onHorizontalScroll}
-        scrollableColumnsCount={this.state.scrollableColumnsCount}
-        getScrollableColumn={(i) =>
-          this.state.columns[this.state.fixedColumnsCount + i]
-        }
-        getFixedColumn={(i) => this.state.columns[i]}
-        fixedColumnsCount={this.state.fixedColumnsCount}
-        fixedRightColumnsCount={this.state.fixedRightColumnsCount}
-        getFixedRightColumn={(i) =>
-          this.state.columns[
-            this.state.fixedColumnsCount + this.state.scrollableColumnsCount + i
-          ]
-        }
+        columnsCount={this.state.columnsCount}
+        getColumn={(i) => this.state.columns[i]}
         getColumnGroup={(i) => this.state.columnGroups[i]}
         {...this.props}
       />

--- a/src/api/apiMethods.js
+++ b/src/api/apiMethods.js
@@ -85,17 +85,16 @@ const getApiMethodsSelector = () =>
 
         if (columnIndex >= 0 && columnIndex < fixedColumnsCount) {
           return CellGroupType.FIXED;
-        } else if (
+        }
+
+        if (
           columnIndex >= fixedColumnsCount &&
           columnIndex < fixedColumnsCount + scrollableColumnsCount
         ) {
           return CellGroupType.SCROLLABLE;
-        } else if (
-          columnIndex >= fixedColumnsCount + scrollableColumnsCount &&
-          columnIndex < columnSettings.columnsCount
-        ) {
-          return CellGroupType.FIXED_RIGHT;
         }
+
+        return CellGroupType.FIXED_RIGHT;
       };
 
       const _getCellGroupTypeFromColumnGroupIndex = (columnGroupIndex) => {
@@ -125,17 +124,16 @@ const getApiMethodsSelector = () =>
           columnGroupIndex <= lastFixedColumGroupIndex
         ) {
           return CellGroupType.FIXED;
-        } else if (
+        }
+
+        if (
           columnGroupIndex > lastFixedColumGroupIndex &&
           columnGroupIndex <= lastScrollableColumnGroupIndex
         ) {
           return CellGroupType.SCROLLABLE;
-        } else if (
-          columnGroupIndex > lastScrollableColumnGroupIndex &&
-          columnGroupIndex <= lastFixedRightColumnGroupIndex
-        ) {
-          return CellGroupType.FIXED_RIGHT;
         }
+
+        return CellGroupType.FIXED_RIGHT;
       };
 
       const _getColumnLocalIndex = (columnIndex, cellGroupType) => {

--- a/src/api/apiMethods.js
+++ b/src/api/apiMethods.js
@@ -73,6 +73,16 @@ const getApiMethodsSelector = () =>
       } = columnCounts(state);
 
       const _getCellGroupTypeFromColumnIndex = (columnIndex) => {
+        if (
+          columnIndex < 0 ||
+          columnIndex >= columnSettings.columnsCount ||
+          !Number.isInteger(columnIndex)
+        ) {
+          throw `columnIndex must be an integer between 0 and ${
+            columnSettings.columnsCount - 1
+          } inclusive`;
+        }
+
         if (columnIndex >= 0 && columnIndex < fixedColumnsCount) {
           return CellGroupType.FIXED;
         } else if (
@@ -101,6 +111,14 @@ const getApiMethodsSelector = () =>
           fixedRightColumnsCount - 1,
           CellGroupType.FIXED_RIGHT
         ).props.columnGroupIndex;
+
+        if (
+          columnGroupIndex < 0 ||
+          columnGroupIndex > lastFixedRightColumnGroupIndex ||
+          !Number.isInteger(columnGroupIndex)
+        ) {
+          throw `columnGroupIndex must be an integer between 0 and ${lastFixedRightColumnGroupIndex} inclusive`;
+        }
 
         if (
           columnGroupIndex >= 0 &&

--- a/src/api/apiMethods.js
+++ b/src/api/apiMethods.js
@@ -57,21 +57,82 @@ const getApiMethodsSelector = () =>
         fixedRightColumns,
         fixedRightColumnGroups,
         scrollableColOffsetIntervalTree,
+        fixedColumnsCount,
         fixedColumnOffsets,
         fixedColumnGroupOffsets,
+        fixedRightColumnsCount,
         fixedRightColumnOffsets,
         fixedRightColumnGroupOffsets,
+        scrollableColumnsCount,
         storedScrollableColumns,
         storedScrollableColumnGroups,
       } = state;
 
-      const getColumnOffset = (index, cellGroupType) => {
+      const _getCellGroupTypeFromColumnIndex = (columnIndex) => {
+        if (columnIndex >= 0 && columnIndex < fixedColumnsCount) {
+          return CellGroupType.FIXED;
+        } else if (
+          columnIndex >= fixedColumnsCount &&
+          columnIndex < fixedColumnsCount + scrollableColumnsCount
+        ) {
+          return CellGroupType.SCROLLABLE;
+        } else if (
+          columnIndex >= fixedColumnsCount + scrollableColumnsCount &&
+          columnIndex < columnSettings.columnsCount
+        ) {
+          return CellGroupType.FIXED_RIGHT;
+        }
+      };
+
+      const _getCellGroupTypeFromColumnGroupIndex = (columnGroupIndex) => {
+        const lastFixedColumGroupIndex = _getColumn(
+          fixedColumnsCount - 1,
+          CellGroupType.FIXED
+        ).props.columnGroupIndex;
+        const lastScrollableColumnGroupIndex = _getColumn(
+          scrollableColumnsCount - 1,
+          CellGroupType.SCROLLABLE
+        ).props.columnGroupIndex;
+        const lastFixedRightColumnGroupIndex = _getColumn(
+          fixedRightColumnsCount - 1,
+          CellGroupType.FIXED_RIGHT
+        ).props.columnGroupIndex;
+
+        if (
+          columnGroupIndex >= 0 &&
+          columnGroupIndex <= lastFixedColumGroupIndex
+        ) {
+          return CellGroupType.FIXED;
+        } else if (
+          columnGroupIndex > lastFixedColumGroupIndex &&
+          columnGroupIndex <= lastScrollableColumnGroupIndex
+        ) {
+          return CellGroupType.SCROLLABLE;
+        } else if (
+          columnGroupIndex > lastScrollableColumnGroupIndex &&
+          columnGroupIndex <= lastFixedRightColumnGroupIndex
+        ) {
+          return CellGroupType.FIXED_RIGHT;
+        }
+      };
+
+      const _getColumnLocalIndex = (columnIndex, cellGroupType) => {
         if (cellGroupType === CellGroupType.FIXED) {
-          fixedColumnOffsets[index];
+          return columnIndex;
+        } else if (cellGroupType === CellGroupType.SCROLLABLE) {
+          return columnIndex - fixedColumnsCount;
         } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
-          fixedRightColumnOffsets[index];
+          return columnIndex - fixedColumnsCount - scrollableColumnsCount;
+        }
+      };
+
+      const _getColumnOffset = (localColumnIndex, cellGroupType) => {
+        if (cellGroupType === CellGroupType.FIXED) {
+          return fixedColumnOffsets[localColumnIndex];
+        } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
+          return fixedRightColumnOffsets[localColumnIndex];
         } else {
-          return scrollableColOffsetIntervalTree.sumTo(index);
+          return scrollableColOffsetIntervalTree.sumTo(localColumnIndex);
         }
       };
 
@@ -80,31 +141,28 @@ const getApiMethodsSelector = () =>
           return fixedColumnsWidth;
         } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
           return fixedRightColumnsWidth;
-        } else {
+        } else if (cellGroupType === CellGroupType.SCROLLABLE) {
           return scrollContentWidth;
         }
       };
 
-      const _getColumn = (
-        columnIndex,
-        cellGroupType = CellGroupType.SCROLLABLE
-      ) => {
+      const _getColumn = (localColumnIndex, cellGroupType) => {
         if (cellGroupType === CellGroupType.FIXED) {
-          return fixedColumns[columnIndex];
+          return fixedColumns[localColumnIndex];
         } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
-          return fixedRightColumns[columnIndex];
-        } else {
-          return _getScrollableColumn(columnIndex);
+          return fixedRightColumns[localColumnIndex];
+        } else if (cellGroupType === CellGroupType.SCROLLABLE) {
+          return _getScrollableColumn(localColumnIndex);
         }
       };
 
-      const _getScrollableColumn = (columnIndex) => {
-        let column = storedScrollableColumns.object[columnIndex];
+      const _getScrollableColumn = (localColumnIndex) => {
+        let column = storedScrollableColumns.object[localColumnIndex];
 
         // if no column exists in the cache, then fetch the column from the user
         if (!column) {
           column = convertColumnElementsToData(
-            columnSettings.getScrollableColumn(columnIndex)
+            columnSettings.getColumn(localColumnIndex + fixedColumnsCount)
           );
 
           // we don't store the column to the cache because our functions should be pure
@@ -122,14 +180,14 @@ const getApiMethodsSelector = () =>
         // if no column group exists in the cache, then fetch the column group from the user
         if (!columnGroup) {
           columnGroup = convertColumnElementsToData(
-            columnSettings.getScrollableColumnGroup(columnGroupIndex)
+            columnSettings.getColumnGroup(columnGroupIndex)
           );
 
           // we also need to figure out the children of the column group to accurately determine the start and end child indexes, as well as the supposed total width of the column group
           let firstChildIndex;
           let lastChildIndex;
           // NOTE (pradeep): This runs at O(N). Consider another approach, like a binary search to atleast make this run at O(log N).
-          for (let i = 0; i < columnSettings.scrollableColumnsCount; i++) {
+          for (let i = 0; i < scrollableColumnsCount; i++) {
             const column = _getScrollableColumn(i);
             if (column.props.columnGroupIndex === columnGroupIndex) {
               firstChildIndex = _.min([i, firstChildIndex]);
@@ -153,39 +211,63 @@ const getApiMethodsSelector = () =>
         return columnGroup;
       };
 
-      const getColumn = (
-        columnIndex,
-        cellGroupType = CellGroupType.SCROLLABLE
-      ) => {
-        const column = _getColumn(columnIndex, cellGroupType);
-        const offset = getColumnOffset(columnIndex, cellGroupType);
+      const getColumn = (columnIndex) => {
+        const cellGroupType = _getCellGroupTypeFromColumnIndex(columnIndex);
+        const localColumnIndex = _getColumnLocalIndex(
+          columnIndex,
+          cellGroupType
+        );
+        const column = _getColumn(localColumnIndex, cellGroupType);
+        const offset = _getColumnOffset(localColumnIndex, cellGroupType);
         return _getMinimalColumn(column, offset);
       };
 
-      const getColumnCount = (cellGroupType = CellGroupType.SCROLLABLE) => {
+      const getColumnCount = (cellGroupType = null) => {
         if (cellGroupType === CellGroupType.FIXED) {
-          return columnSettings.fixedColumnsCount;
+          return fixedColumnsCount;
         } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
-          return columnSettings.fixedRightColumnsCount;
+          return fixedRightColumnsCount;
+        } else if (cellGroupType == CellGroupType.SCROLLABLE) {
+          return scrollableColumnsCount;
         } else {
-          return columnSettings.scrollableColumnsCount;
+          return columnSettings.columnsCount;
         }
       };
 
-      const getColumnGroupCount = (
-        cellGroupType = CellGroupType.SCROLLABLE
-      ) => {
+      const _getScrollableColumnGroupsCount = () => {
+        if (scrollableColumnsCount === 0) {
+          return 0;
+        }
+        const lastScrollableColumn = _getScrollableColumn(
+          scrollableColumnsCount - 1
+        );
+        const firstScrollableColumn = _getScrollableColumn(0);
+
+        return (
+          lastScrollableColumn.props.columnGroupIndex -
+          firstScrollableColumn.props.columnGroupIndex +
+          1
+        );
+      };
+
+      const getColumnGroupCount = (cellGroupType = null) => {
         if (cellGroupType === CellGroupType.FIXED) {
           return fixedColumnGroups.length;
-        } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
-          return fixedRightColumnGroups.length;
-        } else {
-          // the parent column group of the last scrollable column will also be the last scrollable column group
-          const lastColumn = _getScrollableColumn(
-            columnSettings.scrollableColumnsCount - 1
-          );
-          return lastColumn.props.columnGroupIndex + 1;
         }
+        if (cellGroupType === CellGroupType.FIXED_RIGHT) {
+          return fixedRightColumnGroups.length;
+        }
+        const scrollableColumnGroupsCount = _getScrollableColumnGroupsCount();
+        if (cellGroupType === CellGroupType.SCROLLABLE) {
+          return scrollableColumnGroupsCount;
+        }
+
+        // if cellGroupType is not given return total column groups.
+        return (
+          scrollableColumnGroupsCount +
+          fixedColumnGroups.length +
+          fixedRightColumnGroups.length
+        );
       };
 
       const _getScrollableColumnGroupOffset = (columnGroup) => {
@@ -195,10 +277,7 @@ const getApiMethodsSelector = () =>
         );
       };
 
-      const getColumnGroup = (
-        columnGroupIndex,
-        cellGroupType = CellGroupType.SCROLLABLE
-      ) => {
+      const _getColumnGroup = (columnGroupIndex, cellGroupType) => {
         let columnGroup;
         let offset = 0;
 
@@ -206,8 +285,12 @@ const getApiMethodsSelector = () =>
           columnGroup = fixedColumnGroups[columnGroupIndex];
           offset = fixedColumnGroupOffsets[columnGroupIndex];
         } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
-          columnGroup = fixedRightColumnGroups[columnGroupIndex];
-          offset = fixedRightColumnGroupOffsets[columnGroupIndex];
+          const localColumnGroupIndex =
+            columnGroupIndex -
+            getColumnGroupCount(CellGroupType.FIXED) -
+            getColumnGroupCount(CellGroupType.SCROLLABLE);
+          columnGroup = fixedRightColumnGroups[localColumnGroupIndex];
+          offset = fixedRightColumnGroupOffsets[localColumnGroupIndex];
         } else {
           columnGroup = _getScrollableColumnGroup(columnGroupIndex);
           offset = _getScrollableColumnGroupOffset(columnGroup);
@@ -216,13 +299,21 @@ const getApiMethodsSelector = () =>
         return _getMinimalColumnGroup(columnGroup, offset);
       };
 
-      const getColumnGroupByChild = (
-        columnIndex,
-        cellGroupType = CellGroupType.SCROLLABLE
-      ) => {
-        const column = _getColumn(columnIndex, cellGroupType);
+      const getColumnGroup = (columnGroupIndex) => {
+        const cellGroupType =
+          _getCellGroupTypeFromColumnGroupIndex(columnGroupIndex);
+        return _getColumnGroup(columnGroupIndex, cellGroupType);
+      };
+
+      const getColumnGroupByChild = (columnIndex) => {
+        const cellGroupType = _getCellGroupTypeFromColumnIndex(columnIndex);
+        const localColumnIndex = _getColumnLocalIndex(
+          columnIndex,
+          cellGroupType
+        );
+        const column = _getColumn(localColumnIndex, cellGroupType);
         const columnGroupIndex = column.props.columnGroupIndex;
-        return getColumnGroup(columnGroupIndex, cellGroupType);
+        return _getColumnGroup(columnGroupIndex, cellGroupType);
       };
 
       const _getElementAtOffset = (container, offset) => {
@@ -252,33 +343,52 @@ const getApiMethodsSelector = () =>
         };
       };
 
-      const getColumnAtOffset = (
+      const _getColumnAtOffset = (
         offset,
         cellGroupType = CellGroupType.SCROLLABLE
       ) => {
         let column, columnOffset;
         if (cellGroupType === CellGroupType.FIXED) {
           const { element } = _getElementAtOffset(fixedColumns, offset);
-          columnOffset = fixedColumnOffsets[element.props.index];
+          columnOffset =
+            fixedColumnOffsets[
+              _getColumnLocalIndex(element.props.index, CellGroupType.FIXED)
+            ];
           column = element;
         } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
           const { element } = _getElementAtOffset(fixedRightColumns, offset);
-          columnOffset = fixedRightColumnOffsets[element.props.index];
+          columnOffset =
+            fixedRightColumnOffsets[
+              _getColumnLocalIndex(
+                element.props.index,
+                CellGroupType.FIXED_RIGHT
+              )
+            ];
           column = element;
         } else {
-          let index =
-            scrollableColOffsetIntervalTree.greatestLowerBound(offset);
-          index = _.clamp(index, 0, columnSettings.scrollableColumnsCount - 1);
-          column = _getScrollableColumn(index);
-          columnOffset = scrollableColOffsetIntervalTree.sumUntil(index);
+          const localIndex = _.clamp(
+            scrollableColOffsetIntervalTree.greatestLowerBound(offset),
+            0,
+            scrollableColumnsCount - 1
+          );
+          column = _getScrollableColumn(localIndex);
+          columnOffset = scrollableColOffsetIntervalTree.sumUntil(localIndex);
         }
+        return { column, columnOffset };
+      };
 
-        if (column) {
-          column = _getMinimalColumn(column, columnOffset);
-        }
-
+      const getColumnAtOffset = (
+        offset,
+        cellGroupType = CellGroupType.SCROLLABLE
+      ) => {
+        const { column, columnOffset } = _getColumnAtOffset(
+          offset,
+          cellGroupType
+        );
         return {
-          column,
+          column: _.isNil(column)
+            ? column
+            : _getMinimalColumn(column, columnOffset),
           distanceFromOffset: offset - columnOffset,
         };
       };
@@ -287,35 +397,17 @@ const getApiMethodsSelector = () =>
         offset,
         cellGroupType = CellGroupType.SCROLLABLE
       ) => {
-        let columnGroup, distanceFromOffset, columnGroupOffset;
-        if (cellGroupType === CellGroupType.FIXED) {
-          const { element } = _getElementAtOffset(fixedColumns, offset);
-          columnGroupOffset = fixedColumnOffsets[element.props.index];
-          columnGroup = element;
-        } else if (cellGroupType === CellGroupType.FIXED_RIGHT) {
-          const { element } = _getElementAtOffset(fixedRightColumns, offset);
-          columnGroupOffset = fixedRightColumnOffsets[element.props.index];
-          columnGroup = element;
-        } else {
-          // figure out the column at given offset
-          let columnIndex =
-            scrollableColOffsetIntervalTree.greatestLowerBound(offset);
-          columnIndex = _.clamp(
-            columnIndex,
-            0,
-            columnSettings.scrollableColumnsCount - 1
-          );
-          const column = _getScrollableColumn(columnIndex);
-
-          // get the parent column group of the column
-          const { columnGroupIndex } = column.props;
-          columnGroup = _getScrollableColumnGroup(columnGroupIndex);
-          columnGroupOffset = _getScrollableColumnGroupOffset(columnGroup);
+        const { column } = _getColumnAtOffset(offset, cellGroupType);
+        if (_.isNil(column)) {
+          return { columnGroup: null, distanceFromOffset: null };
         }
-
+        const columnGroup = _getColumnGroup(
+          column.props.columnGroupIndex,
+          cellGroupType
+        );
         return {
-          columnGroup: _getMinimalColumnGroup(columnGroup, columnGroupOffset),
-          distanceFromOffset: offset - columnGroupOffset,
+          columnGroup,
+          distanceFromOffset: offset - columnGroup.offset,
         };
       };
 

--- a/src/api/apiMethods.js
+++ b/src/api/apiMethods.js
@@ -10,6 +10,7 @@
 import _ from 'lodash';
 import convertColumnElementsToData from '../helper/convertColumnElementsToData';
 import shallowEqualSelector from '../helper/shallowEqualSelector';
+import columnCounts from '../selectors/columnCounts';
 import { CellGroupType } from '../enums/CellGroup';
 
 /**
@@ -57,16 +58,19 @@ const getApiMethodsSelector = () =>
         fixedRightColumns,
         fixedRightColumnGroups,
         scrollableColOffsetIntervalTree,
-        fixedColumnsCount,
         fixedColumnOffsets,
         fixedColumnGroupOffsets,
-        fixedRightColumnsCount,
         fixedRightColumnOffsets,
         fixedRightColumnGroupOffsets,
-        scrollableColumnsCount,
         storedScrollableColumns,
         storedScrollableColumnGroups,
       } = state;
+
+      const {
+        fixedColumnsCount,
+        fixedRightColumnsCount,
+        scrollableColumnsCount,
+      } = columnCounts(state);
 
       const _getCellGroupTypeFromColumnIndex = (columnIndex) => {
         if (columnIndex >= 0 && columnIndex < fixedColumnsCount) {

--- a/src/helper/convertColumnElementsToData.js
+++ b/src/helper/convertColumnElementsToData.js
@@ -12,9 +12,6 @@
 'use strict';
 
 import React from 'react';
-import forEach from 'lodash/forEach';
-import invariant from '../stubs/invariant';
-import map from 'lodash/map';
 import pick from 'lodash/pick';
 
 export function extractProps(columnProps) {

--- a/src/reducers/columnAnchor.js
+++ b/src/reducers/columnAnchor.js
@@ -15,6 +15,7 @@ import clamp from '../vendor_upstream/core/clamp';
 
 import scrollbarsVisibleSelector from '../selectors/scrollbarsVisible';
 import { getScrollableColumnWidth } from './updateScrollableColumn';
+import columnCounts from '../selectors/columnCounts';
 
 /**
  * Get the anchor for scrolling.
@@ -70,11 +71,9 @@ export function getColumnAnchor(state, newProps, oldProps) {
  */
 export function scrollToX(state, scrollX) {
   const { availableWidth } = scrollbarsVisibleSelector(state);
-  const {
-    scrollableColOffsetIntervalTree,
-    scrollableColumnsCount,
-    scrollContentWidth,
-  } = state;
+  const { scrollableColOffsetIntervalTree, scrollContentWidth } = state;
+
+  const { scrollableColumnsCount } = columnCounts(state);
 
   if (scrollableColumnsCount === 0) {
     return {
@@ -138,13 +137,9 @@ export function scrollToX(state, scrollX) {
  */
 function scrollToColX(state, colIndex) {
   const { availableWidth } = scrollbarsVisibleSelector(state);
-  const {
-    scrollableColOffsetIntervalTree,
-    fixedColumnsCount,
-    scrollableColumnsCount,
-    storedWidths,
-    scrollX,
-  } = state;
+  const { scrollableColOffsetIntervalTree, storedWidths, scrollX } = state;
+
+  const { fixedColumnsCount, scrollableColumnsCount } = columnCounts(state);
 
   if (scrollableColumnsCount === 0) {
     return {

--- a/src/reducers/columnAnchor.js
+++ b/src/reducers/columnAnchor.js
@@ -72,10 +72,9 @@ export function scrollToX(state, scrollX) {
   const { availableWidth } = scrollbarsVisibleSelector(state);
   const {
     scrollableColOffsetIntervalTree,
-    columnSettings,
+    scrollableColumnsCount,
     scrollContentWidth,
   } = state;
-  const { scrollableColumnsCount } = columnSettings;
 
   if (scrollableColumnsCount === 0) {
     return {
@@ -141,11 +140,11 @@ function scrollToColX(state, colIndex) {
   const { availableWidth } = scrollbarsVisibleSelector(state);
   const {
     scrollableColOffsetIntervalTree,
-    columnSettings,
+    fixedColumnsCount,
+    scrollableColumnsCount,
     storedWidths,
     scrollX,
   } = state;
-  const { scrollableColumnsCount, fixedColumnsCount } = columnSettings;
 
   if (scrollableColumnsCount === 0) {
     return {

--- a/src/reducers/computeRenderedCols.js
+++ b/src/reducers/computeRenderedCols.js
@@ -22,6 +22,7 @@ import {
   getScrollableColumnWidth,
 } from './updateScrollableColumn';
 import convertColumnElementsToData from '../helper/convertColumnElementsToData';
+import columnCounts from '../selectors/columnCounts';
 
 /**
  * Returns data about the columns to render
@@ -41,7 +42,8 @@ import convertColumnElementsToData from '../helper/convertColumnElementsToData';
 export default function computeRenderedCols(state, scrollAnchor) {
   let colRange = calculateRenderedColRange(state, scrollAnchor);
 
-  const { scrollableColumnsCount, scrollContentWidth } = state;
+  const { scrollContentWidth } = state;
+  const { scrollableColumnsCount } = columnCounts(state);
   const { availableScrollWidth } = tableHeightsSelector(state);
 
   const {
@@ -289,7 +291,7 @@ function computeRenderedColumnGroups(state) {
 function calculateRenderedColRange(state, scrollAnchor) {
   const { bufferColCount, maxAvailableWidth } = roughHeightsSelector(state);
 
-  const scrollableColumnsCount = state.scrollableColumnsCount;
+  const { scrollableColumnsCount } = columnCounts(state);
 
   if (scrollableColumnsCount === 0) {
     return {
@@ -488,9 +490,10 @@ function getVirtualizedColumns(state) {
     state.cachedColumnsToRender.array,
     state.columnsToRender
   );
+  const { scrollableColumnsCount } = columnCounts(state);
   const scrollableColumns = {};
   for (let colIdx of cachedColumnsToRender) {
-    if (colIdx < state.scrollableColumnsCount) {
+    if (colIdx < scrollableColumnsCount) {
       scrollableColumns[colIdx] = getScrollableColumn(state, colIdx);
     }
   }

--- a/src/reducers/flexColumnWidths.js
+++ b/src/reducers/flexColumnWidths.js
@@ -35,10 +35,7 @@ export function initializeFlexColumnWidths(state) {
 
   // iterate scrollable columns until they fill up the available space
   let idx = 0;
-  while (
-    availableWidth > 0 &&
-    idx < state.columnSettings.scrollableColumnsCount
-  ) {
+  while (availableWidth > 0 && idx < state.scrollableColumnsCount) {
     const column = getScrollableColumn(state, idx);
     availableWidth -= column.props.width;
     flexTotal += column.props.flexGrow;
@@ -46,10 +43,7 @@ export function initializeFlexColumnWidths(state) {
   }
 
   // check if there's free space left to fill up flex widths
-  if (
-    availableWidth <= 0 &&
-    idx < state.columnSettings.scrollableColumnsCount
-  ) {
+  if (availableWidth <= 0 && idx < state.scrollableColumnsCount) {
     return;
   }
 

--- a/src/reducers/flexColumnWidths.js
+++ b/src/reducers/flexColumnWidths.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+import columnCounts from '../selectors/columnCounts';
 import scrollbarsVisibleSelector from '../selectors/scrollbarsVisible';
 import {
   getScrollableColumn,
@@ -25,6 +26,7 @@ export function initializeFlexColumnWidths(state) {
   const { scrollEnabledY } = scrollbarsVisibleSelector(state);
   const tableWidth = state.tableSize.width;
   const scrollbarSpace = scrollEnabledY ? state.scrollbarYWidth : 0;
+  const { scrollableColumnsCount } = columnCounts(state);
   let availableWidth = tableWidth - scrollbarSpace - state.fixedContentWidth;
 
   let flexTotal = 0;
@@ -35,7 +37,7 @@ export function initializeFlexColumnWidths(state) {
 
   // iterate scrollable columns until they fill up the available space
   let idx = 0;
-  while (availableWidth > 0 && idx < state.scrollableColumnsCount) {
+  while (availableWidth > 0 && idx < scrollableColumnsCount) {
     const column = getScrollableColumn(state, idx);
     availableWidth -= column.props.width;
     flexTotal += column.props.flexGrow;
@@ -43,7 +45,7 @@ export function initializeFlexColumnWidths(state) {
   }
 
   // check if there's free space left to fill up flex widths
-  if (availableWidth <= 0 && idx < state.scrollableColumnsCount) {
+  if (availableWidth <= 0 && idx < scrollableColumnsCount) {
     return;
   }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -307,9 +307,8 @@ function initializeFixedColumnWidthsAndOffsets(state) {
     }
     columnData.props.index = idx;
     fixedRightColumnsWidth += columnData.props.width;
-    fixedRightColumns.push(columnData);
+    fixedRightColumns.unshift(columnData);
   }
-  fixedRightColumns.reverse();
 
   const fixedContentWidth = fixedRightColumnsWidth + fixedColumnsWidth;
 

--- a/src/reducers/updateScrollableColumn.js
+++ b/src/reducers/updateScrollableColumn.js
@@ -27,16 +27,19 @@ export function getScrollableColumn(state, localColIdx) {
     return state.storedScrollableColumns.object[localColIdx];
   }
 
+  // index of the column in relation to the whole table.
+  const colIdx = localColIdx + state.fixedColumnsCount;
+
   // if column doesn't exist in cache, then get the column from the user
-  const columnProps = state.columnSettings.getScrollableColumn(localColIdx);
+  const columnProps = state.columnSettings.getColumn(colIdx);
   const column = convertColumnElementsToData(columnProps);
-  column.props.index = localColIdx;
+  column.props.index = colIdx;
 
   // update column groups associated with the current column
   const { columnGroupIndex } = column.props;
   if (!_.isNil(columnGroupIndex)) {
     const columnGroupProps =
-      state.columnSettings.getScrollableColumnGroup(columnGroupIndex);
+      state.columnSettings.getColumnGroup(columnGroupIndex);
     const columnGroup = convertColumnElementsToData(columnGroupProps);
     const storedColumnGroup =
       state.storedScrollableColumnGroups.object[columnGroupIndex];

--- a/src/reducers/updateScrollableColumn.js
+++ b/src/reducers/updateScrollableColumn.js
@@ -28,7 +28,7 @@ export function getScrollableColumn(state, localColIdx) {
   }
 
   // index of the column in relation to the whole table.
-  const colIdx = localColIdx + state.fixedColumnsCount;
+  const colIdx = localColIdx + state.fixedColumns.length;
 
   // if column doesn't exist in cache, then get the column from the user
   const columnProps = state.columnSettings.getColumn(colIdx);

--- a/src/selectors/columnCounts.js
+++ b/src/selectors/columnCounts.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule columnsCount
+ */
+
+'use strict';
+
+/**
+ * @param {Object} state
+ * @returns {Number}
+ */
+export default function columnCounts(state) {
+  const { columnSettings, fixedColumns, fixedRightColumns } = state;
+  return {
+    fixedColumnsCount: fixedColumns.length,
+    fixedRightColumnsCount: fixedRightColumns.length,
+    scrollableColumnsCount:
+      columnSettings.columnsCount -
+      fixedColumns.length -
+      fixedRightColumns.length,
+  };
+}


### PR DESCRIPTION
## Description
JIRA: https://jira.schrodinger.com/browse/SS-39836
Arch Doc:  https://docs.google.com/document/d/1dfiyC5oW4Jrpc7WNqqhipxIRplH9FRQUqh6-MP7faAI/edit?usp=sharing

Summary
1. Made column Index global to table instead of cell group, and modify context api accordingly.
2. Simplify column virtualisation api, o that it require only one getter function instead of 3 separate getter function for each cell group type.
3.  Rename some file and variable name to make them more specific and less confusing, see https://github.com/schrodinger/fixed-data-table-2/commit/54fb5ba5101c5fa18f757a19e5ac450edb6c6754. (This branch is cut from column-virtualization-renaming so it won't show those changes)

## ToDo -:
Test and fix plugins to work after this change. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
