### PR TITLE
Flush scroll updates when Scrollbar thumb is dragged

### DIFF
--- a/src/plugins/Scrollbar.js
+++ b/src/plugins/Scrollbar.js
@@ -434,7 +434,8 @@ class Scrollbar extends React.PureComponent {
      *
      * (Read more on automatic batching by React here: https://github.com/reactwg/react-18/discussions/21)
      */
-    ReactDOM.flushSync(() =>
+    const flushSync = ReactDOM.flushSync || ((fn) => fn()); // ReactDOM.flushSync doesn't exist in older versions of React
+    flushSync(() =>
       this._setNextState(
         this._calculateState(
           this.state.position + delta,

--- a/src/plugins/Scrollbar.js
+++ b/src/plugins/Scrollbar.js
@@ -419,12 +419,29 @@ class Scrollbar extends React.PureComponent {
       : deltaY;
     delta /= this.state.scale;
 
-    this._setNextState(
-      this._calculateState(
-        this.state.position + delta,
-        props.size,
-        props.contentSize,
-        props.orientation
+    /**
+     * NOTE (pradeep): Starting from React 18, React batches multiple state updates together for improving performance.
+     *
+     * While this is generally good, the legacy code here (for whatever reason) expects state updates to be
+     * unbatched.
+     * This leads to https://github.com/schrodinger/fixed-data-table-2/issues/668, where the scrollbar doesn't
+     * move as fast as the user's cursor when they drag the scrollbar thumb.
+     * This causes the cursor and the scrollbar to go out of sync, which is a bit frustrating.
+     *
+     * I'm fixing this by using ReactDOM's flushSync API to make sure that the state update is flushed immediately.
+     *
+     * TODO (pradeep): While the fix works, we should really be relying on automatic batching for performance.
+     *
+     * (Read more on automatic batching by React here: https://github.com/reactwg/react-18/discussions/21)
+     */
+    ReactDOM.flushSync(() =>
+      this._setNextState(
+        this._calculateState(
+          this.state.position + delta,
+          props.size,
+          props.contentSize,
+          props.orientation
+        )
       )
     );
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Starting from React 18, React [batches multiple state updates](https://github.com/reactwg/react-18/discussions/21) together for improving performance; and this is done automatically by React when the `createRoot` API is used.

While this is generally good, the custom scrollbar legacy code here (for whatever reason) expects state updates to be unbatched...
This leads to #668, where the scrollbar doesn't move as fast as the user's cursor when they drag the scrollbar thumb.
This causes the cursor and the scrollbar to go out of sync, which is a bit frustrating to the user.

I'm temporarily fixing this by using ReactDOM's flushSync API to make sure that the state update is flushed immediately.

*I wanna note that while the fix works, we should really be relying on automatic batching for performance.*

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #668 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our local examples with React versions `15.3.0` (the oldest supported version in FDT), `16.13.1` (the ones dev use), and `18.2.0` (the current latest).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.