### PR TITLE
Polyfill `globalThis`

### DIFF
--- a/src/vendor_upstream/core/cancelAnimationFramePolyfill.js
+++ b/src/vendor_upstream/core/cancelAnimationFramePolyfill.js
@@ -9,16 +9,18 @@
  * @providesModule cancelAnimationFramePolyfill
  */
 
+import globalThis from './globalThisPolyfill';
+
 /**
  * Here is the native and polyfill version of cancelAnimationFrame.
  * Please don't use it directly and use cancelAnimationFrame module instead.
  */
-var cancelAnimationFrame =
-  global.cancelAnimationFrame ||
-  global.webkitCancelAnimationFrame ||
-  global.mozCancelAnimationFrame ||
-  global.oCancelAnimationFrame ||
-  global.msCancelAnimationFrame ||
-  global.clearTimeout;
+const cancelAnimationFrame =
+  globalThis.cancelAnimationFrame ||
+  globalThis.webkitCancelAnimationFrame ||
+  globalThis.mozCancelAnimationFrame ||
+  globalThis.oCancelAnimationFrame ||
+  globalThis.msCancelAnimationFrame ||
+  globalThis.clearTimeout;
 
 export default cancelAnimationFrame;

--- a/src/vendor_upstream/core/globalThisPolyfill.js
+++ b/src/vendor_upstream/core/globalThisPolyfill.js
@@ -9,7 +9,7 @@
  * @providesModule globalThisPolyfill
  */
 
-const globalThis =
+const globalThisPolyfill =
   typeof globalThis !== 'undefined'
     ? globalThis
     : typeof window !== 'undefined'
@@ -20,4 +20,4 @@ const globalThis =
     ? self
     : {};
 
-export default globalThis;
+export default globalThisPolyfill;

--- a/src/vendor_upstream/core/globalThisPolyfill.js
+++ b/src/vendor_upstream/core/globalThisPolyfill.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright Schrodinger, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule globalThisPolyfill
+ */
+
+const globalThis =
+  typeof globalThis !== 'undefined'
+    ? globalThis
+    : typeof window !== 'undefined'
+    ? window
+    : typeof global !== 'undefined'
+    ? global
+    : typeof self !== 'undefined'
+    ? self
+    : {};
+
+export default globalThis;

--- a/src/vendor_upstream/core/nativeRequestAnimationFrame.js
+++ b/src/vendor_upstream/core/nativeRequestAnimationFrame.js
@@ -9,11 +9,13 @@
  * @providesModule nativeRequestAnimationFrame
  */
 
-var nativeRequestAnimationFrame =
-  global.requestAnimationFrame ||
-  global.webkitRequestAnimationFrame ||
-  global.mozRequestAnimationFrame ||
-  global.oRequestAnimationFrame ||
-  global.msRequestAnimationFrame;
+import globalThis from './globalThisPolyfill';
+
+const nativeRequestAnimationFrame =
+  globalThis.requestAnimationFrame ||
+  globalThis.webkitRequestAnimationFrame ||
+  globalThis.mozRequestAnimationFrame ||
+  globalThis.oRequestAnimationFrame ||
+  globalThis.msRequestAnimationFrame;
 
 export default nativeRequestAnimationFrame;

--- a/src/vendor_upstream/core/requestAnimationFramePolyfill.js
+++ b/src/vendor_upstream/core/requestAnimationFramePolyfill.js
@@ -11,6 +11,7 @@
 
 import emptyFunction from './emptyFunction';
 import nativeRequestAnimationFrame from './nativeRequestAnimationFrame';
+import globalThis from './globalThisPolyfill';
 
 var lastTime = 0;
 
@@ -24,7 +25,7 @@ var requestAnimationFrame =
     var currTime = Date.now();
     var timeDelay = Math.max(0, 16 - (currTime - lastTime));
     lastTime = currTime + timeDelay;
-    return global.setTimeout(function () {
+    return globalThis.setTimeout(function () {
       callback(Date.now());
     }, timeDelay);
   };

--- a/src/vendor_upstream/dom/translateDOMPositionXY.js
+++ b/src/vendor_upstream/dom/translateDOMPositionXY.js
@@ -14,14 +14,17 @@
 
 import BrowserSupportCore from './BrowserSupportCore';
 import getVendorPrefixedName from '../core/getVendorPrefixedName';
+import globalThis from '../core/globalThisPolyfill';
 
 var TRANSFORM = getVendorPrefixedName('transform');
 var BACKFACE_VISIBILITY = getVendorPrefixedName('backfaceVisibility');
 
 var translateDOMPositionXY = (function () {
   if (BrowserSupportCore.hasCSSTransforms()) {
-    var ua = global.window ? global.window.navigator.userAgent : 'UNKNOWN';
-    var isSafari = /Safari\//.test(ua) && !/Chrome\//.test(ua);
+    const ua = globalThis.window
+      ? globalThis.window.navigator.userAgent
+      : 'UNKNOWN';
+    const isSafari = /Safari\//.test(ua) && !/Chrome\//.test(ua);
     // It appears that Safari messes up the composition order
     // of GPU-accelerated layers
     // (see bug https://bugs.webkit.org/show_bug.cgi?id=61824).

--- a/src/vendor_upstream/struct/PrefixIntervalTree.js
+++ b/src/vendor_upstream/struct/PrefixIntervalTree.js
@@ -14,11 +14,12 @@
 'use strict';
 
 import invariant from '../../stubs/invariant';
+import globalThis from '../core/globalThisPolyfill';
 
 var parent = (node) => Math.floor(node / 2);
 
 var Int32Array =
-  global.Int32Array ||
+  globalThis.Int32Array ||
   function (size: number): Array<number> {
     var xs = [];
     for (var i = size - 1; i >= 0; --i) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some of our old vendors/third-party code tries to reference `global` which don't really exist in browser environments.

This PR change usages from `global` to the more upto standard [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis), which works across different environments like node, browser, workers, etc.
However, `globalThis` is not supported in old browsers (like IE 11), so I'm also adding something like a polyfill to make sure that `globalThis` defaults back to `window`, `global`, `self`, etc which are the global objects in various environments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #673.
React-vite doesn't seem to define or shim `global`, so trying to render FDT-2 in this environment throws a NPE.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this out in local examples. 
Also tested in a minimal react-vite boilerplate code that just imported FDT-2 and rendered a basic table.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
