### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -22,24 +22,24 @@ jobs:
 
     steps:
 
-    # checkout our repo for the current commit
-    - name: Check out repo
-      uses: actions/checkout@v3
+      # checkout our repo for the current commit
+      - name: Check out repo
+        uses: actions/checkout@v3
 
-    # setup specified node version
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
+      # setup specified node version
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
 
-    # build our library to catch any build errors
-    - name: Build!
-      run: yarn run build-dist
+      # build our library to catch any build errors
+      - name: Build!
+        run: yarn run build-dist
 
-    # run all of our tests
-    - name: Test!
-      run: yarn test
+      # run all of our tests
+      - name: Test!
+        run: yarn test

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -92,4 +92,5 @@ jobs:
 
       # publish our site to gh-pages
       - name: Deploy GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v1.2.4

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -79,9 +79,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
 
-      # build our static contents
+      # build our static site contents
       - name: Build static site!
         run: yarn run site-build
+
+      # upload the static site contents as an artifact
+      # the artifact is non-optional, and is consumed by the deploy-pages action below
+      - name: Upload static site artifacts
+        uses: actions/upload-pages-artifact@v1.0.7
+        with:
+          path: "__site__/"
 
       # publish our site to gh-pages
       - name: Deploy GitHub Pages

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
+      # enable and setup GitHub pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
       # setup node version 16 which is not old but still stable
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -69,10 +69,6 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      # enable and setup GitHub pages
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
       # setup node version 16 which is not old but still stable
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -3,7 +3,7 @@
 # This workflow will be run whenever a new release is published.
 
 # NOTE (pradeep): I'm having this workflow bail out if the release doesn't target v1.2.x. 
-# This is because we don't have a way (yet) to support multiple FDT versions/docs  be deployed at the same time,
+# This is because we don't have a way (yet) to support multiple FDT versions/docs be deployed at the same time,
 # and hence we choose to deploy only the most stable release.
 
 # Guide: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
@@ -50,32 +50,39 @@ jobs:
     needs: check-release
     runs-on: ubuntu-latest
     
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate soure
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     # skip deploying to gh-pages if release is not "stable"
     if: ${{ needs.check-release.outputs.is_stable == 'true' }}
 
     steps:
 
-    # checkout our repo for the current commit
-    - name: Check out repo
-      uses: actions/checkout@v3
+      # checkout our repo for the current commit
+      - name: Check out repo
+        uses: actions/checkout@v3
 
-    # setup node version 16 which is not old but still stable
-    - name: Use Node.js 16
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16
-        cache: 'yarn'
+      # setup node version 16 which is not old but still stable
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
 
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile # do a clean install of all of our dependencies
 
-    # build our static contents
-    - name: Build static site!
-      run: yarn run site-build
+      # build our static contents
+      - name: Build static site!
+        run: yarn run site-build
 
-    # publish our site to gh-pages
-    - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }} # authenticate the action to our workflow
-        publish_dir: ./__site__ # this directory will be copied over to gh-pages
+      # publish our site to gh-pages
+      - name: Deploy GitHub Pages
+        uses: actions/deploy-pages@v1.2.4

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -50,7 +50,7 @@ jobs:
         fi
   
   build:
-    name: Build site
+    name: Build and upload artifacts
     needs: check-release
     runs-on: ubuntu-latest
 
@@ -77,6 +77,13 @@ jobs:
       - name: Build static site!
         run: yarn run site-build
   
+      # upload the static site contents as an artifact.
+      # the artifact is non-optional, and is consumed in the next job.
+      - name: Upload static site artifacts
+        uses: actions/upload-pages-artifact@v1.0.7
+        with:
+          path: "__site__/"
+
   deploy:
     name: Deploy site
     needs: build
@@ -93,13 +100,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      # upload the static site contents as an artifact
-      # the artifact is non-optional, and is consumed by the deploy-pages action below
-      - name: Upload static site artifacts
-        uses: actions/upload-pages-artifact@v1.0.7
-        with:
-          path: "__site__/"
-
       # publish our site to gh-pages
       - name: Deploy GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -14,10 +14,15 @@ on:
   release:
     types: [published]
 
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
 
   check-release:
-    name: Check if release is stable
+    name: Check release version
     runs-on: ubuntu-latest
 
     # map step output to job output
@@ -43,22 +48,11 @@ jobs:
           echo "This is not a stable release!"
           echo "::set-output name=is_stable::false"
         fi
-
   
-  deploy:
-    name: Deploy website via gh-pages!
+  build:
+    name: Build site
     needs: check-release
     runs-on: ubuntu-latest
-    
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate soure
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     # skip deploying to gh-pages if release is not "stable"
     if: ${{ needs.check-release.outputs.is_stable == 'true' }}
@@ -82,7 +76,23 @@ jobs:
       # build our static site contents
       - name: Build static site!
         run: yarn run site-build
+  
+  deploy:
+    name: Deploy site
+    needs: build
+    runs-on: ubuntu-latest
+    
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate soure
 
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
       # upload the static site contents as an artifact
       # the artifact is non-optional, and is consumed by the deploy-pages action below
       - name: Upload static site artifacts

--- a/package.json
+++ b/package.json
@@ -87,13 +87,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pradeepnschrodinger/fixed-data-table-2.git"
+    "url": "https://github.com/schrodinger/fixed-data-table-2.git"
   },
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/schrodinger/fixed-data-table-2/issues"
   },
-  "homepage": "https://pradeepnschrodinger.github.io/fixed-data-table-2",
+  "homepage": "https://schrodinger.github.io/fixed-data-table-2",
   "tags": [
     "react",
     "table"

--- a/package.json
+++ b/package.json
@@ -87,13 +87,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/schrodinger/fixed-data-table-2.git"
+    "url": "https://github.com/pradeepnschrodinger/fixed-data-table-2.git"
   },
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/schrodinger/fixed-data-table-2/issues"
   },
-  "homepage": "https://schrodinger.github.io/fixed-data-table-2",
+  "homepage": "https://pradeepnschrodinger.github.io/fixed-data-table-2",
   "tags": [
     "react",
     "table"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have a workflow which automatically deploys the latest changes to GitHub pages.
Unfortunately the workflow was failing since it was using`peaceiris/actions-gh-pages@v3` which isn't in our whitelisted set of workflows.

To fix this, we can either change "Actions Permissions" in our repo settings to whitelist this action, or use the official GitHub actions for deployment.
I went with the latter approach here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my fork -- https://github.com/pradeepnschrodinger/fixed-data-table-2/actions/runs/4221076102

## Screenshots (if appropriate):
<img width="1653" alt="image" src="https://user-images.githubusercontent.com/41563608/220042118-400b9845-e11b-49b0-95f0-8c4322309e20.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.