### PR TITLE
Fix Error when refreshing data in table with smaller data

### DIFF
--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -137,6 +137,10 @@ class FixedDataTableBufferedRows extends React.Component {
           continue;
         }
       }
+      if (rowIndex >= this.props.rowSettings.rowsCount) {
+        this._staticRowArray[i] = null;
+        continue;
+      }
       const rowOffsetTop =
         rowOffsets[rowIndex] -
         Math.floor(scrollTop / bufferHeight) * bufferHeight;

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -12,7 +12,9 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import defaultTo from 'lodash/defaultTo';
 import inRange from 'lodash/inRange';
+import isNil from 'lodash/isNil';
 import get from 'lodash/get';
 import sortBy from 'lodash/sortBy';
 
@@ -126,18 +128,15 @@ class FixedDataTableBufferedRows extends React.Component {
 
     // render each row from the buffer into the static row array
     for (let i = 0; i < this._staticRowArray.length; i++) {
-      let rowIndex = rowsToRender[i];
       // if the row doesn't exist in the buffer set, then take the previous one
-      if (rowIndex === undefined) {
-        rowIndex = this._staticRowArray[i]
-          ? this._staticRowArray[i].props.index
-          : undefined;
-        if (rowIndex === undefined) {
-          this._staticRowArray[i] = null;
-          continue;
-        }
-      }
-      if (rowIndex >= this.props.rowSettings.rowsCount) {
+      const rowIndex = defaultTo(
+        rowsToRender[i],
+        get(this._staticRowArray[i], ['props', 'index'])
+      );
+      if (
+        isNil(rowIndex) ||
+        !inRange(rowIndex, 0, this.props.rowSettings.rowsCount)
+      ) {
         this._staticRowArray[i] = null;
         continue;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 This explicitly filter out (or unmount) the stale rows which could present in `this._staticRowArray[i]` of FixedDataTableBufferedRows when rowCounts changes.

## Motivation and Context
Issue -: https://github.com/schrodinger/fixed-data-table-2/issues/676

## How Has This Been Tested?
For testing i repro this bug using https://codesandbox.io/s/dynamic-row-test-fixed-data-table-2-pbpc9p if we scroll to end then click `update dataset` button then it will crashes the FDT.  I tested manually by updating the package with this commit, the issue is no longer repro-able after updating,

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
