### PR TITLE
Allow mouse events to work when Touch Scroll is enabled

### DIFF
--- a/src/ReactTouchHandler.js
+++ b/src/ReactTouchHandler.js
@@ -95,10 +95,6 @@ class ReactTouchHandler {
   }
 
   onTouchStart(/*object*/ event) {
-    if (this._preventDefault) {
-      event.preventDefault();
-    }
-
     // Start tracking drag delta for scrolling
     this._lastTouchX = event.touches[0].pageX;
     this._lastTouchY = event.touches[0].pageY;
@@ -120,10 +116,6 @@ class ReactTouchHandler {
   }
 
   onTouchEnd(/*object*/ event) {
-    if (this._preventDefault) {
-      event.preventDefault();
-    }
-
     // Stop tracking velocity
     clearInterval(this._trackerId);
     this._trackerId = null;

--- a/test/ReactTouchHandler-test.js
+++ b/test/ReactTouchHandler-test.js
@@ -67,7 +67,8 @@ describe('ReactTouchHandler', function () {
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
-    it('should prevent default if flag is true', function () {
+    // NOTE (pradeep): this ensures that mouse events like clicks still fire
+    it('should not prevent default even if the flag is true', function () {
       // --- Run Test ---
       var reactTouchHandler = new ReactTouchHandler(
         () => {},
@@ -79,7 +80,7 @@ describe('ReactTouchHandler', function () {
       reactTouchHandler.onTouchStart(fakeEvent);
 
       // --- Verify Expectations ---
-      assert.isTrue(fakeEvent.preventDefault.calledOnce);
+      assert.isFalse(fakeEvent.preventDefault.called);
     });
 
     it('should start new interval', function () {
@@ -148,7 +149,8 @@ describe('ReactTouchHandler', function () {
       assert.isFalse(fakeEvent.stopPropagation.called);
     });
 
-    it('should prevent default if flag is true', function () {
+    // NOTE (pradeep): this ensures that mouse events like clicks still fire
+    it('should not prevent default even if flag is true', function () {
       // --- Run Test ---
       var reactTouchHandler = new ReactTouchHandler(
         () => {},
@@ -160,7 +162,7 @@ describe('ReactTouchHandler', function () {
       reactTouchHandler.onTouchEnd(fakeEvent);
 
       // --- Verify Expectations ---
-      assert.isTrue(fakeEvent.preventDefault.calledOnce);
+      assert.isFalse(fakeEvent.preventDefault.called);
     });
 
     it('should clear last interval', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
FDT is a bit aggressive in preventing default scroll handlers when touch scroll is enabled.
This leads to mouse events like clicks not working when they originate from the table.

The changeset here relaxes this by making sure we only prevent the default behavior for `touchmove` events instead of `touchstart` and `touchend`.
This is based on the suggestion from MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#handling_clicks).

> Since calling preventDefault() on a [touchstart](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchstart_event) or the first [touchmove](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchmove_event) event of a series prevents the corresponding mouse events from firing, it's common to call preventDefault() on touchmove rather than touchstart. That way, mouse events can still fire and things like links will continue to work. Alternatively, some frameworks have taken to re-firing touch events as mouse events for this same purpose.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In LD grid, we want to support mouse events on the grid even when touch support is enabled.
eg: Clicking on a cell for selection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Enabled touch scrolling via the `touchScrollEnabled` table prop and turned on `stopScrollDefaultHandling`.
Verified that I can still click stuff on the grid while on touch mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
