### PR TITLE
Fix reorder logic post API refactor

### DIFF
--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -124,7 +124,6 @@ class FixedDataTableCellGroupImpl extends React.Component {
       ) {
         const key = columnProps.columnKey || 'cell_' + i;
         cells[i] = this._renderCell(
-          i,
           props.rowIndex,
           props.rowHeight,
           columnProps,
@@ -160,7 +159,6 @@ class FixedDataTableCellGroupImpl extends React.Component {
   }
 
   _renderCell = (
-    /*number*/ columnIndex,
     /*number*/ rowIndex,
     /*number*/ height,
     /*object*/ columnProps,
@@ -180,7 +178,7 @@ class FixedDataTableCellGroupImpl extends React.Component {
 
     return (
       <FixedDataTableCell
-        columnIndex={columnIndex}
+        columnIndex={columnProps.index}
         isScrolling={this.props.isScrolling}
         isHeaderOrFooter={this.props.isHeaderOrFooter}
         isHeader={this.props.isHeader}

--- a/src/plugins/ResizeReorder/DragProxy.js
+++ b/src/plugins/ResizeReorder/DragProxy.js
@@ -260,8 +260,8 @@ class DragProxy extends React.PureComponent {
     }
 
     const columnCount = this.props.isGroupHeader
-      ? this.context.getColumnGroupCount(cellGroupType)
-      : this.context.getColumnCount(cellGroupType);
+      ? this.context.getColumnGroupCount()
+      : this.context.getColumnCount();
     let columnBefore;
     let columnAfter;
 

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -14,6 +14,7 @@ import map from 'lodash/map';
 import shallowEqualSelector from '../helper/shallowEqualSelector';
 import { getTotalFlexGrow, getTotalWidth } from '../helper/widthHelper';
 import scrollbarsVisible from './scrollbarsVisible';
+import { concat } from 'lodash';
 
 /**
  * @typedef {{
@@ -35,8 +36,11 @@ import scrollbarsVisible from './scrollbarsVisible';
  *   columnProps: !Array.<columnDefinition>,
  *   availableScrollWidth: number,
  *   fixedColumns: !Array.<columnDefinition>,
+ *   fixedColumnGroups: !Array.<columnDefinition>,
  *   fixedRightColumns: !Array.<columnDefinition>,
+ *   fixedRightColumnGroups: !Array.<columnDefinition>,
  *   scrollableColumns: !Array.<columnDefinition>,
+ *   scrollableColumnGroups: !Array.<columnDefinition>,
  *   maxScrollX: number,
  * }} The total width of all columns.
  */
@@ -50,31 +54,37 @@ function columnWidths(
   const scrollbarSpace = scrollEnabledY ? scrollbarYWidth : 0;
   const viewportWidth = width - scrollbarSpace;
 
-  const { newColumnGroupProps, newColumnProps } = flexWidths(
-    columnGroupProps,
-    columnProps,
-    viewportWidth
-  );
+  const {
+    columnGroupProps: columnGroupPropsWithFlex,
+    columnProps: columnPropsWithFlex,
+  } = flexWidths(columnGroupProps, columnProps, viewportWidth);
   const {
     fixed: fixedColumns,
     fixedRight: fixedRightColumns,
     scrollable: scrollableColumns,
-  } = groupElements(newColumnProps);
+  } = groupElements(columnPropsWithFlex);
   const {
     fixed: fixedColumnGroups,
     fixedRight: fixedRightColumnGroups,
     scrollable: scrollableColumnGroups,
-  } = groupElements(newColumnGroupProps);
+  } = groupElements(columnGroupPropsWithFlex);
 
   const availableScrollWidth =
     viewportWidth -
     getTotalWidth(fixedColumns) -
     getTotalWidth(fixedRightColumns);
-  const maxScrollX = Math.max(0, getTotalWidth(newColumnProps) - viewportWidth);
+  const maxScrollX = Math.max(
+    0,
+    getTotalWidth(columnPropsWithFlex) - viewportWidth
+  );
 
   return {
-    columnGroupProps: newColumnGroupProps,
-    columnProps: newColumnProps,
+    columnGroupProps: concat(
+      fixedColumnGroups,
+      scrollableColumnGroups,
+      fixedRightColumnGroups
+    ),
+    columnProps: concat(fixedColumns, scrollableColumns, fixedRightColumns),
     availableScrollWidth,
     fixedColumns,
     fixedRightColumns,
@@ -91,8 +101,8 @@ function columnWidths(
  * @param {!Array.<columnDefinition>} columnProps
  * @param {number} viewportWidth
  * @return {{
- *   newColumnGroupProps: !Array.<columnDefinition>,
- *   newColumnProps: !Array.<columnDefinition>
+ *   columnGroupProps: !Array.<columnDefinition>,
+ *   columnProps: !Array.<columnDefinition>
  * }}
  */
 function flexWidths(columnGroupProps, columnProps, viewportWidth) {
@@ -141,8 +151,8 @@ function flexWidths(columnGroupProps, columnProps, viewportWidth) {
   });
 
   return {
-    newColumnGroupProps,
-    newColumnProps,
+    columnGroupProps: newColumnGroupProps,
+    columnProps: newColumnProps,
   };
 }
 

--- a/test/selectors/columnWidths-test.js
+++ b/test/selectors/columnWidths-test.js
@@ -17,14 +17,14 @@ describe('columnWidths', function () {
 
     const fixedGroup1 = [
       {
-        id: 2,
+        id: 1,
         fixed: true,
         flexGrow: 10,
         width: 50,
         groupIdx: 0,
       },
       {
-        id: 4,
+        id: 2,
         fixed: true,
         width: 60,
         groupIdx: 0,
@@ -32,13 +32,13 @@ describe('columnWidths', function () {
     ];
     const fixedGroup2 = [
       {
-        id: 5,
+        id: 3,
         fixed: true,
         width: 90,
         groupIdx: 2,
       },
       {
-        id: 7,
+        id: 4,
         fixed: true,
         width: 10,
         groupIdx: 2,
@@ -46,14 +46,14 @@ describe('columnWidths', function () {
     ];
     const scrollableGroup1 = [
       {
-        id: 1,
+        id: 5,
         fixed: false,
         flexGrow: 5,
         width: 50,
         groupIdx: 1,
       },
       {
-        id: 3,
+        id: 6,
         fixed: false,
         flexGrow: 10,
         width: 20,
@@ -62,7 +62,7 @@ describe('columnWidths', function () {
     ];
     const scrollableGroup2 = [
       {
-        id: 6,
+        id: 7,
         fixed: false,
         flexGrow: 1,
         width: 100,
@@ -107,15 +107,15 @@ describe('columnWidths', function () {
       );
     assert.deepEqual(
       columnProps.map((column) => column.id),
-      [2, 4, 1, 3, 5, 7, 6]
+      [1, 2, 3, 4, 5, 6, 7]
     );
     assert.deepEqual(
       fixedColumns.map((column) => column.id),
-      [2, 4, 5, 7]
+      [1, 2, 3, 4]
     );
     assert.deepEqual(
       scrollableColumns.map((column) => column.id),
-      [1, 3, 6]
+      [5, 6, 7]
     );
   });
 
@@ -131,11 +131,11 @@ describe('columnWidths', function () {
 
     assert.deepEqual(
       columnGroupProps.map((column) => column.width),
-      [110, 70, 100, 100]
+      [110, 100, 70, 100]
     );
     assert.deepEqual(
       columnProps.map((column) => column.width),
-      [50, 60, 50, 20, 90, 10, 100]
+      [50, 60, 90, 10, 50, 20, 100]
     );
     assert.deepEqual(
       fixedColumns.map((column) => column.width),
@@ -161,11 +161,11 @@ describe('columnWidths', function () {
 
     assert.deepEqual(
       columnGroupProps.map((column) => column.width),
-      [110 + 100, 70 + 150, 100, 100 + 10]
+      [110 + 100, 100, 70 + 150, 100 + 10]
     );
     assert.deepEqual(
       columnProps.map((column) => column.width),
-      [50 + 100, 60, 50 + 50, 20 + 100, 90, 10, 100 + 10]
+      [50 + 100, 60, 90, 10, 50 + 50, 20 + 100, 100 + 10]
     );
     assert.deepEqual(
       fixedColumns.map((column) => column.width),
@@ -192,11 +192,11 @@ describe('columnWidths', function () {
 
     assert.deepEqual(
       columnGroupProps.map((column) => column.width),
-      [110 + 100, 70 + 150, 100, 100 + 11]
+      [110 + 100, 100, 70 + 150, 100 + 11]
     );
     assert.deepEqual(
       columnProps.map((column) => column.width),
-      [50 + 100, 60, 50 + 50, 20 + 100, 90, 10, 100 + 11]
+      [50 + 100, 60, 90, 10, 50 + 50, 20 + 100, 100 + 11]
     );
     assert.deepEqual(
       fixedColumns.map((column) => column.width),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reordering using ReorderCell sometimes reports incorrect column keys.
This came from https://github.com/schrodinger/fixed-data-table-2/pull/667, where the public APIs were modified to make use of global column index but the column index passed to the cell component was still the local column index.

## Breaking change
Note that there's a small breaking change here:
Previously, `columnBefore` and `columnAfter` were strictly contained within the cell group of the cell being reordered. So reordering to extreme ends can cause either `columnBefore` and/or `columnAfter` to be `undefined`.

Now, `columnBefore` and `columnAfter` can report past the current cell group.
I think this is fine because:
1. This gives more information, and is consistent with the new column index design which moves away from "local indices".
2. The client can choose to go back to the old behaviour by just checking if the column key belongs to the same cell group.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes reordering issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in local reorder examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
