### PR TITLE
Fix edge case where column group width becomes undefined

### DIFF
--- a/src/reducers/updateScrollableColumn.js
+++ b/src/reducers/updateScrollableColumn.js
@@ -54,6 +54,7 @@ export function getScrollableColumn(state, localColIdx) {
       _.get(storedColumnGroup, 'props.lastChildIdx'),
     ]);
 
+    columnGroup.props.width = _.get(storedColumnGroup, 'props.width');
     columnGroup.props.index = columnGroupIndex;
 
     // cache the column group


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Column Group width in `storedScrollableColumnGroup` can sometimes become undefined even when it has already rendered. This happens in case where  `getScrollableColumn` get called which saved columnGroup without width in `storedScrollableColumnGroup` but `computeRenderedColumnGroups` is not called.

## Motivation and Context
Jira: https://jira.schrodinger.com/browse/SS-42307

## How Has This Been Tested?
Tested using AutoScrollExample and in LD where these changes  fixed SS-42307.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
