### PR TITLE
Improve performance for v1.2

### DIFF
--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -29,13 +29,14 @@ class AutoScrollExample extends React.Component {
         {rowIndex}, {columnKey}{' '}
       </div>
     );
+    const headerRenderer = ({ columnKey }) => <div> {columnKey} </div>;
 
     for (let i = 0; i < 100; i++) {
       this.columns[i] = (
         <Column
           key={i}
           columnKey={i}
-          header={<div> {i} </div>}
+          header={headerRenderer}
           cell={cellRenderer}
           width={100}
           allowCellsRecycling={true}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -156,8 +156,8 @@ class FixedDataTableBufferedRows extends React.Component {
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
 
     // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
-    const sortedRows = sortBy(this._staticRowArray, (row) =>
-      get(row, 'props.ariaRowIndex', Infinity)
+    const sortedRows = this._staticRowArray.sort(
+      (row) => row?.props?.ariaRowIndex || Infinity
     );
 
     return <div style={style}>{sortedRows}</div>;

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -61,7 +61,7 @@ export default function computeRenderedRows(state, scrollAnchor) {
   const firstRowIndex = rowRange.firstViewportIdx;
   const endRowIndex = rowRange.endViewportIdx;
 
-  computeRenderedRowOffsets(newState, rowRange, state.scrolling);
+  computeRenderedRowOffsets(newState, rowRange);
 
   let scrollY = 0;
   if (rowsCount > 0) {
@@ -222,17 +222,11 @@ function calculateRenderedRowRange(state, scrollAnchor) {
  *   firstBufferIdx: number,
  *   firstViewportIdx: number,
  * }} rowRange
- * @param {boolean} viewportOnly
  * @private
  */
-function computeRenderedRowOffsets(state, rowRange, viewportOnly) {
+function computeRenderedRowOffsets(state, rowRange) {
   const { rowBufferSet, rowOffsetIntervalTree, storedHeights } = state;
-  const {
-    endBufferIdx,
-    endViewportIdx,
-    firstBufferIdx,
-    firstViewportIdx,
-  } = rowRange;
+  const { endBufferIdx, firstBufferIdx } = rowRange;
 
   const renderedRowsCount = endBufferIdx - firstBufferIdx;
   if (renderedRowsCount === 0) {
@@ -241,18 +235,15 @@ function computeRenderedRowOffsets(state, rowRange, viewportOnly) {
     return;
   }
 
-  const startIdx = viewportOnly ? firstViewportIdx : firstBufferIdx;
-  const endIdx = viewportOnly ? endViewportIdx : endBufferIdx;
-
   // output for this function
   const rows = []; // state.rows
   const rowOffsets = {}; // state.rowOffsets
 
   // incremental way for calculating rowOffset
-  let runningOffset = rowOffsetIntervalTree.sumUntil(startIdx);
+  let runningOffset = rowOffsetIntervalTree.sumUntil(firstBufferIdx);
 
   // compute row index and offsets for every rows inside the buffer
-  for (let rowIdx = startIdx; rowIdx < endIdx; rowIdx++) {
+  for (let rowIdx = firstBufferIdx; rowIdx < endBufferIdx; rowIdx++) {
     // Update the offset for rendering the row
     rowOffsets[rowIdx] = runningOffset;
     runningOffset += storedHeights[rowIdx];
@@ -261,8 +252,8 @@ function computeRenderedRowOffsets(state, rowRange, viewportOnly) {
     const rowPosition = addRowToBuffer(
       rowIdx,
       rowBufferSet,
-      startIdx,
-      endIdx,
+      firstBufferIdx,
+      endBufferIdx,
       renderedRowsCount
     );
     rows[rowPosition] = rowIdx;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Long time back, we had a performance optimization done in v1 (see #421) where FDT only updates the rows inside the visible viewport instead of the whole row bufferset.

However, after #658, the original optimization no longer works, and instead causes a decrease in performance.
I'm removing it until we can figure out an alternative which probably requires a redesign to the `IntegerBufferSet` data structure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves performance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
