### PR TITLE
Fix performance regressions for v1.2

### DIFF
--- a/examples/AutoScrollExample.js
+++ b/examples/AutoScrollExample.js
@@ -29,13 +29,14 @@ class AutoScrollExample extends React.Component {
         {rowIndex}, {columnKey}{' '}
       </div>
     );
+    const headerRenderer = ({ columnKey }) => <div> {columnKey} </div>;
 
     for (let i = 0; i < 100; i++) {
       this.columns[i] = (
         <Column
           key={i}
           columnKey={i}
-          header={<div> {i} </div>}
+          header={headerRenderer}
           cell={cellRenderer}
           width={100}
           allowCellsRecycling={true}

--- a/examples/ReorderExample.js
+++ b/examples/ReorderExample.js
@@ -48,9 +48,8 @@ class ReorderExample extends React.Component {
       ],
     };
 
-    this._onColumnReorderEndCallback = this._onColumnReorderEndCallback.bind(
-      this
-    );
+    this._onColumnReorderEndCallback =
+      this._onColumnReorderEndCallback.bind(this);
   }
 
   _onColumnReorderEndCallback(event) {

--- a/examples/ResizeExample.js
+++ b/examples/ResizeExample.js
@@ -23,9 +23,8 @@ class ResizeExample extends React.Component {
       },
     };
 
-    this._onColumnResizeEndCallback = this._onColumnResizeEndCallback.bind(
-      this
-    );
+    this._onColumnResizeEndCallback =
+      this._onColumnResizeEndCallback.bind(this);
   }
 
   _onColumnResizeEndCallback(newColumnWidth, columnKey) {

--- a/examples/ResponsiveExample.js
+++ b/examples/ResponsiveExample.js
@@ -21,13 +21,8 @@ class ResponsiveExample extends React.Component {
 
   render() {
     const { dataList } = this.state;
-    const {
-      height,
-      width,
-      containerHeight,
-      containerWidth,
-      ...props
-    } = this.props;
+    const { height, width, containerHeight, containerWidth, ...props } =
+      this.props;
     return (
       <Table
         rowHeight={50}

--- a/examples/helpers/cells.js
+++ b/examples/helpers/cells.js
@@ -11,14 +11,8 @@ import ReactTooltip from 'react-tooltip';
 
 class CollapseCell extends React.PureComponent {
   render() {
-    const {
-      data,
-      rowIndex,
-      columnKey,
-      collapsedRows,
-      callback,
-      ...props
-    } = this.props;
+    const { data, rowIndex, columnKey, collapsedRows, callback, ...props } =
+      this.props;
     return (
       <DataCell {...props}>
         <a onClick={() => callback(rowIndex)}>
@@ -103,14 +97,8 @@ const PagedCell = ({ data, ...props }) => {
 
 class RemovableHeaderCell extends React.PureComponent {
   render() {
-    const {
-      data,
-      rowIndex,
-      columnKey,
-      callback,
-      children,
-      ...props
-    } = this.props;
+    const { data, rowIndex, columnKey, callback, children, ...props } =
+      this.props;
     return (
       <DataCell {...props}>
         {children}

--- a/site/home/HeroTable.js
+++ b/site/home/HeroTable.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var FakeObjectDataListStore = require('../../examples/helpers/FakeObjectDataListStore')
-  .default;
+var FakeObjectDataListStore =
+  require('../../examples/helpers/FakeObjectDataListStore').default;
 var FixedDataTable = require('fixed-data-table-2');
 var React = require('react');
 var Constants = require('../Constants');

--- a/src/ColumnResizerLine.js
+++ b/src/ColumnResizerLine.js
@@ -130,8 +130,8 @@ class ColumnResizerLine extends React.PureComponent {
       <div
         className={cx({
           'fixedDataTableColumnResizerLineLayout/main': true,
-          'fixedDataTableColumnResizerLineLayout/hiddenElem': !this.props
-            .visible,
+          'fixedDataTableColumnResizerLineLayout/hiddenElem':
+            !this.props.visible,
           'public/fixedDataTableColumnResizerLine/main': true,
         })}
         style={style}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -696,11 +696,8 @@ class FixedDataTable extends React.Component {
    * @private
    */
   _reportScrollBarsUpdates() {
-    const {
-      bodyOffsetTop,
-      scrollbarXOffsetTop,
-      visibleRowsHeight,
-    } = tableHeightsSelector(this.props);
+    const { bodyOffsetTop, scrollbarXOffsetTop, visibleRowsHeight } =
+      tableHeightsSelector(this.props);
     const {
       tableSize: { width },
       scrollContentHeight,
@@ -1081,9 +1078,8 @@ class FixedDataTable extends React.Component {
     /*number|string*/ columnKey,
     /*object*/ event
   ) => {
-    const coordinates = FixedDataTableEventHelper.getCoordinatesFromEvent(
-      event
-    );
+    const coordinates =
+      FixedDataTableEventHelper.getCoordinatesFromEvent(event);
     const clientX = coordinates.x;
     const clientY = coordinates.y;
     this.props.columnActions.resizeColumn({
@@ -1194,12 +1190,8 @@ class FixedDataTable extends React.Component {
   };
 
   _scrollToX = (/*number*/ scrollPos) => {
-    const {
-      onHorizontalScroll,
-      scrollActions,
-      scrollX,
-      scrolling,
-    } = this.props;
+    const { onHorizontalScroll, scrollActions, scrollX, scrolling } =
+      this.props;
 
     if (scrollPos === scrollX) {
       return;

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -83,13 +83,8 @@ class FixedDataTableBufferedRows extends React.Component {
   }
 
   render() /*object*/ {
-    let {
-      offsetTop,
-      rowOffsets,
-      scrollTop,
-      isScrolling,
-      rowsToRender,
-    } = this.props;
+    let { offsetTop, rowOffsets, scrollTop, isScrolling, rowsToRender } =
+      this.props;
     rowsToRender = rowsToRender || [];
 
     if (isScrolling) {
@@ -237,7 +232,11 @@ class FixedDataTableBufferedRows extends React.Component {
    * @private
    */
   rowSortComparator(rowA, rowB) {
-    return (rowA?.props.ariaRowIndex || -1) - (rowB?.props.ariaRowIndex || -1);
+    // NOTE (pradeep): Aria row index can't be zero, but the row itself can be undefined.
+    // I picked -1 as the default here. As long as the default sites outside the usual row index range,
+    // it should work. I purposefully didn't choose Infinity or -Infinity, as they might break
+    // arithmetic operations.
+    return (rowA?.props.ariaRowIndex ?? -1) - (rowB?.props.ariaRowIndex ?? -1);
   }
 }
 export default FixedDataTableBufferedRows;

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -155,10 +155,11 @@ class FixedDataTableBufferedRows extends React.Component {
     const style = {};
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
 
-    // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
-    const sortedRows = sortBy(this._staticRowArray, (row) =>
-      get(row, 'props.ariaRowIndex', Infinity)
-    );
+    // // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
+    // const sortedRows = sortBy(this._staticRowArray, (row) =>
+    //   get(row, 'props.ariaRowIndex', Infinity)
+    // );
+    const sortedRows = this._staticRowArray;
 
     return <div style={style}>{sortedRows}</div>;
   }

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -156,10 +156,9 @@ class FixedDataTableBufferedRows extends React.Component {
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
 
     // // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
-    // const sortedRows = sortBy(this._staticRowArray, (row) =>
-    //   get(row, 'props.ariaRowIndex', Infinity)
-    // );
-    const sortedRows = this._staticRowArray;
+    const sortedRows = this._staticRowArray.sort(
+      (row) => row?.props?.ariaRowIndex || Infinity
+    );
 
     return <div style={style}>{sortedRows}</div>;
   }

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -154,7 +154,9 @@ class FixedDataTableBufferedRows extends React.Component {
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
 
     // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
-    const sortedRows = this._staticRowArray.toSorted(this.rowSortComparator);
+    const sortedRows = this._staticRowArray
+      .slice()
+      .sort(this.rowSortComparator);
 
     return <div style={style}>{sortedRows}</div>;
   }

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -155,7 +155,7 @@ class FixedDataTableBufferedRows extends React.Component {
     const style = {};
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
 
-    // // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
+    // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
     const sortedRows = this._staticRowArray.sort(
       (row) => row?.props?.ariaRowIndex || Infinity
     );

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -15,8 +15,6 @@ import React from 'react';
 import defaultTo from 'lodash/defaultTo';
 import inRange from 'lodash/inRange';
 import isNil from 'lodash/isNil';
-import get from 'lodash/get';
-import sortBy from 'lodash/sortBy';
 
 import cx from './vendor_upstream/stubs/cx';
 import emptyFunction from './vendor_upstream/core/emptyFunction';
@@ -131,7 +129,7 @@ class FixedDataTableBufferedRows extends React.Component {
       // if the row doesn't exist in the buffer set, then take the previous one
       const rowIndex = defaultTo(
         rowsToRender[i],
-        get(this._staticRowArray[i], ['props', 'index'])
+        this._staticRowArray[i]?.props.index
       );
       if (
         isNil(rowIndex) ||
@@ -156,9 +154,7 @@ class FixedDataTableBufferedRows extends React.Component {
     FixedDataTableTranslateDOMPosition(style, 0, containerOffsetTop, false);
 
     // NOTE (pradeep): Sort the rows by row index so that they appear with the right order in the DOM (see #221)
-    const sortedRows = this._staticRowArray.sort(
-      (row) => row?.props?.ariaRowIndex || Infinity
-    );
+    const sortedRows = this._staticRowArray.toSorted(this.rowSortComparator);
 
     return <div style={style}>{sortedRows}</div>;
   }
@@ -230,6 +226,16 @@ class FixedDataTableBufferedRows extends React.Component {
         {...rowProps}
       />
     );
+  }
+
+  /**
+   * @param {?React.ReactElement} rowA
+   * @param {?React.ReactElement} rowB
+   * @returns {number}
+   * @private
+   */
+  rowSortComparator(rowA, rowB) {
+    return (rowA?.props.ariaRowIndex || -1) - (rowB?.props.ariaRowIndex || -1);
   }
 }
 export default FixedDataTableBufferedRows;

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -215,14 +215,8 @@ class FixedDataTableCell extends React.Component {
   };
 
   render() /*object*/ {
-    var {
-      height,
-      width,
-      isVisible,
-      columnKey,
-      isHeaderOrFooter,
-      ...props
-    } = this.props;
+    var { height, width, isVisible, columnKey, isHeaderOrFooter, ...props } =
+      this.props;
 
     var style = {
       height,
@@ -253,8 +247,8 @@ class FixedDataTableCell extends React.Component {
         'public/fixedDataTableCell/highlighted': props.highlighted,
         'public/fixedDataTableCell/main': true,
         'public/fixedDataTableCell/hasReorderHandle': !!props.onColumnReorder,
-        'public/fixedDataTableCell/reordering': this.state
-          .isReorderingThisColumn,
+        'public/fixedDataTableCell/reordering':
+          this.state.isReorderingThisColumn,
       }),
       props.className
     );

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -170,14 +170,14 @@ class FixedDataTableRowImpl extends React.Component {
       return true;
     }
 
-    // if row's visibility has changed, then update it
-    if (this.props.visible !== nextProps.visible) {
-      return true;
-    }
-
     // if row is still not visible then no need to update
     if (!nextProps.visible) {
       return false;
+    }
+
+    // if row's visibility has changed, then update it
+    if (this.props.visible !== nextProps.visible) {
+      return true;
     }
 
     // Only update the row if scrolling leads to a change in horizontal offsets.

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -170,7 +170,8 @@ class FixedDataTableRowImpl extends React.Component {
       return true;
     }
 
-    // if row is still not visible then no need to update
+    // if row is not visible then no need to render it
+    // change in visibility is handled by the parent
     if (!nextProps.visible) {
       return false;
     }

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -77,11 +77,8 @@ function scrollTo(state, props, oldScrollToColumn, scrollX) {
     return scrollX;
   }
 
-  const {
-    availableScrollWidth,
-    fixedColumns,
-    scrollableColumns,
-  } = columnWidths(state);
+  const { availableScrollWidth, fixedColumns, scrollableColumns } =
+    columnWidths(state);
   const fixedColumnsCount = fixedColumns.length;
   const scrollableColumnsCount = scrollableColumns.length;
 

--- a/src/reducers/computeRenderedRows.js
+++ b/src/reducers/computeRenderedRows.js
@@ -227,12 +227,8 @@ function calculateRenderedRowRange(state, scrollAnchor) {
  */
 function computeRenderedRowOffsets(state, rowRange, viewportOnly) {
   const { rowBufferSet, rowOffsetIntervalTree, storedHeights } = state;
-  const {
-    endBufferIdx,
-    endViewportIdx,
-    firstBufferIdx,
-    firstViewportIdx,
-  } = rowRange;
+  const { endBufferIdx, endViewportIdx, firstBufferIdx, firstViewportIdx } =
+    rowRange;
 
   const renderedRowsCount = endBufferIdx - firstBufferIdx;
   if (renderedRowsCount === 0) {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -240,12 +240,8 @@ function initializeRowHeightsAndOffsets(state) {
  * @private
  */
 function setStateFromProps(state, props) {
-  const {
-    columnGroupProps,
-    columnProps,
-    elementTemplates,
-    useGroupHeader,
-  } = convertColumnElementsToData(props.children);
+  const { columnGroupProps, columnProps, elementTemplates, useGroupHeader } =
+    convertColumnElementsToData(props.children);
 
   const newState = Object.assign({}, state, {
     columnGroupProps,

--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -55,9 +55,8 @@ function columnWidths(
     columnProps,
     viewportWidth
   );
-  const { fixedColumns, fixedRightColumns, scrollableColumns } = groupColumns(
-    newColumnProps
-  );
+  const { fixedColumns, fixedRightColumns, scrollableColumns } =
+    groupColumns(newColumnProps);
 
   const availableScrollWidth =
     viewportWidth -

--- a/src/stubs/UserAgent_DEPRECATED.js
+++ b/src/stubs/UserAgent_DEPRECATED.js
@@ -76,9 +76,10 @@ function _populate() {
   //
   // Opera/9.80 (foo) Presto/2.2.15 Version/10.10
   var uas = navigator.userAgent;
-  var agent = /(?:MSIE.(\d+\.\d+))|(?:(?:Firefox|GranParadiso|Iceweasel).(\d+\.\d+))|(?:Opera(?:.+Version.|.)(\d+\.\d+))|(?:AppleWebKit.(\d+(?:\.\d+)?))|(?:Trident\/\d+\.\d+.*rv:(\d+\.\d+))/.exec(
-    uas
-  );
+  var agent =
+    /(?:MSIE.(\d+\.\d+))|(?:(?:Firefox|GranParadiso|Iceweasel).(\d+\.\d+))|(?:Opera(?:.+Version.|.)(\d+\.\d+))|(?:AppleWebKit.(\d+(?:\.\d+)?))|(?:Trident\/\d+\.\d+.*rv:(\d+\.\d+))/.exec(
+      uas
+    );
   var os = /(Mac OS X)|(Windows)|(Linux)/.exec(uas);
 
   _iphone = /\b(iPhone|iP[ao]d)/.exec(uas);

--- a/src/vendor_upstream/dom/DOMMouseMoveTracker.js
+++ b/src/vendor_upstream/dom/DOMMouseMoveTracker.js
@@ -104,9 +104,8 @@ class DOMMouseMoveTracker {
       this._deltaX = 0;
       this._deltaY = 0;
       this._isDragging = true;
-      var coordinates = FixedDataTableEventHelper.getCoordinatesFromEvent(
-        event
-      );
+      var coordinates =
+        FixedDataTableEventHelper.getCoordinatesFromEvent(event);
       var x = coordinates.x;
       var y = coordinates.y;
       this._x = x;

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -71,9 +71,8 @@ class ReactWheelHandler {
 
     // if shift is held, swap the axis of scrolling.
     if (event.shiftKey && ReactWheelHandler._allowInternalAxesSwap()) {
-      normalizedEvent = ReactWheelHandler._swapNormalizedWheelAxis(
-        normalizedEvent
-      );
+      normalizedEvent =
+        ReactWheelHandler._swapNormalizedWheelAxis(normalizedEvent);
     } else if (!event.shiftKey) {
       normalizedEvent.pixelX *= this._isRTL ? -1 : 1;
     }

--- a/src/vendor_upstream/struct/IntegerBufferSet.js
+++ b/src/vendor_upstream/struct/IntegerBufferSet.js
@@ -43,9 +43,8 @@ class IntegerBufferSet {
     this.getNewPositionForValue = this.getNewPositionForValue.bind(this);
     this.getValuePosition = this.getValuePosition.bind(this);
     this.getSize = this.getSize.bind(this);
-    this.replaceFurthestValuePosition = this.replaceFurthestValuePosition.bind(
-      this
-    );
+    this.replaceFurthestValuePosition =
+      this.replaceFurthestValuePosition.bind(this);
   }
 
   getSize() /*number*/ {

--- a/test/helper/convertColumnElementsToData-test.js
+++ b/test/helper/convertColumnElementsToData-test.js
@@ -59,29 +59,25 @@ describe('convertColumnElementsToData', function () {
   });
 
   it('should return appropriate columnGroupProps, columnProps, and elementTemplates', function () {
-    const {
-      columnGroupProps,
-      columnProps,
-      elementTemplates,
-      useGroupHeader,
-    } = convertColumnElementsToData([
-      {
-        props: {
-          fixed: true,
-          children: [column1, column2],
-          header: { id: 'g1' },
+    const { columnGroupProps, columnProps, elementTemplates, useGroupHeader } =
+      convertColumnElementsToData([
+        {
+          props: {
+            fixed: true,
+            children: [column1, column2],
+            header: { id: 'g1' },
+          },
+          type: { __TableColumnGroup__: true },
         },
-        type: { __TableColumnGroup__: true },
-      },
-      {
-        props: {
-          fixed: false,
-          children: [column3],
-          header: { id: 'g2' },
+        {
+          props: {
+            fixed: false,
+            children: [column3],
+            header: { id: 'g2' },
+          },
+          type: { __TableColumnGroup__: true },
         },
-        type: { __TableColumnGroup__: true },
-      },
-    ]);
+      ]);
 
     assert.deepEqual(columnGroupProps, [{ fixed: true }, { fixed: false }]);
     assert.deepEqual(columnProps, [
@@ -114,12 +110,8 @@ describe('convertColumnElementsToData', function () {
   });
 
   it('should not specify a groupIdx if none exists', function () {
-    const {
-      columnGroupProps,
-      columnProps,
-      elementTemplates,
-      useGroupHeader,
-    } = convertColumnElementsToData([column1, column2]);
+    const { columnGroupProps, columnProps, elementTemplates, useGroupHeader } =
+      convertColumnElementsToData([column1, column2]);
 
     assert.deepEqual(columnGroupProps, []);
     assert.deepEqual(columnProps, [

--- a/test/selectors/columnWidths-test.js
+++ b/test/selectors/columnWidths-test.js
@@ -97,17 +97,14 @@ describe('columnWidths', function () {
   });
 
   it('should partition columns on fixed flag', function () {
-    const {
-      columnProps,
-      fixedColumns,
-      scrollableColumns,
-    } = columnWidths.resultFunc(
-      columnGroupPropsIn,
-      columnPropsIn,
-      scrollEnabledY,
-      width,
-      Scrollbar.SIZE
-    );
+    const { columnProps, fixedColumns, scrollableColumns } =
+      columnWidths.resultFunc(
+        columnGroupPropsIn,
+        columnPropsIn,
+        scrollEnabledY,
+        width,
+        Scrollbar.SIZE
+      );
     assert.deepEqual(
       columnProps.map((column) => column.id),
       [2, 4, 1, 3, 5, 7, 6]
@@ -123,18 +120,14 @@ describe('columnWidths', function () {
   });
 
   it('should maintain widths when no surplus', function () {
-    const {
-      columnGroupProps,
-      columnProps,
-      fixedColumns,
-      scrollableColumns,
-    } = columnWidths.resultFunc(
-      columnGroupPropsIn,
-      columnPropsIn,
-      scrollEnabledY,
-      width,
-      Scrollbar.SIZE
-    );
+    const { columnGroupProps, columnProps, fixedColumns, scrollableColumns } =
+      columnWidths.resultFunc(
+        columnGroupPropsIn,
+        columnPropsIn,
+        scrollEnabledY,
+        width,
+        Scrollbar.SIZE
+      );
 
     assert.deepEqual(
       columnGroupProps.map((column) => column.width),
@@ -157,18 +150,14 @@ describe('columnWidths', function () {
   it('should distribute flex width', function () {
     width = 640;
 
-    const {
-      columnGroupProps,
-      columnProps,
-      fixedColumns,
-      scrollableColumns,
-    } = columnWidths.resultFunc(
-      columnGroupPropsIn,
-      columnPropsIn,
-      scrollEnabledY,
-      width,
-      Scrollbar.SIZE
-    );
+    const { columnGroupProps, columnProps, fixedColumns, scrollableColumns } =
+      columnWidths.resultFunc(
+        columnGroupPropsIn,
+        columnPropsIn,
+        scrollEnabledY,
+        width,
+        Scrollbar.SIZE
+      );
 
     assert.deepEqual(
       columnGroupProps.map((column) => column.width),
@@ -192,18 +181,14 @@ describe('columnWidths', function () {
     width = 656;
     scrollEnabledY = true;
 
-    const {
-      columnGroupProps,
-      columnProps,
-      fixedColumns,
-      scrollableColumns,
-    } = columnWidths.resultFunc(
-      columnGroupPropsIn,
-      columnPropsIn,
-      scrollEnabledY,
-      width,
-      Scrollbar.SIZE
-    );
+    const { columnGroupProps, columnProps, fixedColumns, scrollableColumns } =
+      columnWidths.resultFunc(
+        columnGroupPropsIn,
+        columnPropsIn,
+        scrollEnabledY,
+        width,
+        Scrollbar.SIZE
+      );
 
     assert.deepEqual(
       columnGroupProps.map((column) => column.width),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
(Safer replacement for #695)

## Description
<!--- Describe your changes in detail -->
After the changes from #628, #630, and #658, FDT has become slightly slower.
The issues can be summarized as:
* lodash util functions are slower than their native counter parts (#630)
* `shouldComponentUpdate` checks got less optimized and hence lead to more re-renders per frame (#628, #658)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves performance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local examples.
I've also benchmarked performance between this version and the initial `v1.2.0` release, and performance is nearly identical.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
