### PR TITLE
fix resize cell indicator not showing when maxHeight

### DIFF
--- a/src/api/apiData.js
+++ b/src/api/apiData.js
@@ -9,11 +9,16 @@
  */
 import columnWidths from '../selectors/columnWidths';
 import shallowEqualSelector from '../helper/shallowEqualSelector';
+import tableHeightsSelector from '../selectors/tableHeights';
 
 const getApiDataSelector = () =>
   shallowEqualSelector(
     [
       (state) => state.tableSize.height,
+      (state) =>
+        (state.headerHeight ? state.headerHeight : 0) +
+        (state.groupHeaderHeight ? state.groupHeaderHeight : 0) +
+        tableHeightsSelector(state).visibleRowsHeight,
       (state) => state.elementHeights.groupHeaderHeight,
       (state) => state.scrollX,
       (state) => state.maxScrollX,
@@ -22,6 +27,7 @@ const getApiDataSelector = () =>
     ],
     (
       /*number*/ tableHeight,
+      /*number*/ bodyAndHeaderHeight,
       /*number*/ groupHeaderHeight,
       /*number*/ scrollX,
       /*number*/ maxScrollX,
@@ -30,6 +36,7 @@ const getApiDataSelector = () =>
     ) => {
       return {
         tableHeight,
+        bodyAndHeaderHeight,
         groupHeaderHeight,
         scrollX,
         maxScrollX,

--- a/src/api/apiData.js
+++ b/src/api/apiData.js
@@ -14,11 +14,7 @@ import tableHeightsSelector from '../selectors/tableHeights';
 const getApiDataSelector = () =>
   shallowEqualSelector(
     [
-      (state) => state.tableSize.height,
-      (state) =>
-        (state.headerHeight ? state.headerHeight : 0) +
-        (state.groupHeaderHeight ? state.groupHeaderHeight : 0) +
-        tableHeightsSelector(state).visibleRowsHeight,
+      (state) => tableHeightsSelector(state).componentHeight,
       (state) => state.elementHeights.groupHeaderHeight,
       (state) => state.scrollX,
       (state) => state.maxScrollX,
@@ -27,7 +23,6 @@ const getApiDataSelector = () =>
     ],
     (
       /*number*/ tableHeight,
-      /*number*/ bodyAndHeaderHeight,
       /*number*/ groupHeaderHeight,
       /*number*/ scrollX,
       /*number*/ maxScrollX,
@@ -36,7 +31,6 @@ const getApiDataSelector = () =>
     ) => {
       return {
         tableHeight,
-        bodyAndHeaderHeight,
         groupHeaderHeight,
         scrollX,
         maxScrollX,

--- a/src/plugins/ResizeReorder/ResizeCell.js
+++ b/src/plugins/ResizeReorder/ResizeCell.js
@@ -89,7 +89,7 @@ class ResizeCell extends React.PureComponent {
       <>
         <ResizerKnob
           height={this.props.height}
-          resizerLineHeight={this.context.tableHeight}
+          resizerLineHeight={this.context.bodyAndHeaderHeight}
           onColumnResizeEnd={this.props.onColumnResizeEnd}
           width={this.props.width}
           minWidth={this.props.minWidth}

--- a/src/plugins/ResizeReorder/ResizeCell.js
+++ b/src/plugins/ResizeReorder/ResizeCell.js
@@ -89,7 +89,7 @@ class ResizeCell extends React.PureComponent {
       <>
         <ResizerKnob
           height={this.props.height}
-          resizerLineHeight={this.context.bodyAndHeaderHeight}
+          resizerLineHeight={this.context.tableHeight}
           onColumnResizeEnd={this.props.onColumnResizeEnd}
           width={this.props.width}
           minWidth={this.props.minWidth}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When we use maxHeight instead of height prop the tableHeight which is calculated and passed to ResizeCell plugin is undefined. Due to which resizerLineHeight is undefined and we are unable to see the resizer line
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The resize line is shown only when the table is configures by setting the height property. It is not shown when the table is configured using only maxHeight. The changes fix this issue
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: https://github.com/schrodinger/fixed-data-table-2/issues/704
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
https://www.youtube.com/watch?v=dVY1S15phRY
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
