### PR TITLE
Fix touch handlers and make them passive

### DIFF
--- a/examples/ColumnGroupsResizeReorderExample.js
+++ b/examples/ColumnGroupsResizeReorderExample.js
@@ -156,6 +156,7 @@ class ColumnGroupsExample extends React.Component {
         rowsCount={dataList.getSize()}
         width={1000}
         height={500}
+        touchScrollEnabled={true}
         {...this.props}
       >
         {this.state.columnGroupOrder.map(function (columnGroupKey, i) {

--- a/examples/ReorderExample.js
+++ b/examples/ReorderExample.js
@@ -90,6 +90,7 @@ class ReorderExample extends React.Component {
         rowsCount={dataList.getSize()}
         width={1000}
         height={500}
+        touchScrollEnabled={true}
         {...this.props}
       >
         {this.state.columnOrder.map(function (columnKey, i) {

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -794,6 +794,7 @@ class FixedDataTable extends React.Component {
           fixedRightColumns={fixedRightColumnGroups}
           scrollableColumns={scrollableColumnGroups}
           visible={true}
+          touchEnabled={touchScrollEnabled}
           onColumnResizeEndCallback={onColumnResizeEndCallback}
           onColumnReorderEndCallback={onColumnReorderEndCallback}
           showScrollbarY={scrollEnabledY}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -177,6 +177,7 @@ class FixedDataTableCell extends React.Component {
       isVisible,
       columnKey,
       isHeaderOrFooter,
+      touchEnabled,
       ...props
     } = this.props;
 
@@ -205,6 +206,7 @@ class FixedDataTableCell extends React.Component {
     );
 
     let cellProps = {
+      touchEnabled,
       isVisible,
       isHeader: this.props.isHeader,
       isGroupHeader: this.props.isGroupHeader,

--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -91,6 +91,7 @@ class FixedDataTableCellDefault extends React.Component {
       isGroupHeader,
       maxWidth,
       minWidth,
+      touchEnabled,
       ...props
     } = this.props;
 

--- a/src/FixedDataTableCellDefaultDeprecated.js
+++ b/src/FixedDataTableCellDefaultDeprecated.js
@@ -96,6 +96,7 @@ class FixedDataTableCellDefault extends React.Component {
       isGroupHeader,
       maxWidth,
       minWidth,
+      touchEnabled,
       ...props
     } = this.props;
 

--- a/src/api/apiData.js
+++ b/src/api/apiData.js
@@ -20,7 +20,6 @@ const getApiDataSelector = () =>
       (state) => state.maxScrollX,
       (state) => columnWidths(state).availableScrollWidth,
       (state) => state.isRTL,
-      (state) => state.touchScrollEnabled,
     ],
     (
       /*number*/ tableHeight,
@@ -28,8 +27,7 @@ const getApiDataSelector = () =>
       /*number*/ scrollX,
       /*number*/ maxScrollX,
       /*number*/ availableScrollWidth,
-      /*boolean*/ isRTL,
-      /*boolean*/ touchEnabled
+      /*boolean*/ isRTL
     ) => {
       return {
         tableHeight,
@@ -38,7 +36,6 @@ const getApiDataSelector = () =>
         maxScrollX,
         availableScrollWidth,
         isRTL,
-        touchEnabled,
       };
     }
   );

--- a/src/api/apiData.js
+++ b/src/api/apiData.js
@@ -20,6 +20,7 @@ const getApiDataSelector = () =>
       (state) => state.maxScrollX,
       (state) => columnWidths(state).availableScrollWidth,
       (state) => state.isRTL,
+      (state) => state.touchScrollEnabled,
     ],
     (
       /*number*/ tableHeight,
@@ -27,7 +28,8 @@ const getApiDataSelector = () =>
       /*number*/ scrollX,
       /*number*/ maxScrollX,
       /*number*/ availableScrollWidth,
-      /*boolean*/ isRTL
+      /*boolean*/ isRTL,
+      /*boolean*/ touchEnabled
     ) => {
       return {
         tableHeight,
@@ -36,6 +38,7 @@ const getApiDataSelector = () =>
         maxScrollX,
         availableScrollWidth,
         isRTL,
+        touchEnabled,
       };
     }
   );

--- a/src/plugins/ResizeReorder/ReorderCell.js
+++ b/src/plugins/ResizeReorder/ReorderCell.js
@@ -115,10 +115,9 @@ class ReorderCell extends React.PureComponent {
       onColumnReorderStart,
       onColumnReorderEnd,
       reorderStartEvent,
+      children,
       ...props
     } = this.props;
-
-    const { children, left } = props;
 
     let className = joinClasses(
       cx({
@@ -167,16 +166,26 @@ class ReorderCell extends React.PureComponent {
 
     return (
       <div
+        ref={this.setReorderHandle}
         className={cx({
           'fixedDataTableCellLayout/columnReorderContainer': true,
           'fixedDataTableCellLayout/columnReorderContainer/active': false,
         })}
-        onMouseDown={this.onMouseDown}
-        onTouchStart={this.onTouchStart}
         style={style}
       />
     );
   }
+
+  setReorderHandle = (element) => {
+    if (element) {
+      element.addEventListener('mousedown', this.onMouseDown, {
+        passive: false,
+      });
+      element.addEventListener('touchstart', this.onTouchStart, {
+        passive: false,
+      });
+    }
+  };
 
   onTouchStart = (ev) => {
     if (!this.props.touchEnabled) {

--- a/src/plugins/ResizeReorder/ResizerKnob.js
+++ b/src/plugins/ResizeReorder/ResizerKnob.js
@@ -101,6 +101,8 @@ class ResizerKnob extends React.PureComponent {
   };
 
   setupHandlers() {
+    // TODO (pradeep): Remove these and pass to our knob component directly after React
+    // provides an API where event handlers can be specified to be non-passive (facebook/react#6436).
     this.resizerKnobRef.addEventListener('mousedown', this.onMouseDown, {
       passive: false,
     });

--- a/src/plugins/ResizeReorder/ResizerKnob.js
+++ b/src/plugins/ResizeReorder/ResizerKnob.js
@@ -48,7 +48,7 @@ class ResizerKnob extends React.PureComponent {
    * Ref to ResizerKnob
    * @type {HTMLDivElement}
    */
-  curRef = null;
+  resizerKnobRef = null;
 
   /**
    *
@@ -62,8 +62,14 @@ class ResizerKnob extends React.PureComponent {
 
   componentDidMount() {
     this.setState({
-      top: this.curRef.getBoundingClientRect().top,
+      top: this.resizerKnobRef.getBoundingClientRect().top,
     });
+
+    this.setupHandlers();
+  }
+
+  componentWillUnmount() {
+    this.cleanupHandlers();
   }
 
   render() {
@@ -82,15 +88,53 @@ class ResizerKnob extends React.PureComponent {
     return (
       <div
         className={cx('fixedDataTableCellLayout/columnResizerContainer')}
-        ref={(element) => (this.curRef = element)}
+        ref={this.setResizerKnobRef}
         style={resizerKnobStyle}
-        onMouseDown={this.onMouseDown}
-        onTouchStart={this.props.touchEnabled ? this.onMouseDown : null}
-        onTouchEnd={this.props.touchEnabled ? this.suppressEvent : null}
-        onTouchMove={this.props.touchEnabled ? this.suppressEvent : null}
       >
         {resizerLine}
       </div>
+    );
+  }
+
+  setResizerKnobRef = (element) => {
+    this.resizerKnobRef = element;
+  };
+
+  setupHandlers() {
+    this.resizerKnobRef.addEventListener('mousedown', this.onMouseDown, {
+      passive: false,
+    });
+    this.resizerKnobRef.addEventListener('touchstart', this.onTouchStart, {
+      passive: false,
+    });
+    this.resizerKnobRef.addEventListener(
+      'touchmove',
+      this.suppressEventIfInTouchMode,
+      { passive: false }
+    );
+    this.resizerKnobRef.addEventListener(
+      'touchend',
+      this.suppressEventIfInTouchMode,
+      { passive: false }
+    );
+  }
+
+  cleanupHandlers() {
+    this.resizerKnobRef.removeEventListener('mousedown', this.onMouseDown, {
+      passive: false,
+    });
+    this.resizerKnobRef.removeEventListener('touchstart', this.onTouchStart, {
+      passive: false,
+    });
+    this.resizerKnobRef.removeEventListener(
+      'touchmove',
+      this.suppressEventIfInTouchMode,
+      { passive: false }
+    );
+    this.resizerKnobRef.removeEventListener(
+      'touchend',
+      this.suppressEventIfInTouchMode,
+      { passive: false }
     );
   }
 
@@ -106,6 +150,15 @@ class ResizerKnob extends React.PureComponent {
       this.props.touchEnabled
     );
     this.mouseMoveTracker.captureMouseMoves(event);
+  };
+
+  /**
+   * @param {TouchEvent} event The touch start event
+   */
+  onTouchStart = (event) => {
+    if (this.props.touchEnabled) {
+      this.onMouseDown(event);
+    }
   };
 
   /**
@@ -185,7 +238,10 @@ class ResizerKnob extends React.PureComponent {
   /**
    * @param {Object} event
    */
-  suppressEvent = (event) => {
+  suppressEventIfInTouchMode = (event) => {
+    if (!this.props.touchEnabled) {
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
   };

--- a/src/vendor_upstream/dom/DOMMouseMoveTracker.js
+++ b/src/vendor_upstream/dom/DOMMouseMoveTracker.js
@@ -86,17 +86,20 @@ class DOMMouseMoveTracker {
       this._eventTouchStartToken = EventListener.listen(
         this._domNode,
         'touchstart',
-        this._onMouseMove
+        this._onMouseMove,
+        { passive: false }
       );
       this._eventTouchMoveToken = EventListener.listen(
-        this._domNode,
+        event.target,
         'touchmove',
-        this._onMouseMove
+        this._onMouseMove,
+        { passive: false }
       );
       this._eventTouchEndToken = EventListener.listen(
-        this._domNode,
+        event.target,
         'touchend',
-        this._onMouseUp
+        this._onMouseUp,
+        { passive: false }
       );
     }
 

--- a/src/vendor_upstream/stubs/EventListener.js
+++ b/src/vendor_upstream/stubs/EventListener.js
@@ -23,14 +23,15 @@ const EventListener = {
    * @param {DOMEventTarget} target DOM element to register listener on.
    * @param {string} eventType Event type, e.g. 'click' or 'mouseover'.
    * @param {function} callback Callback function.
+   * @param {object} options Extra options to customize the listener
    * @return {object} Object with a `remove` method.
    */
-  listen(target, eventType, callback) {
+  listen(target, eventType, callback, options = {}) {
     if (target.addEventListener) {
-      target.addEventListener(eventType, callback, false);
+      target.addEventListener(eventType, callback, options || false);
       return {
         remove() {
-          target.removeEventListener(eventType, callback, false);
+          target.removeEventListener(eventType, callback, options || false);
         },
       };
     } else if (target.attachEvent) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Touch support in FDT v2 is wonky. 
There's multiple issues here:

## problem 1
We're no longer passing down the `touchEnabled` prop to the [cell renderers](https://github.com/schrodinger/fixed-data-table-2/blob/28e518a95e78fdefe3536befec580afa3add68d5/src/FixedDataTableCell.js#L207-L217) within FDT.
But the resizer plugin `<ResizeCell />` still [expects it](https://github.com/schrodinger/fixed-data-table-2/blob/28e518a95e78fdefe3536befec580afa3add68d5/src/plugins/ResizeReorder/ResizerKnob.js#L88-L90), making it not work for touch devices.

## problem 2
The touch/mouse related event listeners were treated as passive. 
This is a problem with React not yet having an API for clients to specify event listener options.

FDT relies on stopping propagation or preventing default behavior of these events in various places, and they did not work as expected.
I'm fixing this by manually registering the handlers via `addEventListener` with the [`passive`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive) property turned OFF.
See facebook/react#6436

## problem 3
Sometimes, the first touch events don't seem to work unless the user does a follow-up click.
One particular case is when the user clicks on the reorder knob; FDT will render a "drag proxy" which replaces the original cell thus making the original touch event (which relies on the original cell to be in the document tree) to not work properly.

The docs explain this nicely: https://developer.mozilla.org/en-US/docs/Web/API/Touch/target

> The read-only target property of the Touch interface returns the ([EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)) on which the touch contact started when it was first placed on the surface, even if the touch point has since moved outside the interactive area of that element or even been removed from the document. **Note that if the target element is removed from the document, events will still be targeted at it, and hence won't necessarily bubble up to the window or document anymore.** If there is any risk of an element being removed while it is being touched, the best practice is to attach the touch listeners directly to the target.

## problem 4
`<ReorderCell />` accidentally renders the children twice in some cases because we accidentally passed its' children to its child renderer...
Check this [comment](https://github.com/schrodinger/fixed-data-table-2/pull/706#discussion_r1389857673) for details.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #705 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with local examples, and also on codesandbox: https://codesandbox.io/s/fixed-data-table-2-touch-resizing-s22nn7
TODO: Test within LiveDesign

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.