### PR TITLE
Fix resizer line positioning

### DIFF
--- a/src/css/layout/fixedDataTableColumnResizerLineLayout.css
+++ b/src/css/layout/fixedDataTableColumnResizerLineLayout.css
@@ -26,7 +26,7 @@
   border-right-width: 1px;
   box-sizing: border-box;
   position: absolute;
-  z-index: 10;
+  z-index: 100;
   pointer-events: none;
 }
 

--- a/src/css/style/fixedDataTableColumnResizerLine.css
+++ b/src/css/style/fixedDataTableColumnResizerLine.css
@@ -16,5 +16,4 @@
 .public/fixedDataTableColumnResizerLine/main {
   border-color: #0284ff;
   width: 1px;
-  position: fixed;
 }

--- a/src/plugins/ResizeReorder/ResizerKnob.js
+++ b/src/plugins/ResizeReorder/ResizerKnob.js
@@ -35,11 +35,6 @@ class ResizerKnob extends React.PureComponent {
      * @type {number} Total displacement of mouse calculated from initial position when resizing started
      */
     totalDisplacement: 0,
-
-    /**
-     * @type {number} Top position of ResizerKnow. It is passed to ResizerLine to render at appropriate position.
-     */
-    top: 0,
   };
 
   state = { ...this.initialState };
@@ -61,10 +56,6 @@ class ResizerKnob extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.setState({
-      top: this.resizerKnobRef.getBoundingClientRect().top,
-    });
-
     this.setupHandlers();
   }
 
@@ -81,7 +72,7 @@ class ResizerKnob extends React.PureComponent {
         height={this.props.resizerLineHeight}
         visible={!!this.state.isColumnResizing}
         left={this.state.currentMouseXCoordinate}
-        top={this.state.top}
+        parentRef={this.resizerKnobRef}
       />
     );
 
@@ -169,7 +160,10 @@ class ResizerKnob extends React.PureComponent {
   onMouseDown = (ev) => {
     this.initializeDOMMouseMoveTracker(ev);
     const initialMouseXCoordinate =
-      FixedDataTableEventHelper.getCoordinatesFromEvent(ev).x;
+      FixedDataTableEventHelper.getCoordinatesFromEvent(ev).x -
+      ev.currentTarget
+        .closest(cx('.fixedDataTableLayout/main'))
+        .getBoundingClientRect().left;
     this.setState({
       initialMouseXCoordinate,
       isColumnResizing: true,

--- a/src/plugins/ResizeReorder/ResizerLine.js
+++ b/src/plugins/ResizeReorder/ResizerLine.js
@@ -39,9 +39,9 @@ class ResizerLine extends React.PureComponent {
     left: PropTypes.number.isRequired,
 
     /**
-     * Top position of resizer line
+     * The parent HTML Element.
      */
-    top: PropTypes.number.isRequired,
+    parentRef: PropTypes.object,
   };
 
   render() {
@@ -49,14 +49,19 @@ class ResizerLine extends React.PureComponent {
       return null;
     }
 
+    const tableRef = this.getTableRef();
+    if (!tableRef) {
+      return null;
+    }
+
     const style = {
       height: this.props.height,
-      top: this.props.top,
+      top: 0,
       left: this.props.left,
     };
 
     return (
-      <Portal>
+      <Portal node={tableRef}>
         <div
           className={joinClasses(
             cx('fixedDataTableColumnResizerLineLayout/main'),
@@ -71,6 +76,15 @@ class ResizerLine extends React.PureComponent {
         </div>
       </Portal>
     );
+  }
+
+  getTableRef() {
+    const parentRef = this.props.parentRef;
+    if (!parentRef) {
+      return null;
+    }
+
+    return parentRef.closest(cx('.fixedDataTableLayout/main'));
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes resizer line's positoning so that it works with cases where the main table is positioned/offset in a modal (see #707).

The main change here is that we no longer render the resizer line at `document.body` with `fixed` positioning. 
Instead, it's portalled to the top-level table element and given a `relative` positioning.
This ensures that the resizer line has the same stacking context and positioning relative to the table (behavior in v1.2).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #707 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with local examples.

## Screenshots (if appropriate):
Before:
<img width="1191" alt="Screenshot 2023-12-03 at 2 56 57 AM" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/4cae4572-f4a5-4676-bb4c-84695c07d6d9">
<img width="802" alt="Screenshot 2023-12-03 at 2 58 44 AM" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/2ad21abc-c36b-47e2-bc12-358b3f4d93ec">

After:
<img width="1216" alt="Screenshot 2023-12-03 at 2 53 04 AM" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/f0ea1a7e-6bae-46a1-9bc4-91fe9dfbfdc3">
<img width="765" alt="Screenshot 2023-12-03 at 2 59 08 AM" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/a9325357-2e97-49bc-87b6-443c4f586765">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
