### PR TITLE
Remove usages of `npm bin`

### DIFF
--- a/build_helpers/buildStaticSite.sh
+++ b/build_helpers/buildStaticSite.sh
@@ -4,6 +4,6 @@ set -e
 rm -rf ./__site__
 rm -rf ./__site_prerender__
 ./build_helpers/buildAPIDocs.sh
-NODE_ENV=production npx webpack --config "$PWD/site/webpack-client.config.js"
-NODE_ENV=production npx webpack --config "$PWD/site/webpack-prerender.config.js"
+NODE_ENV=production webpack --config "$PWD/site/webpack-client.config.js"
+NODE_ENV=production webpack --config "$PWD/site/webpack-prerender.config.js"
 NODE_ENV=production ./build_helpers/buildSiteIndexPages.sh

--- a/build_helpers/buildStaticSite.sh
+++ b/build_helpers/buildStaticSite.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -e
-PATH=$(npm bin):$PATH
 
 rm -rf ./__site__
 rm -rf ./__site_prerender__
 ./build_helpers/buildAPIDocs.sh
-NODE_ENV=production webpack --config "$PWD/site/webpack-client.config.js"
-NODE_ENV=production webpack --config "$PWD/site/webpack-prerender.config.js"
+NODE_ENV=production npx webpack --config "$PWD/site/webpack-client.config.js"
+NODE_ENV=production npx webpack --config "$PWD/site/webpack-prerender.config.js"
 NODE_ENV=production ./build_helpers/buildSiteIndexPages.sh

--- a/build_helpers/startSiteDevServer.sh
+++ b/build_helpers/startSiteDevServer.sh
@@ -4,7 +4,7 @@ set -e
 rm -rf ./__site__
 rm -rf ./__site_prerender__
 ./build_helpers/buildAPIDocs.sh
-npx webpack --config "$PWD/site/webpack-client.config.js"
-npx webpack --config "$PWD/site/webpack-prerender.config.js"
+webpack --config "$PWD/site/webpack-client.config.js"
+webpack --config "$PWD/site/webpack-prerender.config.js"
 ./build_helpers/buildSiteIndexPages.sh
-npx webpack-dev-server --config "$PWD/site/webpack-client.config.js"
+webpack-dev-server --config "$PWD/site/webpack-client.config.js"

--- a/build_helpers/startSiteDevServer.sh
+++ b/build_helpers/startSiteDevServer.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -e
-PATH=$(npm bin):$PATH
 
 rm -rf ./__site__
 rm -rf ./__site_prerender__
 ./build_helpers/buildAPIDocs.sh
-webpack --config "$PWD/site/webpack-client.config.js"
-webpack --config "$PWD/site/webpack-prerender.config.js"
+npx webpack --config "$PWD/site/webpack-client.config.js"
+npx webpack --config "$PWD/site/webpack-prerender.config.js"
 ./build_helpers/buildSiteIndexPages.sh
-webpack-dev-server --config "$PWD/site/webpack-client.config.js"
+npx webpack-dev-server --config "$PWD/site/webpack-client.config.js"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`npm bin` has been removed in npm v9 and above.
See [v9 docs](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/#:~:text=npm%20bin%20has%20been%20removed%20(use%20npx%20or%20npm%20exec%20to%20execute%20binaries)):
> `npm bin` has been removed (use `npx` or `npm exec` to execute binaries)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some of our scripts still reference `npm bin` (see #708), so it causes failures.
This fixes #708.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test locally by running `npm run site-dev-server` and `npm run site-build`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
