### PR TITLE
Fix scrollbar thumb crashing in React@next (v19)

### DIFF
--- a/src/css/layout/ScrollbarLayout.css
+++ b/src/css/layout/ScrollbarLayout.css
@@ -27,13 +27,6 @@
 .ScrollbarLayout/mainHorizontal {
   height: var(--scrollbar-size);
   left: 0;
-  transition-property: background-color height;
-}
-
-/* Touching the scroll-track directly makes the scroll-track bolder */
-.ScrollbarLayout/mainHorizontal.public/Scrollbar/mainActive,
-.ScrollbarLayout/mainHorizontal:hover {
-  height: var(--scrollbar-size-large);
 }
 
 .ScrollbarLayout/face {
@@ -41,9 +34,11 @@
   overflow: hidden;
   position: absolute;
   z-index: 1;
-  transition-duration: 250ms;
-  transition-timing-function: ease;
-  transition-property: width;
+
+  /* keep the thumb aligned to the center */
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 /**
@@ -57,7 +52,9 @@
   content: '';
   display: block;
   position: absolute;
-  transition: background-color 250ms ease;
+  transition-duration: 250ms;
+  transition-timing-function: ease;
+  transition-property: background-color, height, width;
 }
 
 .ScrollbarLayout/faceHorizontal {
@@ -67,10 +64,8 @@
 }
 
 .ScrollbarLayout/faceHorizontal:after {
-  bottom: var(--scrollbar-face-margin);
-  left: 0;
-  top: var(--scrollbar-face-margin);
   width: 100%;
+  height: calc(100% - var(--scrollbar-face-margin) * 2);
 }
 
 .fixedDataTable_isRTL .ScrollbarLayout/faceHorizontal,
@@ -79,9 +74,10 @@
   left: auto;
 }
 
+/* expand horizontal scrollbar face when active */
 .ScrollbarLayout/faceHorizontal.public/Scrollbar/faceActive:after,
 .ScrollbarLayout/main:hover .ScrollbarLayout/faceHorizontal:after {
-  bottom: calc(var(--scrollbar-face-margin)/2);
+  height: calc(100% - var(--scrollbar-face-margin));
 }
 
 .ScrollbarLayout/faceVertical {
@@ -92,13 +88,11 @@
 
 .ScrollbarLayout/faceVertical:after {
   height: 100%;
-  left: var(--scrollbar-face-margin);
-  right: var(--scrollbar-face-margin);
-  top: 0;
+  width: calc(100% - var(--scrollbar-face-margin) * 2);
 }
 
+/* expand veritcal scrollbar face when active */
 .ScrollbarLayout/main:hover .ScrollbarLayout/faceVertical:after,
 .ScrollbarLayout/faceVertical.public/Scrollbar/faceActive:after {
-  left: calc(var(--scrollbar-face-margin)/2);
-  right: calc(var(--scrollbar-face-margin)/2);
+  width: calc(100% - var(--scrollbar-face-margin));
 }

--- a/src/plugins/Scrollbar.js
+++ b/src/plugins/Scrollbar.js
@@ -33,8 +33,6 @@ const FACE_MARGIN_2 = FACE_MARGIN * 2;
 const FACE_SIZE_MIN = 30;
 const KEYBOARD_SCROLL_AMOUNT = 40;
 
-let _lastScrolledScrollbar = null;
-
 class Scrollbar extends React.PureComponent {
   static propTypes = {
     contentSize: PropTypes.number.isRequired,
@@ -110,7 +108,7 @@ class Scrollbar extends React.PureComponent {
     let faceStyle;
     const isHorizontal = this.state.isHorizontal;
     const isVertical = !isHorizontal;
-    const isActive = this.state.focused || this.state.isDragging;
+    const isActive = this.state.isDragging;
     const faceSize = this.state.faceSize;
     const isOpaque = this.props.isOpaque;
     const verticalTop = this.props.verticalTop || 0;
@@ -182,8 +180,6 @@ class Scrollbar extends React.PureComponent {
 
     return (
       <div
-        onFocus={this._onFocus}
-        onBlur={this._onBlur}
         onKeyDown={this._onKeyDown}
         onMouseDown={this._onMouseDown}
         onTouchCancel={this._onTouchCancel}
@@ -243,9 +239,6 @@ class Scrollbar extends React.PureComponent {
     if (this._mouseMoveTracker) {
       this._mouseMoveTracker.releaseMouseMoves();
       this._mouseMoveTracker = null;
-    }
-    if (_lastScrolledScrollbar === this) {
-      _lastScrolledScrollbar = null;
     }
   }
 
@@ -313,15 +306,10 @@ class Scrollbar extends React.PureComponent {
       position = maxPosition;
     }
 
-    const isDragging = this._mouseMoveTracker
-      ? this._mouseMoveTracker.isDragging()
-      : false;
-
     // This function should only return flat values that can be compared quiclky
     // by `ReactComponentWithPureRenderMixin`.
     const state = {
       faceSize,
-      isDragging,
       isHorizontal,
       position,
       scale,
@@ -358,6 +346,8 @@ class Scrollbar extends React.PureComponent {
   };
 
   _onMouseDown = (/*object*/ event) => {
+    this.setState({ isDragging: true });
+
     /** @type {object} */
     let nextState;
 
@@ -387,7 +377,6 @@ class Scrollbar extends React.PureComponent {
       nextState = {};
     }
 
-    nextState.focused = true;
     this._setNextState(nextState);
 
     this._mouseMoveTracker.captureMouseMoves(event);
@@ -535,32 +524,6 @@ class Scrollbar extends React.PureComponent {
     );
   };
 
-  _onFocus = () => {
-    this.setState({
-      focused: true,
-    });
-  };
-
-  _onBlur = () => {
-    this.setState({
-      focused: false,
-    });
-  };
-
-  _blur = () => {
-    const el = ReactDOM.findDOMNode(this);
-    if (!el) {
-      return;
-    }
-
-    try {
-      this._onBlur();
-      el.blur();
-    } catch (oops) {
-      // pass
-    }
-  };
-
   getTouchX = (/*object*/ e) => {
     return Math.round(
       e.targetTouches[0].clientX - e.target.getBoundingClientRect().x
@@ -592,11 +555,6 @@ class Scrollbar extends React.PureComponent {
         this.props.onScroll(nextState.position);
       }
       return;
-    }
-
-    if (willScroll && _lastScrolledScrollbar !== this) {
-      _lastScrolledScrollbar && _lastScrolledScrollbar._blur();
-      _lastScrolledScrollbar = this;
     }
   };
 

--- a/src/stubs/cssVar.js
+++ b/src/stubs/cssVar.js
@@ -19,7 +19,6 @@ const CSS_VARS = {
   '--scrollbar-face-margin': '4px',
   '--scrollbar-face-radius': '6px',
   '--scrollbar-size': '15px',
-  '--scrollbar-size-large': '17px',
   '--scrollbar-track-color': '#fff',
   '--border-color': '#d3d3d3',
   '--fbui-white': '#fff',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to interact with FDT's scrollbar on latest React (react@next or react@19 at the time of writing) crashes the whole app with the following error:
```
fixed-data-table-2.js:5137 Uncaught TypeError: (0 , ReactDOM.default).findDOMNode is not a function
    at Scrollbar.eval [as _blur] (fixed-data-table-2.js:5137:38)
    at Scrollbar.eval [as _setNextState] (fixed-data-table-2.js:5168:58)
    at Scrollbar.componentDidUpdate (fixed-data-table-2.js:5186:14)
```
This confirms that `ReactDOM.findDOMNode` which was already marked as deprecated is now removed in a future version of React.

Furthermore, once a scrollbar is active, it never goes into an inactive state even after stopping scroll or moving the cursor away from the scrollbar. Animations are also semi-broken...

## Context
We've been using `ReactDOM.findDOMNode` in our scrollbar component to get a reference to the scrollbar DOM so as to blur it out.
Digging through the code, this looks like it was simply done to figure out if the scrollbar is in an active state of use.

Technically we don't need to any of this, and we can instead rely on `DOMMouseMoveTracker` to figure out if the user is dragging and using the scrollbar.

## Fixes
I'm fixing all of this by cleaning up a bit of the Scrollbar component such that:
* Any code associated with blurring the scrollbar is removed
  * ReactDOM.findDOMNode isn't used anymore
  * We no longer have to maintain a reference to the last used scrollbar
* Fixes scrollbar UI so that scrollbar thumb correctly indicates that it is active
  * I simplified the CSS and removed the CSS var `scrollbar-size-large`

## Screenshot
Inactive scrollbars
<img width="821" alt="Screenshot 2024-03-30 at 12 17 11 PM" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/a3339049-b2fa-462e-b4d4-dd5a7184f1c2">

Active horizontal scrollbar
<img width="825" alt="image" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/92d44b31-0d47-456c-a840-4fa6442fd74f">

Active vertical scrollbar
<img width="822" alt="image" src="https://github.com/schrodinger/fixed-data-table-2/assets/41563608/bcb36274-d948-4dea-a35a-0ffb1c4bc0cc">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local examples having multiple scrollbars.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
