### PR TITLE
Remove buffer row count console log

### DIFF
--- a/src/selectors/roughHeights.js
+++ b/src/selectors/roughHeights.js
@@ -175,7 +175,6 @@ function getScrollStateX(columnElements, scrollFlags, width, scrollbarYWidth) {
 function getBufferRowCount(maxAvailableHeight, rowSettings) {
   const { bufferRowCount, rowHeight, subRowHeight } = rowSettings;
   if (bufferRowCount !== undefined) {
-    console.log('buffer set: ' + bufferRowCount);
     return bufferRowCount;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR removes a console log statement.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`roughHeights.js` logs the value of `bufferRowCount` whenever this variable is defined. This console log introduces a lot of noise in production, and most of the time the row count is just `0`. This statement is probably for debugging purpose only during local development. No other JS file has such statement. Could we remove it?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No test needed.

## Screenshots (if appropriate):

This is what we see in the browser console in production before removing this console log:

<img width="118" alt="Screenshot 2024-05-21 at 11 14 32" src="https://github.com/schrodinger/fixed-data-table-2/assets/1933157/44537f4a-2a61-4774-9378-6bceeaa923a7">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
