### PR TITLE
Fix scrollbar errors when offset is zero

### DIFF
--- a/src/plugins/Scrollbar.js
+++ b/src/plugins/Scrollbar.js
@@ -356,11 +356,11 @@ class Scrollbar extends React.PureComponent {
       // magically available for browsers somehow.
       const nativeEvent = event.nativeEvent;
       let position = this.state.isHorizontal
-        ? nativeEvent.offsetX ||
-          nativeEvent.layerX ||
+        ? nativeEvent.offsetX ??
+          nativeEvent.layerX ??
           this.getTouchX(nativeEvent)
-        : nativeEvent.offsetY ||
-          nativeEvent.layerY ||
+        : nativeEvent.offsetY ??
+          nativeEvent.layerY ??
           this.getTouchY(nativeEvent);
 
       // MouseDown on the scroll-track directly, move the center of the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the issue seen at #723.
The `onmousedown` handler for Scrollbar throws an error when the user tries to scroll at the beginning of the scroll content area, which happens because `targetTouches` is `undefined` at: https://github.com/schrodinger/fixed-data-table-2/blob/522e82be907c41c250b231a76e3127abed9aed81/src/plugins/Scrollbar.js#L527-L537
because we're actually doing a normal mouse click instead of a "touch" click.
But the code shouldn't have reached here in the first place.

The root problem is that FDT thinks it's a touch event because of the way we use the `||` operator in https://github.com/schrodinger/fixed-data-table-2/blob/522e82be907c41c250b231a76e3127abed9aed81/src/plugins/Scrollbar.js#L358-L364
We should instead use the `??` operator for cases like this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #723 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local examples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.