### PR TITLE
#726: Add support for forwarding refs to cell components

### DIFF
--- a/src/FixedDataTableCellDefault.js
+++ b/src/FixedDataTableCellDefault.js
@@ -39,41 +39,8 @@ import joinClasses from './vendor_upstream/core/joinClasses';
  * );
  * ```
  */
-class FixedDataTableCellDefault extends React.Component {
-  static propTypes = {
-    /**
-     * Outer height of the cell.
-     */
-    height: PropTypes.number,
-
-    /**
-     * Outer width of the cell.
-     */
-    width: PropTypes.number,
-
-    /**
-     * Optional prop that if specified on the `Column` will be passed to the
-     * cell. It can be used to uniquely identify which column is the cell is in.
-     */
-    columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * Optional prop that represents the rows index in the table.
-     * For the 'cell' prop of a Column, this parameter will exist for any
-     * cell in a row with a positive index.
-     *
-     * Below that entry point the user is welcome to consume or
-     * pass the prop through at their discretion.
-     */
-    rowIndex: PropTypes.number,
-
-    /**
-     * Whether this cell is currently within the viewport.
-     */
-    isVisible: PropTypes.bool,
-  };
-
-  render() {
+const FixedDataTableCellDefault = React.forwardRef(
+  function FixedDataTableCellDefault(props, ref) {
     //Remove some props which we don't pass into div
     const {
       height,
@@ -92,8 +59,8 @@ class FixedDataTableCellDefault extends React.Component {
       maxWidth,
       minWidth,
       touchEnabled,
-      ...props
-    } = this.props;
+      ...cellProps
+    } = props;
 
     const innerStyle = {
       height,
@@ -103,7 +70,7 @@ class FixedDataTableCellDefault extends React.Component {
 
     return (
       <div
-        {...props}
+        {...cellProps}
         className={joinClasses(
           cx('fixedDataTableCellLayout/wrap'),
           cx('public/fixedDataTableCell/wrap'),
@@ -111,11 +78,45 @@ class FixedDataTableCellDefault extends React.Component {
           className
         )}
         style={innerStyle}
+        ref={ref}
       >
         {children}
       </div>
     );
   }
-}
+);
+
+FixedDataTableCellDefault.propTypes = {
+  /**
+   * Outer height of the cell.
+   */
+  height: PropTypes.number,
+
+  /**
+   * Outer width of the cell.
+   */
+  width: PropTypes.number,
+
+  /**
+   * Optional prop that if specified on the `Column` will be passed to the
+   * cell. It can be used to uniquely identify which column is the cell is in.
+   */
+  columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Optional prop that represents the rows index in the table.
+   * For the 'cell' prop of a Column, this parameter will exist for any
+   * cell in a row with a positive index.
+   *
+   * Below that entry point the user is welcome to consume or
+   * pass the prop through at their discretion.
+   */
+  rowIndex: PropTypes.number,
+
+  /**
+   * Whether this cell is currently within the viewport.
+   */
+  isVisible: PropTypes.bool,
+};
 
 export default FixedDataTableCellDefault;


### PR DESCRIPTION
## Description
Add support for forwarding refs to cell components, allowing for external control or access to the DOM element rendered by the cell.

- Refactored the component to function-style so as to utilize `React.forwardRef`, enabling the ability to pass a `ref` to the cell component
- Ensured that the `ref` is attached to the top-level `div` element rendered by the cell, enabling usage of ref-based methods or direct DOM manipulation.
- Maintained existing prop-types while supporting the new `ref` forwarding functionality.
- Verified that existing usage patterns of the component remain unaffected by these changes.


## Motivation and Context
Resolves #726

## How Has This Been Tested?
Tested using `npm run test` and by using `npm link` to use the enhanced component in my project, effectively resolving the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Support forwarding refs to cell components, allowing access to the DOM element rendered by the cell.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
