### PR TITLE
Fix StrictMode errors in FixedDataTableContainer

### DIFF
--- a/src/FixedDataTableContainer.js
+++ b/src/FixedDataTableContainer.js
@@ -48,10 +48,6 @@ class FixedDataTableContainer extends React.Component {
       'You must set either a height or a maxHeight'
     );
 
-    if (!currentState) {
-      return null;
-    }
-
     // getDerivedStateFromProps is called for both prop and state updates.
     // If props are unchanged here, then there's no need to recalculate derived state.
     if (nextProps === currentState.props) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When [StrictMode](https://react.dev/reference/react/StrictMode) is enabled, and FDT is run under React v19, we run into NPEs in the top-level FixedDataTableContainer component, causing the table to not function correctly.

In StrictMode runs the constructor and lifecycle methods of `FixedDataTableContainer` a second time.
The order I observed was as follows:
```
constructor
constructor
getDerivedStateFromProps
getDerivedStateFromProps
componentDidMount
componentWillUnmount
componentDidMount
getDerivedStateFromProps
getDerivedStateFromProps
```

So when running in StrictMode, the handlers/redux store gets initialized in the `constructor`, and then immediately gets destroyed in `componentWillUnmount`, leading the table to be in a destroyed state.

I'm fixing this by moving the initialization logic to both the `constructor` and `componentDidMount`, following what we did in https://github.com/schrodinger/fixed-data-table-2/pull/657 in the past.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/schrodinger/fixed-data-table-2/issues/738.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with local examples running React v19.
Tested with a Vite client app running React v19.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
