### PR TITLE
Allow ReorderCell to work in React v19

### DIFF
--- a/src/plugins/ResizeReorder/ReorderCell.js
+++ b/src/plugins/ResizeReorder/ReorderCell.js
@@ -249,11 +249,11 @@ class ReorderCell extends React.PureComponent {
       </ExternalContextProvider>
     );
 
-    if (this.props.__useReactv19Root) {
+    if (this.props.__useReactRoot) {
       const flushSync = ReactDOM.flushSync || ((fn) => fn()); // ReactDOM.flushSync doesn't exist in older versions of React
       // flushSync is required to ensure that the drag proxy gets mounted synchronously in newer version of React
       flushSync(() => {
-        const root = this.props.__useReactv19Root(this.getDragContainer());
+        const root = this.props.__useReactRoot(this.getDragContainer());
         this.dragContainer.root = root;
         root.render(proxy);
       });
@@ -304,7 +304,7 @@ class ReorderCell extends React.PureComponent {
 
   removeDragContainer = () => {
     // since the drag container is going to be removed, also unmount the drag proxy
-    if (this.props.__useReactv19Root) {
+    if (this.props.__useReactRoot) {
       this.dragContainer.root.unmount();
     } else {
       ReactDOM.unmountComponentAtNode(this.dragContainer);
@@ -394,7 +394,7 @@ ReorderCell.propTypes = {
    *
    * const reorderCell = (
    *  <ReorderCell
-   *   __useReactv19Root={createRoot}
+   *   __useReactRoot={createRoot}
    * />
    * ```
    *
@@ -402,7 +402,7 @@ ReorderCell.propTypes = {
    *
    * @deprecated This'll be removed in future major version updates of FDT.
    */
-  __useReactv19Root: PropTypes.func,
+  __useReactRoot: PropTypes.func,
 };
 
 export default ReorderCell;

--- a/src/plugins/ResizeReorder/ReorderCell.js
+++ b/src/plugins/ResizeReorder/ReorderCell.js
@@ -249,11 +249,11 @@ class ReorderCell extends React.PureComponent {
       </ExternalContextProvider>
     );
 
-    if (this.props.__useReactRoot) {
+    if (this.props.__react19RootCreator) {
       const flushSync = ReactDOM.flushSync || ((fn) => fn()); // ReactDOM.flushSync doesn't exist in older versions of React
       // flushSync is required to ensure that the drag proxy gets mounted synchronously in newer version of React
       flushSync(() => {
-        const root = this.props.__useReactRoot(this.getDragContainer());
+        const root = this.props.__react19RootCreator(this.getDragContainer());
         this.dragContainer.root = root;
         root.render(proxy);
       });
@@ -304,7 +304,7 @@ class ReorderCell extends React.PureComponent {
 
   removeDragContainer = () => {
     // since the drag container is going to be removed, also unmount the drag proxy
-    if (this.props.__useReactRoot) {
+    if (this.props.__react19RootCreator) {
       this.dragContainer.root.unmount();
     } else {
       ReactDOM.unmountComponentAtNode(this.dragContainer);
@@ -394,7 +394,7 @@ ReorderCell.propTypes = {
    *
    * const reorderCell = (
    *  <ReorderCell
-   *   __useReactRoot={createRoot}
+   *   __react19RootCreator={createRoot}
    * />
    * ```
    *
@@ -402,7 +402,7 @@ ReorderCell.propTypes = {
    *
    * @deprecated This'll be removed in future major version updates of FDT.
    */
-  __useReactRoot: PropTypes.func,
+  __react19RootCreator: PropTypes.func,
 };
 
 export default ReorderCell;

--- a/src/plugins/ResizeReorder/ReorderCell.js
+++ b/src/plugins/ResizeReorder/ReorderCell.js
@@ -240,13 +240,30 @@ class ReorderCell extends React.PureComponent {
       contents: this.cellRef.current,
     };
 
-    ReactDOM.render(
-      // Since we're effectively rendering the proxy in a separate VDOM root, we cannot directly pass in our context.
-      // To solve this, we use ExternalContextProvider to pass down the context value.
-      // ExternalContextProvider also ensures that even if our cell gets unmounted, the dragged cell still receives updates from context.
+    // Since we're effectively rendering the proxy in a separate VDOM root, we cannot directly pass in our context.
+    // To solve this, we use ExternalContextProvider to pass down the context value.
+    // ExternalContextProvider also ensures that even if our cell gets unmounted, the dragged cell still receives updates from context.
+    const proxy = (
       <ExternalContextProvider value={this.context}>
         <DragProxy {...this.props} {...additionalProps} />
-      </ExternalContextProvider>,
+      </ExternalContextProvider>
+    );
+
+    if (this.props.__useReactv19Root) {
+      const flushSync = ReactDOM.flushSync || ((fn) => fn()); // ReactDOM.flushSync doesn't exist in older versions of React
+      // flushSync is required to ensure that the drag proxy gets mounted synchronously in newer version of React
+      flushSync(() => {
+        const root = this.props.__useReactv19Root(this.getDragContainer());
+        this.dragContainer.root = root;
+        root.render(proxy);
+      });
+      // we consider our cell to be in a reordering state as soon as the drag proxy gets mounted
+      this.setState({ isReordering: true });
+      return;
+    }
+
+    ReactDOM.render(
+      proxy,
       this.getDragContainer(),
       // we consider our cell in a reordering state as soon as the drag proxy gets mounted
       () => this.setState({ isReordering: true })
@@ -287,7 +304,11 @@ class ReorderCell extends React.PureComponent {
 
   removeDragContainer = () => {
     // since the drag container is going to be removed, also unmount the drag proxy
-    ReactDOM.unmountComponentAtNode(this.dragContainer);
+    if (this.props.__useReactv19Root) {
+      this.dragContainer.root.unmount();
+    } else {
+      ReactDOM.unmountComponentAtNode(this.dragContainer);
+    }
 
     this.dragContainer.remove();
     this.dragContainer = null;
@@ -363,6 +384,25 @@ ReorderCell.propTypes = {
    * ```
    */
   onColumnReorderEnd: PropTypes.func.isRequired,
+
+  /**
+   * HACK to make this plugin work in a React v19 environment by letting the client pass the `createRoot` function from `react-dom/client`.
+   *
+   * Example usage:
+   * ```
+   * import { createRoot } from 'react-dom/client';
+   *
+   * const reorderCell = (
+   *  <ReorderCell
+   *   __useReactv19Root={createRoot}
+   * />
+   * ```
+   *
+   * See https://github.com/schrodinger/fixed-data-table-2/issues/743) for more information.
+   *
+   * @deprecated This'll be removed in future major version updates of FDT.
+   */
+  __useReactv19Root: PropTypes.func,
 };
 
 export default ReorderCell;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue
<!--- Describe your changes in detail -->
The `<ReorderCell />` plugin component doesn't work correctly in React v19.
This is because it uses the `ReactDOM.render` API, and this is removed in React v19.

## Fix
I'm adding in a new prop named `__react19RootCreator` which allows users to pass in the `createRoot` API so that `<ReorderCell />` works as expected.
The prop is already marked as deprecated in the docs, and prefixed with`__` to make it apparent that this is more of a hack/temporary workaround.
We'll remove it in FDT v3 since we'll probably only support React 18 and above.

Example usage:
```tsx
import { createRoot } from 'react-dom/client';

...

const reorderCell = (
  <Plugins.ReorderCell
    __react19RootCreator={createRoot}
  >
    {cellContents}
  </Plugins.ReorderCell> 
```

## Other fixes?
My first thought to fix this was to do feature detection by checking if `ReactDOM.render` or `ReactDOM.createRoot` exists at runtime.
Unfortunately, the replacement `ReactDOM.createRoot` is in the new `react-dom/client` package which is unavailable in React v17.
So the following snippet doesn't work in ESM environment in browsers:
```
import ReactDOM from 'react-dom' // for react v17
// the next line throws an error for clients using react v17 because the package doesn't exist
import ReactDOMClient from 'react-dom/client' // for react v19
```

I tried using async imports (`import('ReactDOM/client').then`) and commonJS imports (`const ReactDOM = require('ReactDOM/client')` so that we can do something similar to "optional" imports.
But these don't work without requiring the client to add config changes to their bundler/devserver (eg: storybook's [react-dom shim](https://github.com/storybookjs/storybook/blob/next/code/lib/react-dom-shim/src/preset.ts)).

Another approach I can think of is publishing the plugins as a separate package.
This'll allow us to publish different versions of the plugin for different versions of React.
This is a lot of work for FDT v2 though, and I don't think we can do this cleanly without breaking changes 🤔 .

Yet another approach is to extend our [FixedDataTableAPI](https://github.com/schrodinger/fixed-data-table-2/blob/84e2d3f0b75c990e404fd7bd62aad1c592d55c29/src/api/index.js) to allow plugins to register renderers into FDT, which FDT will then render outside the virtualization layer.
This way reoreder cell's contents won't be lost even if the original column goes outside the viewport, solving the original use case for `ReactDOM.render`.
This seems like a lot of work for a very specific case though.

## History of ReorderCell
When we first implemented the ReorderCell plugin we ran into a nasty edge case where if the user dragged the ReorderCell far away from it's original column, the original/parent cell renderer gets unmounted because it's no longer within the visible viewport (because of FDT's virtualization).
This causes the dragged cell to also disappear.

We tried using React Portals to render the dragged cell contents.
But the portals also disappears since it's rendered directly by the parent cell. 😔

We rendered into a separate React tree via `ReactDOM.render` to fix this specific issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/schrodinger/fixed-data-table-2/issues/743.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the ReorderCell plugin and verified reordering works as expected.
In React v17, there's no additional changes required.
In React v19, reordering works if we pass in the new `__react19RootCreator` prop.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.